### PR TITLE
drupal-demo - Flag MailSetting record as default

### DIFF
--- a/app/config/drupal-demo/install.sh
+++ b/app/config/drupal-demo/install.sh
@@ -39,7 +39,7 @@ pushd "${WEB_ROOT}/sites/${DRUPAL_SITE_DIR}" >> /dev/null
   echo '{"enable_components":["CiviEvent","CiviContribute","CiviMember","CiviMail","CiviReport","CiviPledge","CiviCase","CiviCampaign"]}' \
     | drush cvapi setting.create --in=json
   drush cvapi setting.create versionCheck=0
-  drush cvapi MailSettings.create id=1 domain=example.org
+  drush cvapi MailSettings.create id=1 is_default=1 domain=example.org
 
   ## Setup theme
   #above# drush -y en garland


### PR DESCRIPTION
This resolves errors in which CiviMail bombs when sending real emails because the return-path has been mis-constructed. 
