### PR TITLE
Clarify instructions for Installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ git clone https://github.com/civicrm/civicrm-buildkit.git
 cd civicrm-buildkit/bin
 ./civi-download-tools
 ./amp config
-## At this point, check to make sure you follow the instructions in amp config,
+## At this point, check to make sure you follow the instructions output by amp config,
 ## which involve adding a line to your Apache configuration file
 ./amp test
 ./civibuild create drupal-demo --civi-ver 4.4 --url http://localhost:8001


### PR DESCRIPTION
Several of us over at the pre-civicon civi sprint missed the instructions spit out by ./amp config. I've added a line to the README to clarify.
