### PR TITLE
Updated svn checkout to use HTTPS protocol.

### DIFF
--- a/app/config/caches.sh
+++ b/app/config/caches.sh
@@ -22,4 +22,4 @@ git_cache_setup "https://github.com/civicrm/civicrm-packages.git"            "$C
 git_cache_setup "https://github.com/civicrm/civicrm-joomla.git"              "$CACHE_DIR/civicrm/civicrm-joomla.git"
 git_cache_setup "https://github.com/civicrm/civicrm-wordpress.git"           "$CACHE_DIR/civicrm/civicrm-wordpress.git"
 git_cache_setup "https://github.com/eileenmcnaughton/civicrm_developer.git"  "$CACHE_DIR/eileenmcnaughton/civicrm_developer.git"
-svn_cache_setup "http://svn.civicrm.org/l10n/trunk"                          "$CACHE_DIR/civicrm/l10n-trunk.svn"
+svn_cache_setup "https://svn.civicrm.org/l10n/trunk"                         "$CACHE_DIR/civicrm/l10n-trunk.svn"


### PR DESCRIPTION
Resolves error:
svn: E175002: Unable to connect to a repository at URL 'http://svn.civicrm.org/l10n/trunk'
svn: E175002: OPTIONS request on '/l10n/trunk' failed: 503 Service Unavailable
