### PR TITLE
set civivol branch

### DIFF
--- a/app/config/drupal-demo/drush.make.tmpl
+++ b/app/config/drupal-demo/drush.make.tmpl
@@ -105,5 +105,5 @@ libraries[civivolunteer][destination] = modules
 libraries[civivolunteer][directory_name] = civicrm/tools/extensions/civivolunteer
 libraries[civivolunteer][download][type] = git
 libraries[civivolunteer][download][url] = %%CACHE_DIR%%/civicrm/civivolunteer.git
-libraries[civivolunteer][download][branch] = master
+libraries[civivolunteer][download][branch] = %%CIVI_VERSION%%-1.x
 libraries[civivolunteer][overwrite] = TRUE


### PR DESCRIPTION
trying to fix drupal-demo site to use last release of CiviVolunteer, instead of dev-trunk. Unsure that %CIVI_VERSION will resolve to '4.4'...
https://github.com/civicrm/civivolunteer/tree/4.4-1.x
