### PR TITLE
app/config/*/download.sh - Fix race among concurrent "drush make" builds

### DIFF
--- a/app/config/doctrine/download.sh
+++ b/app/config/doctrine/download.sh
@@ -9,7 +9,8 @@ if [ "$CIVI_VERSION" != "master" ]; then
 fi
 
 [ -z "$CMS_VERSION" ] && CMS_VERSION=7.x
-MAKEFILE="${TMPDIR}/${SITE_TYPE}.make"
+MAKEFILE="${TMPDIR}/${SITE_TYPE}/${SITE_NAME}/${SITE_ID}.make"
+cvutil_makeparent "$MAKEFILE"
 cat "$SITE_CONFIG_DIR/drush.make.tmpl" \
   | sed "s;%%CACHE_DIR%%;${CACHE_DIR};" \
   | sed "s;%%CIVI_VERSION%%;${CIVI_VERSION};" \

--- a/app/config/drupal-clean/download.sh
+++ b/app/config/drupal-clean/download.sh
@@ -5,7 +5,8 @@
 ###############################################################################
 
 [ -z "$CMS_VERSION" ] && CMS_VERSION=7.x
-MAKEFILE="${TMPDIR}/${SITE_TYPE}.make"
+MAKEFILE="${TMPDIR}/${SITE_TYPE}/${SITE_NAME}/${SITE_ID}.make"
+cvutil_makeparent "$MAKEFILE"
 cat "$SITE_CONFIG_DIR/drush.make.tmpl" \
   | sed "s;%%CACHE_DIR%%;${CACHE_DIR};" \
   | sed "s;%%CIVI_VERSION%%;${CIVI_VERSION};" \

--- a/app/config/drupal-clean42/download.sh
+++ b/app/config/drupal-clean42/download.sh
@@ -11,7 +11,8 @@ git_cache_setup "https://github.com/CiviCRM42/civicrm42-packages.git" "$CACHE_DI
 ## Force version 4.2
 CIVI_VERSION=4.2
 [ -z "$CMS_VERSION" ] && CMS_VERSION=7.x
-MAKEFILE="${TMPDIR}/${SITE_TYPE}.make"
+MAKEFILE="${TMPDIR}/${SITE_TYPE}/${SITE_NAME}/${SITE_ID}.make"
+cvutil_makeparent "$MAKEFILE"
 cat "$SITE_CONFIG_DIR/drush.make.tmpl" \
   | sed "s;%%CACHE_DIR%%;${CACHE_DIR};" \
   | sed "s;%%CIVI_VERSION%%;${CIVI_VERSION};" \

--- a/app/config/drupal-demo/download.sh
+++ b/app/config/drupal-demo/download.sh
@@ -9,7 +9,8 @@ git_cache_setup "https://github.com/civicrm/civivolunteer.git" "$CACHE_DIR/civic
 [ -z "$CMS_VERSION" ] && CMS_VERSION=7.x
 [ -z "$VOL_VERSION" ] && VOL_VERSION='4.4-1.x'
 
-MAKEFILE="${TMPDIR}/${SITE_TYPE}.make"
+MAKEFILE="${TMPDIR}/${SITE_TYPE}/${SITE_NAME}/${SITE_ID}.make"
+cvutil_makeparent "$MAKEFILE"
 cat "$SITE_CONFIG_DIR/drush.make.tmpl" \
   | sed "s;%%CACHE_DIR%%;${CACHE_DIR};" \
   | sed "s;%%CIVI_VERSION%%;${CIVI_VERSION};" \

--- a/app/config/hrdemo/download.sh
+++ b/app/config/hrdemo/download.sh
@@ -10,7 +10,8 @@ git_cache_setup "https://github.com/civicrm/civihr.git" "$CACHE_DIR/civicrm/civi
 [ -z "$CIVI_VERSION" ] && CIVI_VERSION=4.4
 [ -z "$HR_VERSION" ] && HR_VERSION=master
 
-MAKEFILE="${TMPDIR}/${SITE_TYPE}.make"
+MAKEFILE="${TMPDIR}/${SITE_TYPE}/${SITE_NAME}/${SITE_ID}.make"
+cvutil_makeparent "$MAKEFILE"
 cat "$SITE_CONFIG_DIR/drush.make.tmpl" \
   | sed "s;%%CACHE_DIR%%;${CACHE_DIR};" \
   | sed "s;%%CIVI_VERSION%%;${CIVI_VERSION};" \

--- a/app/config/symfony/download.sh
+++ b/app/config/symfony/download.sh
@@ -5,7 +5,8 @@
 ###############################################################################
 
 [ -z "$CMS_VERSION" ] && CMS_VERSION=7.x
-MAKEFILE="${TMPDIR}/${SITE_TYPE}.make"
+MAKEFILE="${TMPDIR}/${SITE_TYPE}/${SITE_NAME}/${SITE_ID}.make"
+cvutil_makeparent "$MAKEFILE"
 cat "$SITE_CONFIG_DIR/drush.make.tmpl" \
   | sed "s;%%CACHE_DIR%%;${CACHE_DIR};" \
   | sed "s;%%CIVI_VERSION%%;${CIVI_VERSION};" \


### PR DESCRIPTION
If two concurrent build try use the same build-type with different config
options, then the drush-make files may conflict.
