### PR TITLE
phpunit-xml-cleanup - More aggressive cleaning of messages with \1.

### DIFF
--- a/bin/phpunit-xml-cleanup
+++ b/bin/phpunit-xml-cleanup
@@ -11,6 +11,7 @@ array_shift($files);
 
 foreach ($files as $file) {
   $content = file_get_contents($file);
-  $content = str_replace($sep, '&#x0001;', $content);
+  #$content = str_replace($sep, '&#x0001;', $content);
+  $content = str_replace($sep, '', $content);
   file_put_contents($file, $content);
 }


### PR DESCRIPTION
Standalone phpunit and Jenkins just don't seem to agree on how to handle this situation. In any event, many tools omit \1 from display, so there's not much point in trying to preserve it.
