### PR TITLE
README.md + bin/civi-download-tools - NodeJS, Karma, Bower

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A collection of tools and scripts for creating one or more CiviCRM development/d
  * Git/SVN
  * PHP
  * MySQL (client/server)
+ * NodeJS (for development with CiviCRM v4.6+)
  * Recommended: Apache (TODO: nginx)
  * Recommended: Ruby/Rake
 

--- a/README.md
+++ b/README.md
@@ -34,15 +34,25 @@ website.
 civicrm-buildkit includes several utilities which are useful in developing
 CiviCRM:
 
- * [amp](https://github.com/totten/amp) - Abstracted interface for local httpd/sql service (Apache/nginx/MySQL)
- * **civibuild** - CLI tool which builds a complete source tree (with CMS+Civi+addons), provisions httpd/sql, etc.
- * [civicrm-upgrade-test](https://github.com/civicrm/civicrm-upgrade-test) - Scripts and data files for testing upgrades
- * [composer](http://getcomposer.org/) - Dependency manager for PHP packages
- * [civix](https://github.com/totten/civix) - Code-generator for CiviCRM extensions
- * [git-scan](https://github.com/totten/git-scan/) - Git extension for working with many git repositories
- * [hub](http://hub.github.com/) - Git extension for easily working with GitHub (Note: Requires Ruby/Rake)
- * [drush](http://drush.ws/) - CLI administration tool for Drupal
- * [wp](http://wp-cli.org/) - CLI administration tool for WordPress
+ * CiviCRM
+   * [civix](https://github.com/totten/civix) - Code-generator for CiviCRM extensions
+ * Dependency management
+   * [composer](http://getcomposer.org/) - Dependency manager for PHP packages
+   * [bower](http://bower.io/) - Dependency manager for frontend Javascript packages (Note: Requires NodeJS)
+ * Source code management
+   * [git-scan](https://github.com/totten/git-scan/) - Git extension for working with many git repositories
+   * [hub](http://hub.github.com/) - Git extension for easily working with GitHub (Note: Requires Ruby/Rake)
+ * Site management
+   * [amp](https://github.com/totten/amp) - Abstracted interface for local httpd/sql service (Apache/nginx/MySQL)
+   * **civibuild** - CLI tool which builds a complete source tree (with CMS+Civi+addons), provisions httpd/sql, etc.
+   * [drush](http://drush.ws/) - CLI administration tool for Drupal
+   * [joomla](https://github.com/joomlatools/joomla-console) (joomla-console) - CLI administration for Joomla
+   * [wp](http://wp-cli.org/) (wp-cli) - CLI administration tool for WordPress
+ * Testing
+   * [civicrm-upgrade-test](https://github.com/civicrm/civicrm-upgrade-test) - Scripts and data files for testing upgrades
+   * [karma](http://karma-runner.github.io) (w/[jasmine](http://jasmine.github.io/)) - Unit testing for Javascript (Note: Requires NodeJS)
+   * [paratest](https://github.com/brianium/paratest) - Parallelized version of PHPUnit
+   * [phpunit](http://phpunit.de/) - Unit testing for PHP (with Selenium and DB add-ons)
 
 It will be handy to add these to your PATH:
 

--- a/bin/civi-download-tools
+++ b/bin/civi-download-tools
@@ -50,13 +50,16 @@ function echo_comment() {
 
 ## Ensure that a command is on the PATH. If missing, then give
 ## advice on possible resolutions and exit.
-## usage: check_command <command-name>
+## usage: check_command <command-name> <required|recommended> [<msg>]
 function check_command() {
   local cmd="$1"
+  local requirement="$2"
+  local msg="$3"
+  [ -z "$msg" ] && msg="Failed to locate command \"$cmd\". Please install it (and set the PATH appropriately)."
 
   cmdpath=$(which $cmd)
   if [ -z "$cmdpath" ]; then
-    echo "Failed to locate command \"$cmd\". Please install it (and set the PATH appropriately)."
+    echo "$msg"
     local is_first=1
     for altdir in \
       /Applications/MAMP/Library/bin \
@@ -75,7 +78,9 @@ function check_command() {
         echo " * $altdir"
       fi
     done
-    exit 3
+    if [ "$requirement" = "required" ]; then
+      exit 3
+    fi
   fi
 }
 
@@ -108,13 +113,13 @@ done
 
 ##################################################
 ## Validation
-check_command php
-check_command mysql
-check_command mysqldump
-check_command git
-check_command tar
-check_command bzip2
-check_command gzip
+check_command php required
+check_command mysql required
+check_command mysqldump required
+check_command git required
+check_command tar required
+check_command bzip2 required
+check_command gzip required
 
 if [ ! -d "$TMPDIR" ]; then
   mkdir -p "$TMPDIR"
@@ -225,6 +230,16 @@ pushd $PRJDIR >> /dev/null
   fi
 
 popd >> /dev/null
+set +e
+
+##################################################
+## Recommendations
+##
+## Note: Non-fatal recommendations come at the end so that they appear as
+## the last output (which is most likely to be read).
+
+check_command node recommended "WARNING: Failed to locate command \"node\". NodeJS (http://nodejs.org/) is required for development of CiviCRM v4.6+."
+check_command npm recommended "WARNING: Failed to locate command \"npm\". NodeJS (http://nodejs.org/) is required for development of CiviCRM v4.6+."
 
 ##################################################
 ## Cleanup

--- a/bin/civi-download-tools
+++ b/bin/civi-download-tools
@@ -164,6 +164,26 @@ pushd $PRJDIR >> /dev/null
     cat composer.json composer.lock | php -r 'echo md5(file_get_contents("php://stdin"));' > "$TMPDIR/composer-data.md5"
   fi
 
+  ## Download dependencies (via npm)
+  if which npm > /dev/null ; then
+    PACKAGE_MD5=$(cat package.json | php -r 'echo md5(file_get_contents("php://stdin"));')
+    touch "$TMPDIR/package-data.md5"
+    if [ -z "$IS_FORCE" -a "$(cat $TMPDIR/package-data.md5)" == "$PACKAGE_MD5" -a -d "$PRJDIR/node_modules" ]; then
+      echo_comment "[[npm dependencies already installed. Skipping.]]"
+    else
+      npm install
+      cat package.json | php -r 'echo md5(file_get_contents("php://stdin"));' > "$TMPDIR/package-data.md5"
+    fi
+    for f in node_modules/bower/bin/bower node_modules/karma/bin/karma ; do
+      pushd "$PRJDIR/bin" >> /dev/null
+        toolname=$(basename $f)
+        if [ ! -e "$toolname" ]; then
+          ln -s ../$f $toolname
+        fi
+      popd >> /dev/null
+    done
+  fi
+
   [ ! -d "$PRJDIR/extern" ] && mkdir "$PRJDIR/extern"
 
   ## Download "civix"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "description": "CiviCRM Buildkit",
+  "main": "index.js",
+  "license": "MIT",
+  "name": "civicrm",
+  "version": "0.1.0",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/civicrm/civicrm-buildkit.git"
+  },
+  "devDependencies": {
+    "bower": "^1.3.1",
+    "karma": "^0.12.16",
+    "karma-chrome-launcher": "^0.1.4",
+    "jasmine-core": "~2.1.2",
+    "karma-jasmine": "~0.3.2"
+  }
+}


### PR DESCRIPTION
Per https://github.com/civicrm/civicrm-core/pull/4767, NodeJS is required
for development in v4.6+, but it is not required for older versions or for
the runtime.