### PR TITLE
INFRA-132 - Add helper phpcs-civi

### DIFF
--- a/bin/phpcs-civi
+++ b/bin/phpcs-civi
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+###############################################################################
+## Bootstrap
+
+## Determine the absolute path of the directory with the file
+## usage: absdirname <file-path>
+function absdirname() {
+  pushd $(dirname $0) >> /dev/null
+    pwd
+  popd >> /dev/null
+}
+
+BINDIR=$(absdirname "$0")
+PRJDIR=$(dirname "$BINDIR")
+PHPCS_STD="$PRJDIR/vendor/drupal/coder/coder_sniffer/Drupal"
+
+###############################################################################
+## Function library
+
+eval "$BINDIR/phpcs" --standard="$PHPCS_STD" "$@"


### PR DESCRIPTION
Running phpcs with Civi's code standard requires knowing the absolute path
to the ruleset.  This is a bit annoying to keep track of.  phpcs-civi will
figure it out.