### PR TITLE
If POSIX APIs missing, display soft warning (instead of hard crash)

### DIFF
--- a/bin/pidlockfile.php
+++ b/bin/pidlockfile.php
@@ -15,6 +15,10 @@ ini_set('display_errors', 1);
 //    echo "Failed to acquire /path/to/my.lock"
 //  fi
 
+if (!function_exists('posix_getpid') || !function_exists('posix_getpgid')) {
+  fwrite(STDERR, "WARNING: pidlockfile.php: POSIX API is unavailable. Cannot lock resources. Concurrent operations may be problematic.\n");
+  exit(0);
+}
 if (count($argv) != 4) {
   echo "Usage: pidlockfile.php <lock-file> <pid> <wait>\n";
   exit(2);

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "php": ">=5.3.3",
     "drush/drush": "dev-master#d1d13676f5beacaa9f8619088fe3ae45ea28a6cf",
     "wp-cli/wp-cli": "0.17",
-    "totten/amp": "dev-master#fefc49e4db80e1296a0e75e79c0c2ff468de18f7",
+    "totten/amp": "dev-master#37edb4a62198c606d51dc4ca384a0faa741bac8e",
     "totten/git-scan": "dev-master#495f9ee8db337b3903929a6bf713f6b427e99d8e",
     "civicrm/strings": "dev-master#f886f33880027639d2aa0eeef79240ae1b7b531c",
     "civicrm/upgrade-test": "dev-master#11bd7affcf26c98ca1d8616cf0b8ff561192f872",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "15600963bb3dad945fba25442b910e04",
+    "hash": "fcea043c6d022a95059d4a597b59cdd2",
     "packages": [
         {
             "name": "brianium/habitat",
@@ -996,7 +996,8 @@
             "authors": [
                 {
                     "name": "Ben Ramsey",
-                    "homepage": "http://benramsey.com"
+                    "homepage": "http://benramsey.com",
+                    "role": "Developer"
                 }
             ],
             "description": "Provides functionality for array_column() to projects using PHP earlier than version 5.5.",
@@ -1535,12 +1536,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/totten/amp.git",
-                "reference": "fefc49e4db80e1296a0e75e79c0c2ff468de18f7"
+                "reference": "37edb4a62198c606d51dc4ca384a0faa741bac8e"
             },
             "dist": {
                 "type": "zip",
                 "url": "https://api.github.com/repos/totten/amp/zipball/3262d51f8a2caed65acea7fbdedb0a80bf9ee970",
-                "reference": "fefc49e4db80e1296a0e75e79c0c2ff468de18f7",
+                "reference": "37edb4a62198c606d51dc4ca384a0faa741bac8e",
                 "shasum": ""
             },
             "require": {
@@ -1575,7 +1576,7 @@
             ],
             "description": "CLI Interface to *AMP-style stacks",
             "homepage": "https://github.com/totten/amp",
-            "time": "2015-01-05 17:45:13"
+            "time": "2015-03-10 20:34:38"
         },
         {
             "name": "totten/git-scan",


### PR DESCRIPTION
According to a quick 'grep', the only time we use the posix_* APIs is to
manage locks/concurrency for civi-download-tools and amp.  As long as you
don't use these tools concurrently on non-POSIX platforms (ie Windows), you
may be OK.