### PR TITLE
drupal-demo - Allow manipulation of the CiviDiscount version

### DIFF
--- a/app/config/drupal-demo/download.sh
+++ b/app/config/drupal-demo/download.sh
@@ -10,6 +10,7 @@ git_cache_setup "https://github.com/dlobo/org.civicrm.module.cividiscount.git" "
 
 [ -z "$CMS_VERSION" ] && CMS_VERSION=7.x
 [ -z "$VOL_VERSION" ] && VOL_VERSION='4.4-1.x'
+[ -z "$DISC_VERSION" ] && DISC_VERSION=master
 
 MAKEFILE="${TMPDIR}/${SITE_TYPE}/${SITE_NAME}/${SITE_ID}.make"
 cvutil_makeparent "$MAKEFILE"
@@ -17,6 +18,7 @@ cat "$SITE_CONFIG_DIR/drush.make.tmpl" \
   | sed "s;%%CACHE_DIR%%;${CACHE_DIR};" \
   | sed "s;%%CIVI_VERSION%%;${CIVI_VERSION};" \
   | sed "s;%%CMS_VERSION%%;${CMS_VERSION};" \
+  | sed "s;%%DISC_VERSION%%;${DISC_VERSION};" \
   | sed "s;%%VOL_VERSION%%;${VOL_VERSION};" \
   > "$MAKEFILE"
 

--- a/app/config/drupal-demo/drush.make.tmpl
+++ b/app/config/drupal-demo/drush.make.tmpl
@@ -121,5 +121,5 @@ libraries[cividiscount][destination] = modules
 libraries[cividiscount][directory_name] = civicrm/tools/extensions/cividiscount
 libraries[cividiscount][download][type] = git
 libraries[cividiscount][download][url] = %%CACHE_DIR%%/dlobo/org.civicrm.module.cividiscount.git
-libraries[cividiscount][download][branch] = %%CIVI_VERSION%%
+libraries[cividiscount][download][branch] = %%DISC_VERSION%%
 libraries[cividiscount][overwrite] = TRUE

--- a/src/civibuild.aliases.sh
+++ b/src/civibuild.aliases.sh
@@ -22,12 +22,12 @@
 ## example: civibuild_alias_resolve d45
 function civibuild_alias_resolve() {
   case "$1" in
-    d43)         SITE_TYPE=drupal-demo      ; CIVI_VERSION=4.3       ; CMS_TITLE="CiviCRM 4.3 Demo on Drupal"        ; VOL_VERSION=v1.3.2	;;
-    d44)         SITE_TYPE=drupal-demo      ; CIVI_VERSION=4.4       ; CMS_TITLE="CiviCRM 4.4 Demo on Drupal"        ; VOL_VERSION=v1.3.2	;;
-    d45)         SITE_TYPE=drupal-demo      ; CIVI_VERSION=4.5       ; CMS_TITLE="CiviCRM 4.5 Demo on Drupal"        ; VOL_VERSION=v4.5-1.3.2	;;
-    d46)         SITE_TYPE=drupal-demo      ; CIVI_VERSION=4.6       ; CMS_TITLE="CiviCRM 4.6 Demo on Drupal"        ; VOL_VERSION=master	;;
-    d47)         SITE_TYPE=drupal-demo      ; CIVI_VERSION=4.7       ; CMS_TITLE="CiviCRM 4.7 Demo on Drupal"        ; VOL_VERSION=master	;;
-    dmaster)     SITE_TYPE=drupal-demo      ; CIVI_VERSION=master    ; CMS_TITLE="CiviCRM Sandbox on Drupal"         ; VOL_VERSION=master	;;
+    d43)         SITE_TYPE=drupal-demo      ; CIVI_VERSION=4.3       ; CMS_TITLE="CiviCRM 4.3 Demo on Drupal"        ; VOL_VERSION=v1.3.2	; DISC_VERSION=4.4	;;
+    d44)         SITE_TYPE=drupal-demo      ; CIVI_VERSION=4.4       ; CMS_TITLE="CiviCRM 4.4 Demo on Drupal"        ; VOL_VERSION=v1.3.2	; DISC_VERSION=4.4	;;
+    d45)         SITE_TYPE=drupal-demo      ; CIVI_VERSION=4.5       ; CMS_TITLE="CiviCRM 4.5 Demo on Drupal"        ; VOL_VERSION=v4.5-1.3.2	; DISC_VERSION=4.5	;;
+    d46)         SITE_TYPE=drupal-demo      ; CIVI_VERSION=4.6       ; CMS_TITLE="CiviCRM 4.6 Demo on Drupal"        ; VOL_VERSION=master	; DISC_VERSION=master	;;
+    d47)         SITE_TYPE=drupal-demo      ; CIVI_VERSION=4.7       ; CMS_TITLE="CiviCRM 4.7 Demo on Drupal"        ; VOL_VERSION=master	; DISC_VERSION=master	;;
+    dmaster)     SITE_TYPE=drupal-demo      ; CIVI_VERSION=master    ; CMS_TITLE="CiviCRM Sandbox on Drupal"         ; VOL_VERSION=master	; DISC_VERSION=master	;;
 
     dc43)        SITE_TYPE=drupal-clean     ; CIVI_VERSION=4.3       ; CMS_TITLE="CiviCRM 4.3 Clean on Drupal"       ;;
     dc44)        SITE_TYPE=drupal-clean     ; CIVI_VERSION=4.4       ; CMS_TITLE="CiviCRM 4.4 Clean on Drupal"       ;;


### PR DESCRIPTION
In recent months, we've relied on a direct matching of civicrm-core and
CiviDiscount versions (e.g. d45 uses civicrm-core branch "4.5" and
cividiscount branch 4.5"). However, CiviDiscount only has branches for 4.4,
4.5, and master -- so d46 and d43 are broken.

This patch allows matching different Civi versions with different
CiviDiscount versions. Whenever CiviDiscount makes a change to
its versioning, we may need to update the build config.