### PR TITLE
Give instructions on how to use civicrm-buildkit via composer

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ would need to re-run ***export***.
 If you want to set up buildkit using composer, do the following...
 
 * Add the following to ~/.composer/composer.json
+  
   ```
   {
     "minimum-stability": "dev",
@@ -94,6 +95,7 @@ If you want to set up buildkit using composer, do the following...
     }
   }
   ```
+  
 * Run `composer global update`
 * Add `~/.composer/vendor/bin` to your PATH varariable like so:
   `export PATH=$HOME/.composer/vendor/bin:$PATH`

--- a/README.md
+++ b/README.md
@@ -62,6 +62,44 @@ a new one.
 Each time you open a new terminal while working on Civi development, you
 would need to re-run ***export***.
 
+### CLI Setup: Composer
+
+If you want to set up buildkit using composer, do the following...
+
+* Add the following to ~/.composer/composer.json
+  ```
+  {
+    "minimum-stability": "dev",
+    "prefer-stable": true,
+    "repositories": [
+      {
+        "type": "git",
+        "url": "https://github.com/civicrm/civicrm-buildkit.git"
+      },
+    {
+        "type": "git",
+        "url": "https://github.com/civicrm/coder.git"
+      },
+      {
+        "type": "git",
+        "url": "https://github.com/totten/paratest.git"
+      },
+      {
+        "type": "git",
+        "url": "https://github.com/totten/joomla-console.git"
+      }
+    ],
+    "require": {
+      "civicrm/civicrm-buildkit": "dev-master"
+    }
+  }
+  ```
+* Run `composer global update`
+* Add `~/.composer/vendor/bin` to your PATH varariable like so:
+  `export PATH=$HOME/.composer/vendor/bin:$PATH`
+
+You will now have the ability to run civibuild, civilint, etc, globally.
+
 ## CLI Tools
 
  * CiviCRM

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
-  "name": "civicrm/civicrm-project",
+  "name": "civicrm/civicrm-buildkit",
   "description": "A skeletal project which includes CiviCRM, Drupal, WordPress, development tools, etc",
-  "homepage": "https://github.com/civicrm/civicrm-project/",
+  "homepage": "https://github.com/civicrm/civicrm-buildkit/",
   "license": "GPL-2.0+",
   "authors": [
     { "name": "Tim Otten", "email": "to-git@think.hm" }
@@ -11,7 +11,7 @@
   },
   "require": {
     "php": ">=5.3.3",
-    "drush/drush": "dev-master#d1d13676f5beacaa9f8619088fe3ae45ea28a6cf",
+    "drush/drush": "~7.0.0-alpha2",
     "wp-cli/wp-cli": "0.17",
     "totten/amp": "dev-master#37edb4a62198c606d51dc4ca384a0faa741bac8e",
     "totten/git-scan": "dev-master#495f9ee8db337b3903929a6bf713f6b427e99d8e",
@@ -38,5 +38,16 @@
       "type": "git",
       "url": "https://github.com/totten/joomla-console.git"
     }
+  ],
+  "replace": {
+    "civicrm/civicrm-project": "self.version"
+  },
+  "bin": [
+    "bin/civibuild",
+    "bin/cividist",
+    "bin/civi-download-tools",
+    "bin/civilint",
+    "bin/gitify",
+    "bin/phpcs-civi"
   ]
 }

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
   },
   "require": {
     "php": ">=5.3.3",
-    "drush/drush": "~7.0.0-alpha2",
+    "drush/drush": "~7.0",
     "wp-cli/wp-cli": "0.17",
     "totten/amp": "dev-master#37edb4a62198c606d51dc4ca384a0faa741bac8e",
     "totten/git-scan": "dev-master#495f9ee8db337b3903929a6bf713f6b427e99d8e",


### PR DESCRIPTION
Updated Composer.json with a few tweaks. Typically, you want to update dependencies unless there is a known reason NOT to, and then you pin them. I found it difficult to do so with these packages because most have been forked.

Consider adding civicrm/civicrm-buildkit to packagist.org as well.