### PR TITLE
add distmaker notes

### DIFF
--- a/doc/cividist.md
+++ b/doc/cividist.md
@@ -6,12 +6,15 @@ CiviDist works by checking out the matching branch in each repo - so if you want
 exist in all repos.
 
 ## Setup: Make the web root
+```
 civibuild create dist --url http://dist.localhost ; 
+```
 
 ## Setup: Register your forks
  Note that if you don't fork one of these repos then you should still add a fork,
  but point it to the main civicrm repo so you have a consistent remote alias for all relevant repos.
 
+```
 cd build/dist/src
 git remote add myfork https://github.com/myfork/civicrm-core.git
 git config core.filemode false
@@ -31,15 +34,22 @@ git config core.filemode false
 cd build/dist/src/Wordpress
 git remote add myfork https://github.com/myfork/civicrm-wordpress.git
 git config core.filemode false
+```
 
 ## Periodic: Update code - this will retrieve from the remote alias - ie. myfork in the text below
+```
 cd build/dist
 env GIT_REMOTE=myfork cividist update 
+```
 
 ## Periodic: Build tarballs
+```
 cd build/dist
 cividist build myfork/4.6
+```
 
 ## Periodic: Cleanup old/orphaned tarballs
+```
 cd build/dist
 cividist prune
+```

--- a/doc/cividist.md
+++ b/doc/cividist.md
@@ -1,0 +1,45 @@
+## CiviDist
+Cividist generates tarballs from the git repos. If you wish to run it with your own repos you will need to do the 2
+setup steps first and then the last 3 when you want to build new tarballs (e.g nightly).
+
+CiviDist works by checking out the matching branch in each repo - so if you want to use a non-standard name it must 
+exist in all repos.
+
+## Setup: Make the web root
+civibuild create dist --url http://dist.localhost ; 
+
+## Setup: Register your forks
+ Note that if you don't fork one of these repos then you should still add a fork,
+ but point it to the main civicrm repo so you have a consistent remote alias for all relevant repos.
+
+cd build/dist/src
+git remote add myfork https://github.com/myfork/civicrm-core.git
+git config core.filemode false
+
+cd build/dist/src/drupal
+git remote add myfork https://github.com/myfork/civicrm-drupal.git
+git config core.filemode false
+
+cd build/dist/src/packages
+git remote add myfork https://github.com/myfork/civicrm-packages.git
+git config core.filemode false
+
+cd build/dist/src/joomla
+git remote add myfork https://github.com/myfork/civicrm-joomla.git
+git config core.filemode false
+
+cd build/dist/src/Wordpress
+git remote add myfork https://github.com/myfork/civicrm-wordpress.git
+git config core.filemode false
+
+## Periodic: Update code - this will retrieve from the remote alias - ie. myfork in the text below
+cd build/dist
+env GIT_REMOTE=myfork cividist update 
+
+## Periodic: Build tarballs
+cd build/dist
+cividist build myfork/4.6
+
+## Periodic: Cleanup old/orphaned tarballs
+cd build/dist
+cividist prune


### PR DESCRIPTION
So, I got on quite well towards creating a fuzion version of buildkit. Some limitations I'd like to look at 

1) the links in the latest dir include the date. Since I'd like a consistent url I would want the links to specific tarballs in the LATEST dir to be (e.g) 

civicrm-4.6.5-drupal.tar.gz

rather than

civicrm-4.6.5-drupal-20150630.tar.gz

The tarballs themselves would not change but it would mean there would be a url that always retrieved the latest

2) point versions / release candidates. 

My preference is to have  a branch for each point release (our convention has been 4.4.15rc1 etc). The main reason I like this is that each point release (or so) I rebase against upstream & the new point release generally has less, cleaner patches. As part of this process I make sure we aren't accumulating too many patches that have not been managed into the upstream repo, so it's partly about being a good citizen & ensuring patches get into core & partly about protecting our customers from regressions when they upgrade. Of course we do try to upstream patches whenever we do them - but some take longer than others to get into core for various reasons.

However, to do it with this system we would need to ditch the hybrid I settled on of having a branch for the repos we alter (core & drupal) & also create a branch per repo for joomla, & wordpress. (packages sits somewhere in the middle since we rarely patch it). 

From our point of view options are
1) just stick with one 4.6 branch, don't rebase & manage merge conflicts  as they happen & lose our regular upstreaming checks.

2) stick with one 4.6 patch & break Torrance's heart by doing push -f to it when we rebase & upstream

3) create dummy repos & dummy point releases for all repos (incl wp & joomla)
 
4) patch distmaker to have a fallback pattern -e.g if not 4.6.5rc1 exists fall back to branch 4.6 & keep doing point versions.

My preference is for 4 but I realise it might not be seen as a generic enough need to go into BK