### PR TITLE
call setup.sh using bash so execute permission not required

### DIFF
--- a/src/civibuild.lib.sh
+++ b/src/civibuild.lib.sh
@@ -448,7 +448,7 @@ function civicrm_install() {
   pushd "$CIVI_CORE" >> /dev/null
     ## Does this build include development support (eg git or tarball-based)?
     if [ -e "xml" -a -e "bin/setup.sh" ]; then
-      env SITE_ID="$SITE_ID" ./bin/setup.sh
+      env SITE_ID="$SITE_ID" bash bin/setup.sh
     elif [ -e "sql/civicrm.mysql" -a -e "sql/civicrm_generated.mysql" ]; then
       cat sql/civicrm.mysql sql/civicrm_generated.mysql | mysql $CIVI_DB_ARGS
     else


### PR DESCRIPTION
We've been hitting probs with needing executable permissions on this file & T recommended this as better