### PR TITLE
migrate vagrant files from precise to trusty

### DIFF
--- a/vagrant/trusty32-shared/Vagrantfile
+++ b/vagrant/trusty32-shared/Vagrantfile
@@ -1,0 +1,142 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  # All Vagrant configuration is done here. The most common configuration
+  # options are documented and commented below. For a complete reference,
+  # please see the online documentation at vagrantup.com.
+
+  # Every Vagrant virtual environment requires a box to build off of.
+  config.vm.box = "ubuntu/trusty32"
+
+  # The url from where the 'config.vm.box' box will be fetched if it
+  # doesn't already exist on the user's system.
+  # config.vm.box_url = "http://files.vagrantup.com/precise32.box"
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # config.vm.network :forwarded_port, guest: 80, host: 8080
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  config.vm.network :private_network, ip: "192.168.168.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network :public_network
+
+  # If true, then any SSH connections made will enable agent forwarding.
+  # Default value: false
+  # config.ssh.forward_agent = true
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  # config.vm.synced_folder "../data", "/vagrant_data"
+  config.vm.synced_folder "../../app/tmp/apt", "/var/cache/apt/archives/"
+  config.vm.synced_folder "../../build", "/var/www", id: "vagrant-root",
+    :owner => "www-data",
+    :group => "www-data",
+    :mount_options => ["dmode=775","fmode=664"]
+  config.vm.synced_folder "../../", "/home/vagrant/civicrm-buildkit", id: "civicrm-buildkit",
+    :owner => "vagrant",
+    :group => "vagrant",
+    :mount_options => ["dmode=775","fmode=664"]
+  config.vm.synced_folder "../../bin", "/home/vagrant/civicrm-buildkit/bin", id: "civicrm-buildkit-bin",
+    :owner => "vagrant",
+    :group => "vagrant",
+    :mount_options => ["dmode=775","fmode=775"]
+  config.vm.synced_folder "../../vendor", "/home/vagrant/civicrm-buildkit/vendor", id: "civicrm-buildkit-vendor",
+    :owner => "vagrant",
+    :group => "vagrant",
+    :mount_options => ["dmode=775","fmode=775"]
+  config.vm.synced_folder "../../extern", "/home/vagrant/civicrm-buildkit/extern", id: "civicrm-buildkit-extern",
+    :owner => "vagrant",
+    :group => "vagrant",
+    :mount_options => ["dmode=775","fmode=775"]
+
+  config.vm.provision :shell, :path => "bootstrap.sh"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  # config.vm.provider :virtualbox do |vb|
+  #   # Don't boot with headless mode
+  #   vb.gui = true
+  #
+  #   # Use VBoxManage to customize the VM. For example to change memory:
+  #   vb.customize ["modifyvm", :id, "--memory", "1024"]
+  # end
+  #
+  # View the documentation for the provider you're using for more
+  # information on available options.
+
+  # Enable provisioning with Puppet stand alone.  Puppet manifests
+  # are contained in a directory path relative to this Vagrantfile.
+  # You will need to create the manifests directory and a manifest in
+  # the file base.pp in the manifests_path directory.
+  #
+  # An example Puppet manifest to provision the message of the day:
+  #
+  # # group { "puppet":
+  # #   ensure => "present",
+  # # }
+  # #
+  # # File { owner => 0, group => 0, mode => 0644 }
+  # #
+  # # file { '/etc/motd':
+  # #   content => "Welcome to your Vagrant-built virtual machine!
+  # #               Managed by Puppet.\n"
+  # # }
+  #
+  # config.vm.provision :puppet do |puppet|
+  #   puppet.manifests_path = "manifests"
+  #   puppet.manifest_file  = "site.pp"
+  # end
+
+  # Enable provisioning with chef solo, specifying a cookbooks path, roles
+  # path, and data_bags path (all relative to this Vagrantfile), and adding
+  # some recipes and/or roles.
+  #
+  # config.vm.provision :chef_solo do |chef|
+  #   chef.cookbooks_path = "../my-recipes/cookbooks"
+  #   chef.roles_path = "../my-recipes/roles"
+  #   chef.data_bags_path = "../my-recipes/data_bags"
+  #   chef.add_recipe "mysql"
+  #   chef.add_role "web"
+  #
+  #   # You may also specify custom JSON attributes:
+  #   chef.json = { :mysql_password => "foo" }
+  # end
+
+  # Enable provisioning with chef server, specifying the chef server URL,
+  # and the path to the validation key (relative to this Vagrantfile).
+  #
+  # The Opscode Platform uses HTTPS. Substitute your organization for
+  # ORGNAME in the URL and validation key.
+  #
+  # If you have your own Chef Server, use the appropriate URL, which may be
+  # HTTP instead of HTTPS depending on your configuration. Also change the
+  # validation key to validation.pem.
+  #
+  # config.vm.provision :chef_client do |chef|
+  #   chef.chef_server_url = "https://api.opscode.com/organizations/ORGNAME"
+  #   chef.validation_key_path = "ORGNAME-validator.pem"
+  # end
+  #
+  # If you're using the Opscode platform, your validator client is
+  # ORGNAME-validator, replacing ORGNAME with your organization name.
+  #
+  # If you have your own Chef Server, the default validation client name is
+  # chef-validator, unless you changed the configuration.
+  #
+  #   chef.validation_client_name = "ORGNAME-validator"
+
+end

--- a/vagrant/trusty32-shared/bootstrap.sh
+++ b/vagrant/trusty32-shared/bootstrap.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -e
+###############################################################
+## This script is executed when launching a new virtual machine
+###############################################################
+
+## Update apt
+sed -i 's/deb-src/#deb-src/' /etc/apt/sources.list
+apt-get update
+
+## Some basic helpers
+apt-get install -y \
+  colordiff \
+  curl \
+  git \
+  git-man \
+  joe \
+  makepasswd \
+  patch \
+  subversion \
+  unzip \
+  wget \
+  zip \
+  nodejs-legacy
+
+## MySQL
+MYSQLPASS=$(makepasswd --chars=16)
+echo "mysql-server-5.5 mysql-server/root_password password $MYSQLPASS" | debconf-set-selections
+echo "mysql-server-5.5 mysql-server/root_password_again password $MYSQLPASS" | debconf-set-selections
+apt-get install -y mysql-server-5.5 mysql-client-5.5
+cat > /root/.my.cnf << EOF
+[client]
+user=root
+password=$MYSQLPASS
+EOF
+chmod 600 /root/.my.cnf
+cp /root/.my.cnf /home/vagrant/.my.cnf
+chown vagrant.vagrant /home/vagrant/.my.cnf
+
+## PHP
+apt-get install -y php5-{cli,imap,ldap,curl,mysql,intl,gd} php-apc
+
+## Apache
+apt-get install -y apache2 libapache2-mod-php5
+
+## Ruby (required for "hub")
+apt-get install -y ruby rake
+
+## civicrm-buildkit -- note: code is already shared (via Vagrantfile)
+PRJDIR=/home/vagrant/civicrm-buildkit
+sudo -u vagrant -H "$PRJDIR/bin/civi-download-tools"
+cat > /etc/profile.d/civicrm_project.sh << EOF
+PATH="$PRJDIR/bin:\$PATH"
+export PATH
+EOF
+
+#[ ! -d "$PRJDIR/app/tmp/apache.d" ] && mkdir -p "$PRJDIR/app/tmp/apache.d"
+echo "IncludeOptional /home/vagrant/.amp/apache.d/*.conf" > /etc/apache2/conf-available/civicrm-buildkit.conf
+a2enconf civicrm-buildkit
+
+sudo -u vagrant -H $PRJDIR/bin/amp config:set \
+  --mysql_type="mycnf" \
+  --httpd_type="apache" \
+  --perm_type="worldWritable"
+#  --mysql_type="dsn" \
+#  --mysql_dsn="mysql://root:$MYSQLPASS@localhost:3306" \
+#  --apache_dir="$PRJDIR/app/tmp/apache.d" \

--- a/vagrant/trusty32-standalone/Vagrantfile
+++ b/vagrant/trusty32-standalone/Vagrantfile
@@ -1,0 +1,133 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  # All Vagrant configuration is done here. The most common configuration
+  # options are documented and commented below. For a complete reference,
+  # please see the online documentation at vagrantup.com.
+
+  # Every Vagrant virtual environment requires a box to build off of.
+  config.vm.box = "ubuntu/trusty32"
+
+  # The url from where the 'config.vm.box' box will be fetched if it
+  # doesn't already exist on the user's system.
+  # config.vm.box_url = "http://files.vagrantup.com/precise32.box"
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # config.vm.network :forwarded_port, guest: 80, host: 8080
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  config.vm.network :private_network, ip: "192.168.168.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network :public_network
+
+  # If true, then any SSH connections made will enable agent forwarding.
+  # Default value: false
+  # config.ssh.forward_agent = true
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  # config.vm.synced_folder "../data", "/vagrant_data"
+  config.vm.synced_folder "../../app/tmp/apt", "/var/cache/apt/archives/",
+    :create => true,
+    :owner => "root",
+    :group => "root"
+  config.vm.synced_folder "../../app/tmp/composer", "/home/vagrant/.composer",
+    :create => true,
+    :owner => "vagrant",
+    :group => "vagrant"
+  config.vm.synced_folder "../../", "/home/vagrant/buildkit.host", id: "buildkit.host",
+    :owner => "vagrant",
+    :group => "vagrant",
+    :mount_options => ["dmode=775","fmode=664"]
+
+  config.vm.provision :shell, :path => "bootstrap.sh"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  config.vm.provider :virtualbox do |vb|
+  #   # Don't boot with headless mode
+  #   vb.gui = true
+  #
+  #   # Use VBoxManage to customize the VM. For example to change memory:
+     vb.customize ["modifyvm", :id, "--memory", "2048"]
+  end
+  #
+  # View the documentation for the provider you're using for more
+  # information on available options.
+
+  # Enable provisioning with Puppet stand alone.  Puppet manifests
+  # are contained in a directory path relative to this Vagrantfile.
+  # You will need to create the manifests directory and a manifest in
+  # the file base.pp in the manifests_path directory.
+  #
+  # An example Puppet manifest to provision the message of the day:
+  #
+  # # group { "puppet":
+  # #   ensure => "present",
+  # # }
+  # #
+  # # File { owner => 0, group => 0, mode => 0644 }
+  # #
+  # # file { '/etc/motd':
+  # #   content => "Welcome to your Vagrant-built virtual machine!
+  # #               Managed by Puppet.\n"
+  # # }
+  #
+  # config.vm.provision :puppet do |puppet|
+  #   puppet.manifests_path = "manifests"
+  #   puppet.manifest_file  = "site.pp"
+  # end
+
+  # Enable provisioning with chef solo, specifying a cookbooks path, roles
+  # path, and data_bags path (all relative to this Vagrantfile), and adding
+  # some recipes and/or roles.
+  #
+  # config.vm.provision :chef_solo do |chef|
+  #   chef.cookbooks_path = "../my-recipes/cookbooks"
+  #   chef.roles_path = "../my-recipes/roles"
+  #   chef.data_bags_path = "../my-recipes/data_bags"
+  #   chef.add_recipe "mysql"
+  #   chef.add_role "web"
+  #
+  #   # You may also specify custom JSON attributes:
+  #   chef.json = { :mysql_password => "foo" }
+  # end
+
+  # Enable provisioning with chef server, specifying the chef server URL,
+  # and the path to the validation key (relative to this Vagrantfile).
+  #
+  # The Opscode Platform uses HTTPS. Substitute your organization for
+  # ORGNAME in the URL and validation key.
+  #
+  # If you have your own Chef Server, use the appropriate URL, which may be
+  # HTTP instead of HTTPS depending on your configuration. Also change the
+  # validation key to validation.pem.
+  #
+  # config.vm.provision :chef_client do |chef|
+  #   chef.chef_server_url = "https://api.opscode.com/organizations/ORGNAME"
+  #   chef.validation_key_path = "ORGNAME-validator.pem"
+  # end
+  #
+  # If you're using the Opscode platform, your validator client is
+  # ORGNAME-validator, replacing ORGNAME with your organization name.
+  #
+  # If you have your own Chef Server, the default validation client name is
+  # chef-validator, unless you changed the configuration.
+  #
+  #   chef.validation_client_name = "ORGNAME-validator"
+
+end

--- a/vagrant/trusty32-standalone/bootstrap.sh
+++ b/vagrant/trusty32-standalone/bootstrap.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+set -e
+###############################################################
+## This script is executed when launching a new virtual machine
+###############################################################
+
+## Update apt
+sed -i 's/deb-src/#deb-src/' /etc/apt/sources.list
+apt-get update
+
+## Some basic helpers
+apt-get install -y \
+  acl \
+  colordiff \
+  curl \
+  git \
+  git-man \
+  joe \
+  makepasswd \
+  patch \
+  rsync \
+  subversion \
+  unzip \
+  wget \
+  zip \
+  npm \
+  nodejs-legacy
+
+## MySQL
+if [ ! -f /usr/sbin/mysqld ]; then
+  MYSQLPASS=$(makepasswd --chars=16)
+  echo "mysql-server-5.5 mysql-server/root_password password $MYSQLPASS" | debconf-set-selections
+  echo "mysql-server-5.5 mysql-server/root_password_again password $MYSQLPASS" | debconf-set-selections
+  apt-get install -y mysql-server-5.5 mysql-client-5.5
+  cat > /root/.my.cnf << EOF
+[client]
+user=root
+password=$MYSQLPASS
+EOF
+  chmod 600 /root/.my.cnf
+  cp /root/.my.cnf /home/vagrant/.my.cnf
+  chown vagrant.vagrant /home/vagrant/.my.cnf
+fi
+
+## PHP
+apt-get install -y php5-{cli,imap,ldap,curl,mysql,intl,gd} php-apc
+
+## Apache
+apt-get install -y apache2 libapache2-mod-php5
+
+## Ruby (required for "hub")
+apt-get install -y ruby rake
+
+## civicrm-buildkit -- Copy from remote (RPRJDIR) to local (LPRJDIR)
+LPRJDIR=/home/vagrant/buildkit
+RPRJDIR=/home/vagrant/buildkit.host
+if [ ! -d "$LPRJDIR" ]; then
+  sudo -u vagrant -H git clone "file://$RPRJDIR" "$LPRJDIR"
+  pushd "$LPRJDIR" >> /dev/null
+    sudo -u vagrant -H git remote set-url origin https://github.com/civicrm/civicrm-buildkit.git
+  popd >> /dev/null
+fi
+
+## apt composer git-cache
+[ ! -d "$LPRJDIR/app/tmp" ]           && sudo -u vagrant -H mkdir -p "$LPRJDIR/app/tmp"
+[ ! -d "$RPRJDIR/app/tmp" ]           && sudo -u vagrant -H mkdir -p "$RPRJDIR/app/tmp"
+[ ! -d "$RPRJDIR/app/tmp/git-cache" ] && sudo -u vagrant -H mkdir -p "$RPRJDIR/app/tmp/git-cache"
+[ ! -e "$LPRJDIR/app/tmp/git-cache" ] && sudo -u vagrant -H ln -s "$RPRJDIR/app/tmp/git-cache" "$LPRJDIR/app/tmp/git-cache"
+#This can reduce downloads, but composer fails to setup symlinks if you use it:
+#[ ! -d "$LPRJDIR/vendor" ]            && sudo -u vagrant -H mkdir -p "$LPRJDIR/vendor"
+#sudo -u vagrant -H rsync -a "$RPRJDIR/vendor/./" "$LPRJDIR/vendor/./"
+sudo -u vagrant -H "$LPRJDIR/bin/civi-download-tools"
+cat > /etc/profile.d/civicrm_project.sh << EOF
+PATH="$LPRJDIR/bin:\$PATH"
+export PATH
+EOF
+
+AMP_APACHE="/home/vagrant/.amp/apache.d"
+if apache2 -v | grep 'Apache/2\.2\.'  -q ; then
+  [ ! -d "$AMP_APACHE" ] && sudo -u vagrant -H mkdir -p "$AMP_APACHE"
+  echo "" > "$AMP_APACHE/placeholder.conf"
+  chown vagrant.vagrant "$AMP_APACHE/placeholder.conf"
+
+  echo "Include $AMP_APACHE/*.conf" > /etc/apache2/conf-available/civicrm-buildkit.conf
+else
+  echo "IncludeOptional /home/vagrant/.amp/apache.d/*.conf" > /etc/apache2/conf-available/civicrm-buildkit.conf
+fi
+a2enconf civicrm-buildkit
+
+sudo -u vagrant -H $LPRJDIR/bin/amp config:set \
+  --mysql_type="mycnf" \
+  --httpd_type="apache" \
+  --perm_type="linuxAcl" \
+  --perm_user="www-data"
+##  --mysql_type="dsn" \
+##  --mysql_dsn="mysql://root:$MYSQLPASS@localhost:3306" \
+##  --apache_dir="$LPRJDIR/app/tmp/apache.d" \


### PR DESCRIPTION
I tried to use the existing Vagrant setup but it didn't work for me. This pull request migrates the Vagrant setup from precise32 (12.04 LTS) to trusty32 (14.04 LTS) and makes a few changes that are required due to the migration.