### PR TITLE
PCHR-343: Changed default login destination for civihr_admin in hr15

### DIFF
--- a/app/config/hr15/install-login-destination.php
+++ b/app/config/hr15/install-login-destination.php
@@ -13,7 +13,7 @@ $rules[] = array(
   'pages_type' => 0,
   'pages' => '',
   'destination_type' => 0,
-  'destination' => 'civicrm/dashboard',
+  'destination' => 'civicrm/tasksassignments/dashboard#/tasks',
   'weight' => 0,
 );
 $rules[] = array(


### PR DESCRIPTION
Changed the default login destination for civihr_admin to be tasks and assignments dashboard.