### PR TITLE
update composer.json to allow wp-cli version greater than 0.21

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
   "require": {
     "php": ">=5.3.3",
     "drush/drush": "dev-master#d1d13676f5beacaa9f8619088fe3ae45ea28a6cf",
-    "wp-cli/wp-cli": "~0.21.0",
+    "wp-cli/wp-cli": ">=0.22",
     "totten/amp": "dev-master#37edb4a62198c606d51dc4ca384a0faa741bac8e",
     "totten/git-scan": "dev-master#495f9ee8db337b3903929a6bf713f6b427e99d8e",
     "totten/php-symbol-diff": "dev-master#54f869ca68a3cd75f3386f8490870369733d2c23",


### PR DESCRIPTION
composer.lock does not update at this time due as we have a conflict in dependencies.

`-joomlatools/joomla-console dev-master-buildkit requires symfony/console 2.4.* -> satisfiable by symfony/console[v2.4.10, v2.4.0, v2.4.1, v2.4.2, v2.4.3, v2.4.4, v2.4.5, v2.4.6, v2.4.7, v2.4.8, v2.4.9].`

` - wp-cli/wp-cli v0.22.0 requires symfony/console 2.7.* -> satisfiable by symfony/console[v2.7.0, v2.7.1, v2.7.2, v2.7.3, v2.7.4, v2.7.5, v2.7.6, v2.7.7, v2.7.8, v2.7.9].`

If we need joomla-console, we will have wp-cli pinned at 0.21.x.  My understanding is that future wp versions will require 0.22 or later, so we need to either remove joomla-tools or switch to a non-composer method to update wp-cl