### PR TITLE
Smart SITE_NAME

### DIFF
--- a/bin/civibuild
+++ b/bin/civibuild
@@ -235,34 +235,18 @@ function civibuild_show() {
   fi
 
   if [ -n "$SHOW_FULL_BUILD_CONF" ]; then
-    civibuild_show_full_config
+    civibuild_show_summary $PERSISTENT_VARS
   else
-    civibuild_show_summary
+    civibuild_show_summary \
+      CMS_ROOT CMS_URL CMS_DB_DSN \
+      CIVI_DB_DSN TEST_DB_DSN \
+      ADMIN_USER ADMIN_PASS DEMO_USER DEMO_PASS
   fi
-}
-
-function civibuild_show_full_config() {
-  cvutil_assertvars civibuild_show_full_config BLDDIR SITE_NAME SITE_ID
-
-  echo "[[Show Full Site Declaration]]"
-  if [ -f "${BLDDIR}/${SITE_NAME}.sh" ]; then
-    echo "[[Saved options from ${BLDDIR}/${SITE_NAME}.sh]]"
-    cat "${BLDDIR}/${SITE_NAME}.sh" | tail -n +2
-  fi
-  if [ -f "${BLDDIR}/${SITE_NAME}.${SITE_ID}.sh" ]; then
-    echo "[[Saved options from ${BLDDIR}/${SITE_NAME}.${SITE_ID}.sh]]"
-    cat "${BLDDIR}/${SITE_NAME}.${SITE_ID}.sh" | tail -n +2
-  fi
-  civibuild_run_optional show
 }
 
 function civibuild_show_summary() {
-  cvutil_assertvars civibuild_show_summary SITE_NAME SITE_ID
-  cvutil_summary "[[Show site summary ($SITE_NAME/$SITE_ID)]]" \
-    CMS_ROOT CMS_URL CMS_DB_DSN \
-    CIVI_DB_DSN \
-    TEST_DB_DSN \
-    ADMIN_USER ADMIN_PASS DEMO_USER DEMO_PASS
+  cvutil_assertvars civibuild_show_summary "$@" 
+  cvutil_summary "[[Show site summary ($SITE_NAME/$SITE_ID)]]" $@
   civibuild_run_optional show
   echo "[[General notes]]"
   echo " - You may need to restart httpd."

--- a/bin/civibuild
+++ b/bin/civibuild
@@ -294,8 +294,6 @@ function civibuild_show_html() {
 function civibuild_edit() {
   cvutil_assertvars civibuild_edit BLDDIR SITE_NAME SITE_ID
 
- whoami
-
   if [ -f "${BLDDIR}/${SITE_NAME}.sh" ]; then
     echo "[[Edit ${BLDDIR}/${SITE_NAME}.sh]]"
     c="${BLDDIR}/${SITE_NAME}.sh"

--- a/bin/civibuild
+++ b/bin/civibuild
@@ -386,6 +386,7 @@ function civibuild_parse_unnamed_params() {
     ## Convert certain aliases like "d45" into better defaults
     civibuild_alias_resolve "$SITE_NAME"
 
+    ## validate SITE_NAME
     if [ ! -f ${BLDDIR}/${SITE_NAME}.sh ]; then
        if [ ! -f ${BLDDIR}/${SITE_NAME}.${SITE_ID}.sh ]; then
          SITE_NAME=
@@ -569,6 +570,7 @@ source "$PRJDIR/src/civibuild.compute-defaults.sh"
 ###############################################################################
 ## Main
 
+## Developer Note: Declare new Actions in src/civibuild.defaults.sh DECLARED_ACTIONS
 case "$ACTION" in
   clone-create)
     civibuild_clone_create

--- a/bin/civibuild
+++ b/bin/civibuild
@@ -379,25 +379,19 @@ function civibuild_parse_unnamed_params() {
       # dont parse site-name
       break
     fi
-
-    ## Convert "drupal-demo" or "drupal-demo/123" to vars SITE_NAME and optionally SITE_ID
-    eval $(cvutil_parse_site_name_id "$OPTION")
-
-    ## Convert certain aliases like "d45" into better defaults
-    civibuild_alias_resolve "$SITE_NAME"
-
-    ## validate SITE_NAME
-    if [ ! -f ${BLDDIR}/${SITE_NAME}.sh ]; then
-       if [ ! -f ${BLDDIR}/${SITE_NAME}.${SITE_ID}.sh ]; then
-         SITE_NAME=
-         SITE_ID=default
-      fi
-    fi
+    
+    civibuild_validate_site_name "$OPTION"
   done
 
   [ -z "$ACTION" ] && civibuild_usage
 
   if [ `echo "$ACTION" | egrep -c 'snapshots|restore-all|ls|list|builds'` -eq 0 ]; then
+
+    if [ -z "$SITE_NAME" ]; then
+      civibuild_detect_site_name
+      civibuild_validate_site_name "$SITE_NAME" 
+    fi
+
     [ -z "$SITE_NAME" ] && civibuild_usage
     [ -z "$SITE_ID" ] && civibuild_usage
 
@@ -413,6 +407,66 @@ function civibuild_parse_unnamed_params() {
       echo "[[Load saved options from ${BLDDIR}/${SITE_NAME}.${SITE_ID}.sh]]"
       source "${BLDDIR}/${SITE_NAME}.${SITE_ID}.sh"
     fi
+  fi
+}
+
+## If passed name is valid, assign to SITE_NAME
+## IF INVALID, SITE_NAME is reset
+## Parses SITE_ID as well
+## calls alias_resolve
+function civibuild_validate_site_name() {
+  ## Convert "drupal-demo" or "drupal-demo/123" to vars SITE_NAME and optionally SITE_ID
+  eval $(cvutil_parse_site_name_id "$1")
+
+  ## validate SITE_NAME
+  if [ ! -f ${BLDDIR}/${SITE_NAME}.sh ]; then
+    if [ ! -f ${BLDDIR}/${SITE_NAME}.${SITE_ID}.sh ]; then
+     SITE_NAME=
+     SITE_ID=default
+    fi
+  fi
+
+  if [ ! -z "$SITE_NAME" ]; then
+    ## Convert certain aliases like "d45" into better defaults
+    civibuild_alias_resolve "$SITE_NAME"
+  fi
+}
+
+## Search build conf CMS_ROOT configs and compare with pwd
+function civibuild_detect_site_name() {
+  local CWD=`pwd`
+  local config_paths=`grep -r CMS_ROOT $BLDDIR | sed s#CMS_ROOT=## | tr -d '"'`;
+
+  local parents=()
+  local children=()
+
+  for site_path in ${config_paths[@]}; do
+    local arr_site=(${site_path//:/ })
+
+    local conf_file=${arr_site[0]}
+    local cms_root=${arr_site[1]}
+
+    if [[ "$cms_root" == $CWD* ]]; then
+  #    echo "CWD is parent, in" $conf_file
+      children=(${children[@]} $conf_file)
+    fi
+
+    if [[ "$CWD" == $cms_root* ]]; then
+  #    echo "CWD is child, in " $conf_file
+      parents=(${parents[@]} $conf_file)
+    fi
+  done
+
+  local build_file=
+  if [ "${#parents[@]}" -eq 1 ] && [ "${#children[@]}" -ne 1 ]; then
+    build_file=$parents
+  elif [ "${#children[@]}" -eq 1 ] && [ "${#parents[@]}" -ne 1 ]; then
+    build_file=$children
+  fi
+
+  if [ -n "$build_file" ]; then
+    SITE_NAME=`basename $build_file .sh`
+    echo "Detected SITE_NAME: $SITE_NAME"
   fi
 }
 

--- a/bin/civibuild
+++ b/bin/civibuild
@@ -60,6 +60,11 @@ Description: Download and/or install the application
   --force             If necessary, destroy pre-existing files/directories/DBs
                       (For "reinstall", "--force" is implicit.)
 
+Syntax: $APP ls
+Syntax: $APP list
+Syntax: $APP builds
+Description: Display a list of build-names found in the build directory. 
+
 Syntax: $APP show <build-name>[/<ms-id>] [options]
 Description: Show key details about the build
   --html <dir>        A new HTML dir which will report build status in detail
@@ -213,6 +218,14 @@ function civibuild_save() {
   fi
 }
 
+function civibuild_list() {
+  cvutil_assertvars civibuild_list BLDDIR
+
+  for b in `find $BLDDIR -maxdepth 1 -type f`; do
+    basename $b | sed 's/\.sh//'
+  done
+}
+
 function civibuild_show() {
   if [ -n "$SHOW_HTML" ]; then
     civibuild_show_html
@@ -349,10 +362,7 @@ ACTION="$1"
 shift
 
 case "$ACTION" in
-  snapshots)
-    # don't parse SITE_NAME
-    ;;
-  restore-all)
+  snapshot|restore-all|ls|list|builds)
     # don't parse SITE_NAME
     ;;
   *)
@@ -573,6 +583,10 @@ case "$ACTION" in
     civibuild_install
     civibuild_save
     civibuild_show
+    ;;
+
+  ls|list|builds)
+    civibuild_list
     ;;
 
   show)

--- a/bin/civibuild
+++ b/bin/civibuild
@@ -385,7 +385,7 @@ ACTION="$1"
 shift
 
 case "$ACTION" in
-  snapshot|restore-all|ls|list|builds)
+  snapshots|restore-all|ls|list|builds)
     # don't parse SITE_NAME
     ;;
   *)

--- a/bin/civibuild
+++ b/bin/civibuild
@@ -358,44 +358,54 @@ function civibuild_clone_show() {
     CLONE_CIVI_DB_DSN
 }
 
+## Parse un-named params by position: <action> <sitename>[/<ms-id>]
+function civibuild_parse_unnamed_params() {
+  for OPTION in $@; do
+    if [ "${OPTION::1}" == "-" ]; then
+      continue
+    fi
+
+    cvutil_is_action $OPTION
+    if [ $ACTION_VALIDATED -eq 1 ]; then
+      ACTION=$OPTION
+      if [ `echo $ACTION | egrep -c 'snapshots|restore-all|ls|list|builds'` -eq 1 ]; then
+        # dont parse site-name
+        continue
+      fi
+    fi
+
+    [ -z $ACTION ] && continue
+
+    ## Convert "drupal-demo" or "drupal-demo/123" to vars SITE_NAME and optionally SITE_ID
+    eval $(cvutil_parse_site_name_id "$OPTION")
+    [ -z "$SITE_NAME" ] && civibuild_usage
+    [ -z "$SITE_ID" ] && civibuild_usage
+
+    ## Convert certain aliases like "d45" into better defaults
+    civibuild_alias_resolve "$SITE_NAME"
+  done
+}
+
 ###############################################################################
 ## Parse options
 source "$PRJDIR/src/civibuild.defaults.sh"
 [ -f "$PRJDIR/app/civibuild.conf" ] && source "$PRJDIR/app/civibuild.conf"
 cvutil_mkdir "$TMPDIR" "$BLDDIR" "$PRJDIR/app/private"
 
-ACTION="$1"
-[ -z "$ACTION" ] && civibuild_usage
-shift
+civibuild_parse_unnamed_params $@
 
-case "$ACTION" in
-  snapshots|restore-all|ls|list|builds)
-    # don't parse SITE_NAME
-    ;;
-  *)
-    ## Convert "drupal-demo" or "drupal-demo/123" to vars SITE_NAME and optionally SITE_ID
-    eval $(cvutil_parse_site_name_id "$1")
-    [ -z "$SITE_NAME" ] && civibuild_usage
-    [ -z "$SITE_ID" ] && civibuild_usage
-    shift
-
-    ## Convert certains aliases like "d45" into better defaults
-    civibuild_alias_resolve "$SITE_NAME"
-
-    ## Load settings based in SITE_NAME / SITE_ID
-    if [ -f "${BLDDIR}/${SITE_NAME}.sh" ]; then
-      echo "[[Load saved options from ${BLDDIR}/${SITE_NAME}.sh]]"
-      source "${BLDDIR}/${SITE_NAME}.sh"
-      if [ "$SITE_ID" != "default" ]; then
-        IS_INSTALLED=
-      fi
-    fi
-    if [ -f "${BLDDIR}/${SITE_NAME}.${SITE_ID}.sh" ]; then
-      echo "[[Load saved options from ${BLDDIR}/${SITE_NAME}.${SITE_ID}.sh]]"
-      source "${BLDDIR}/${SITE_NAME}.${SITE_ID}.sh"
-    fi
-    ;;
-esac
+## Load settings based in SITE_NAME / SITE_ID
+if [ -f "${BLDDIR}/${SITE_NAME}.sh" ]; then
+  echo "[[Load saved options from ${BLDDIR}/${SITE_NAME}.sh]]"
+  source "${BLDDIR}/${SITE_NAME}.sh"
+  if [ "$SITE_ID" != "default" ]; then
+    IS_INSTALLED=
+  fi
+fi
+if [ -f "${BLDDIR}/${SITE_NAME}.${SITE_ID}.sh" ]; then
+  echo "[[Load saved options from ${BLDDIR}/${SITE_NAME}.${SITE_ID}.sh]]"
+  source "${BLDDIR}/${SITE_NAME}.${SITE_ID}.sh"
+fi
 
 declare -a ARGS=()
 while [ -n "$1" ] ; do

--- a/bin/civibuild
+++ b/bin/civibuild
@@ -65,6 +65,9 @@ Syntax: $APP list
 Syntax: $APP builds
 Description: Display a list of build-names found in the build directory. 
 
+Syntax: $APP edit <build-name>[/<ms-id>]
+Description: edit the <build-dir>/<build-name>[.<ms-id>].sh config file
+
 Syntax: $APP show <build-name>[/<ms-id>] [options]
 Description: Show key details about the build
   --html <dir>        A new HTML dir which will report build status in detail
@@ -286,6 +289,27 @@ function civibuild_show_html() {
   cat "$SHOW_NEW_SCAN" > "$SHOW_HTML/git-scan.new.json"
   cat "$SHOW_LAST_SCAN" | php -r 'print_r(json_decode(file_get_contents("php://stdin"),TRUE));' > "$SHOW_HTML/git-scan.last.txt"
   cat "$SHOW_NEW_SCAN" | php -r 'print_r(json_decode(file_get_contents("php://stdin"),TRUE));' > "$SHOW_HTML/git-scan.new.txt"
+}
+
+function civibuild_edit() {
+  cvutil_assertvars civibuild_edit BLDDIR SITE_NAME SITE_ID
+
+ whoami
+
+  if [ -f "${BLDDIR}/${SITE_NAME}.sh" ]; then
+    echo "[[Edit ${BLDDIR}/${SITE_NAME}.sh]]"
+    c="${BLDDIR}/${SITE_NAME}.sh"
+  fi
+  if [ -f "${BLDDIR}/${SITE_NAME}.${SITE_ID}.sh" ]; then
+    echo "[[Edit ${BLDDIR}/${SITE_NAME}.${SITE_ID}.sh]]"
+    c="${BLDDIR}/${SITE_NAME}.${SITE_ID}.sh"
+  fi
+
+  if [ -n "$EDITOR" ]; then
+    $EDITOR $c
+  else
+    echo "No editor found - please configure your EDITOR env variable."
+  fi
 }
 
 function civibuild_clone_create() {
@@ -576,6 +600,10 @@ case "$ACTION" in
   download|dl)
     civibuild_download
     civibuild_save
+    ;;
+
+  edit)
+    civibuild_edit
     ;;
 
   install|reinstall)

--- a/bin/civibuild
+++ b/bin/civibuild
@@ -65,6 +65,7 @@ Description: Show key details about the build
   --html <dir>        A new HTML dir which will report build status in detail
   --new-scan <file>   A new JSON file which summarizes the git structure
   --last-scan <file>  An existing JSON file which summarizes the old git structure
+  --full              Show all build options declared
 
 Syntax: $APP snapshots
 Description: List available snapshots
@@ -217,7 +218,29 @@ function civibuild_show() {
     civibuild_show_html
   fi
 
-  cvutil_assertvars civibuild_show SITE_NAME SITE_ID
+  if [ -n "$SHOW_FULL_BUILD_CONF" ]; then
+    civibuild_show_full_config
+  else
+    civibuild_show_summary
+  fi
+}
+
+function civibuild_show_full_config() {
+  cvutil_assertvars civibuild_show_full_config BLDDIR SITE_NAME SITE_ID
+
+  echo "[[Show Full Site Declaration]]"
+  if [ -f "${BLDDIR}/${SITE_NAME}.sh" ]; then
+    echo "[[Saved options from ${BLDDIR}/${SITE_NAME}.sh]]"
+    cat "${BLDDIR}/${SITE_NAME}.sh" | tail -n +2
+  fi
+  if [ -f "${BLDDIR}/${SITE_NAME}.${SITE_ID}.sh" ]; then
+    echo "[[Saved options from ${BLDDIR}/${SITE_NAME}.${SITE_ID}.sh]]"
+    cat "${BLDDIR}/${SITE_NAME}.${SITE_ID}.sh" | tail -n +2
+  fi
+}
+
+function civibuild_show_summary() {
+  cvutil_assertvars civibuild_show_summary SITE_NAME SITE_ID
   cvutil_summary "[[Show site summary ($SITE_NAME/$SITE_ID)]]" \
     CMS_ROOT CMS_URL CMS_DB_DSN \
     CIVI_DB_DSN \
@@ -433,6 +456,10 @@ while [ -n "$1" ] ; do
 
     --force-install)
       FORCE_INSTALL=1
+      ;;
+
+    --full)
+      SHOW_FULL_BUILD_CONF=1
       ;;
 
     --html)

--- a/bin/civibuild
+++ b/bin/civibuild
@@ -253,6 +253,7 @@ function civibuild_show_full_config() {
     echo "[[Saved options from ${BLDDIR}/${SITE_NAME}.${SITE_ID}.sh]]"
     cat "${BLDDIR}/${SITE_NAME}.${SITE_ID}.sh" | tail -n +2
   fi
+  civibuild_run_optional show
 }
 
 function civibuild_show_summary() {

--- a/bin/civibuild
+++ b/bin/civibuild
@@ -361,29 +361,58 @@ function civibuild_clone_show() {
 ## Parse un-named params by position: <action> <sitename>[/<ms-id>]
 function civibuild_parse_unnamed_params() {
   for OPTION in $@; do
-    if [ "${OPTION::1}" == "-" ]; then
+    #skip named options
+    [ "${OPTION::1}" == "-" ] && continue
+
+    # don't overwrite SITE_NAME if already set
+    [ -n "$SITE_NAME" ] && continue
+
+    if [ -z $ACTION ]; then
+      cvutil_is_action $OPTION
+      if [ $ACTION_VALIDATED -eq 1 ]; then
+        ACTION=$OPTION
+      fi
       continue
     fi
 
-    cvutil_is_action $OPTION
-    if [ $ACTION_VALIDATED -eq 1 ]; then
-      ACTION=$OPTION
-      if [ `echo $ACTION | egrep -c 'snapshots|restore-all|ls|list|builds'` -eq 1 ]; then
-        # dont parse site-name
-        continue
-      fi
+    if [ `echo "$ACTION" | egrep -c 'snapshots|restore-all|ls|list|builds'` -eq 1 ]; then
+      # dont parse site-name
+      break
     fi
-
-    [ -z $ACTION ] && continue
 
     ## Convert "drupal-demo" or "drupal-demo/123" to vars SITE_NAME and optionally SITE_ID
     eval $(cvutil_parse_site_name_id "$OPTION")
-    [ -z "$SITE_NAME" ] && civibuild_usage
-    [ -z "$SITE_ID" ] && civibuild_usage
 
     ## Convert certain aliases like "d45" into better defaults
     civibuild_alias_resolve "$SITE_NAME"
+
+    if [ ! -f ${BLDDIR}/${SITE_NAME}.sh ]; then
+       if [ ! -f ${BLDDIR}/${SITE_NAME}.${SITE_ID}.sh ]; then
+         SITE_NAME=
+         SITE_ID=default
+      fi
+    fi
   done
+
+  [ -z "$ACTION" ] && civibuild_usage
+
+  if [ `echo "$ACTION" | egrep -c 'snapshots|restore-all|ls|list|builds'` -eq 0 ]; then
+    [ -z "$SITE_NAME" ] && civibuild_usage
+    [ -z "$SITE_ID" ] && civibuild_usage
+
+    ## Load settings based in SITE_NAME / SITE_ID
+    if [ -f "${BLDDIR}/${SITE_NAME}.sh" ]; then
+      echo "[[Load saved options from ${BLDDIR}/${SITE_NAME}.sh]]"
+      source "${BLDDIR}/${SITE_NAME}.sh"
+      if [ "$SITE_ID" != "default" ]; then
+        IS_INSTALLED=
+      fi
+    fi
+    if [ -f "${BLDDIR}/${SITE_NAME}.${SITE_ID}.sh" ]; then
+      echo "[[Load saved options from ${BLDDIR}/${SITE_NAME}.${SITE_ID}.sh]]"
+      source "${BLDDIR}/${SITE_NAME}.${SITE_ID}.sh"
+    fi
+  fi
 }
 
 ###############################################################################
@@ -393,19 +422,6 @@ source "$PRJDIR/src/civibuild.defaults.sh"
 cvutil_mkdir "$TMPDIR" "$BLDDIR" "$PRJDIR/app/private"
 
 civibuild_parse_unnamed_params $@
-
-## Load settings based in SITE_NAME / SITE_ID
-if [ -f "${BLDDIR}/${SITE_NAME}.sh" ]; then
-  echo "[[Load saved options from ${BLDDIR}/${SITE_NAME}.sh]]"
-  source "${BLDDIR}/${SITE_NAME}.sh"
-  if [ "$SITE_ID" != "default" ]; then
-    IS_INSTALLED=
-  fi
-fi
-if [ -f "${BLDDIR}/${SITE_NAME}.${SITE_ID}.sh" ]; then
-  echo "[[Load saved options from ${BLDDIR}/${SITE_NAME}.${SITE_ID}.sh]]"
-  source "${BLDDIR}/${SITE_NAME}.${SITE_ID}.sh"
-fi
 
 declare -a ARGS=()
 while [ -n "$1" ] ; do

--- a/src/civibuild.defaults.sh
+++ b/src/civibuild.defaults.sh
@@ -241,3 +241,21 @@ PERSISTENT_VARS="
   SITE_TOKEN SITE_TYPE
 "
 # ignore: runtime options like CIVI_SQL_SKIP and FORCE_DOWNLOAD
+
+###############################################################################
+## Declare Actions
+## Aliases must also be declared
+DECLARED_ACTIONS="
+  clone-create clone-destroy clone-show
+  create
+  destroy
+  download dl
+  edit
+  install reinstall
+  ls list builds
+  show
+  snapshot snapshots
+  restore restore-all
+  upgrade-test ut
+"
+

--- a/src/civibuild.lib.sh
+++ b/src/civibuild.lib.sh
@@ -3,9 +3,9 @@
 ## Bash helper functions
 
 ## Coding conventions:
-## - Function names are "{prefix}_{name}"; prefixes are "util", "civicrm", "wp", etc
+## - Function names are "{prefix}_{name}"; prefixes are "cvutil", "civicrm", "wp", etc
 ## - Options are set as (global) environment variables
-## - Functions declare dependencies on (global) environment variables (util_assertvars).
+## - Functions declare dependencies on (global) environment variables (cvutil_assertvars).
 ##   If a variable missing, the application dies.
 
 ###############################################################################
@@ -198,6 +198,18 @@ EOF
 
   ## Replace main file with temp file
   cat < "$TMPFILE" > "$FILE"
+}
+
+###############################################################################
+## usage: cvutil_is_action <string-to-test>
+function cvutil_is_action() {
+  local action=$1
+  ACTION_VALIDATED=0
+  for a in $DECLARED_ACTIONS; do
+    if [ $a == $action ]; then
+      ACTION_VALIDATED=1
+    fi
+  done
 }
 
 ###############################################################################


### PR DESCRIPTION
branched from https://github.com/civicrm/civicrm-buildkit/pull/231

if SITE_NAME is not passed and current working directory is below a CMS root, or above only one build, then set SITE_NAME intellegently.