### PR TITLE
bin/civibuild - civibuild_validate_site_name is too strict (#234)

### DIFF
--- a/bin/civibuild
+++ b/bin/civibuild
@@ -61,7 +61,7 @@ Description: Download and/or install the application
                       (For "reinstall", "--force" is implicit.)
 
 Syntax: $APP list
-Description: Display a list of build-names found in the build directory. 
+Description: Display a list of build-names found in the build directory.
 
 Syntax: $APP edit <build-name>[/<ms-id>]
 Description: Edit the <build-dir>/<build-name>[.<ms-id>].sh config file
@@ -243,7 +243,7 @@ function civibuild_show() {
 }
 
 function civibuild_show_summary() {
-  cvutil_assertvars civibuild_show_summary "$@" 
+  cvutil_assertvars civibuild_show_summary "$@"
   cvutil_summary "[[Show site summary ($SITE_NAME/$SITE_ID)]]" $@
   civibuild_run_optional show
   echo "[[General notes]]"
@@ -377,7 +377,7 @@ function civibuild_parse_unnamed_params() {
       # dont parse site-name
       break
     fi
-    
+
     civibuild_expand_site_name "$OPTION"
   done
 

--- a/bin/civibuild
+++ b/bin/civibuild
@@ -378,7 +378,7 @@ function civibuild_parse_unnamed_params() {
       break
     fi
     
-    civibuild_validate_site_name "$OPTION"
+    civibuild_expand_site_name "$OPTION"
   done
 
   [ -z "$ACTION" ] && civibuild_usage
@@ -387,7 +387,7 @@ function civibuild_parse_unnamed_params() {
 
     if [ -z "$SITE_NAME" ]; then
       civibuild_detect_site_name
-      civibuild_validate_site_name "$SITE_NAME" 
+      civibuild_expand_site_name "$SITE_NAME"
     fi
 
     [ -z "$SITE_NAME" ] && civibuild_usage
@@ -409,20 +409,9 @@ function civibuild_parse_unnamed_params() {
 }
 
 ## If passed name is valid, assign to SITE_NAME
-## IF INVALID, SITE_NAME is reset
-## Parses SITE_ID as well
-## calls alias_resolve
-function civibuild_validate_site_name() {
+function civibuild_expand_site_name() {
   ## Convert "drupal-demo" or "drupal-demo/123" to vars SITE_NAME and optionally SITE_ID
   eval $(cvutil_parse_site_name_id "$1")
-
-  ## validate SITE_NAME
-  if [ ! -f ${BLDDIR}/${SITE_NAME}.sh ]; then
-    if [ ! -f ${BLDDIR}/${SITE_NAME}.${SITE_ID}.sh ]; then
-     SITE_NAME=
-     SITE_ID=default
-    fi
-  fi
 
   if [ ! -z "$SITE_NAME" ]; then
     ## Convert certain aliases like "d45" into better defaults


### PR DESCRIPTION
When creating a new build, the build doesn't exist yet! Therefore, it fails
the validation rule. The validation rule is overzealous.

@ginkgomzd, is there a reason why the validation needed to check if the folder existed?
I did a quick spot-check of a few scenarios, and they seem to work without
the check:

 * `civibuild create dmaster` (under buildkit base dir)
 * `civibuild restore dmaster` (under buildkit base dir)
 * `civibuild restore` (under the dmaster folder -- autodetect the build)
 * `civibuild restore d46` (under the dmaster folder -- use explicit input, no autodetect)