### PR TITLE
PCHR-894: Fix concurrency issue in drush make

### DIFF
--- a/app/config/hr15/download.sh
+++ b/app/config/hr15/download.sh
@@ -19,4 +19,4 @@ cat "$SITE_CONFIG_DIR/drush.make.tmpl" \
   | sed "s;%%HR_VERSION%%;${HR_VERSION};" \
   > "$MAKEFILE"
 
-drush -y make --working-copy "$MAKEFILE" "$WEB_ROOT"
+drush -y make --concurrency=5 --working-copy "$MAKEFILE" "$WEB_ROOT"


### PR DESCRIPTION
The `drush make` command, when used to build a project with many dependencies (ours has around 50), has a concurrency issue ([details](https://github.com/drush-ops/drush/issues/985)) in the [`drush_make_process`](https://github.com/drush-ops/drush/blob/master/commands/make/make.drush.inc#L710) function, where the projects array content might not make it into the function, resulting in the dependencies not getting downloaded.

By increasing the concurrency value (the default value is 1) the problem seems to be solved, the issue could not be replicated anymore