### PR TITLE
Change hr16 build to checkout by tag

### DIFF
--- a/app/config/hr16/download.sh
+++ b/app/config/hr16/download.sh
@@ -19,4 +19,4 @@ cat "$SITE_CONFIG_DIR/drush.make.tmpl" \
   | sed "s;%%HR_VERSION%%;${HR_VERSION};" \
   > "$MAKEFILE"
 
-drush -y make --working-copy "$MAKEFILE" "$WEB_ROOT"
+drush -y make --concurrency=5 --working-copy "$MAKEFILE" "$WEB_ROOT"

--- a/app/config/hr16/drush.make.tmpl
+++ b/app/config/hr16/drush.make.tmpl
@@ -26,15 +26,14 @@ libraries[civicrmdrupal][destination] = modules
 libraries[civicrmdrupal][directory_name] = civicrm/drupal
 libraries[civicrmdrupal][download][type] = git
 libraries[civicrmdrupal][download][url] = %%CACHE_DIR%%/civicrm/civicrm-drupal.git
-libraries[civicrmdrupal][download][branch] = 7.x-%%CIVI_VERSION%%
-libraries[civicrmdrupal][download][tag] = 7.x-4.7.1
+libraries[civicrmdrupal][download][tag] = 7.x--%%CIVI_VERSION%%
 libraries[civicrmdrupal][overwrite] = TRUE
 
 libraries[civicrmpackages][destination] = modules
 libraries[civicrmpackages][directory_name] = civicrm/packages
 libraries[civicrmpackages][download][type] = git
 libraries[civicrmpackages][download][url] = %%CACHE_DIR%%/civicrm/civicrm-packages.git
-libraries[civicrmpackages][download][branch] = %%CIVI_VERSION%%
+libraries[civicrmpackages][download][tag] = %%CIVI_VERSION%%
 libraries[civicrmpackages][overwrite] = TRUE
 
 libraries[civihr][destination] = modules
@@ -62,8 +61,7 @@ libraries[civicrm][destination] = modules
 libraries[civicrm][directory_name] = civicrm
 libraries[civicrm][download][type] = git
 libraries[civicrm][download][url] = %%CACHE_DIR%%/civicrm/civicrm-core.git
-libraries[civicrm][download][branch] = %%CIVI_VERSION%%
-libraries[civicrm][download][tag] = 4.7.1
+libraries[civicrm][download][tag] = %%CIVI_VERSION%%
 libraries[civicrm][overwrite] = TRUE
 
 ; ****************************************

--- a/src/civibuild.aliases.sh
+++ b/src/civibuild.aliases.sh
@@ -74,7 +74,7 @@ function civibuild_alias_resolve() {
     hr13)        SITE_TYPE=hrdemo           ; CIVI_VERSION=4.5       ; CMS_TITLE="CiviHR 1.3 Demo"                   ; HR_VERSION=1.3        ;;
     hr14)        SITE_TYPE=hrdemo           ; CIVI_VERSION=4.5       ; CMS_TITLE="CiviHR 1.4 Demo"                   ; HR_VERSION=1.4        ;;
     hr15)        SITE_TYPE=hr15             ; CIVI_VERSION=4.6       ; CMS_TITLE="CiviHR 1.5 Demo"                   ; HR_VERSION=master     ;;
-    hr16)	 SITE_TYPE=hr16		    ; CIVI_VERSION=4.7	     ; CMS_TITLE="CiviHR 1.6 Demo"		     ; HR_VERSION=PCHR-863-migrate-to-4.7     ;;
+    hr16)	 SITE_TYPE=hr16		    ; CIVI_VERSION=4.7.6     ; CMS_TITLE="CiviHR 1.6 Demo"		     ; HR_VERSION=PCHR-863-migrate-to-4.7     ;;
     hrmaster)    SITE_TYPE=hr15             ; CIVI_VERSION=master    ; CMS_TITLE="CiviHR Sandbox"                    ; HR_VERSION=master     ;;
 
     ## For testing purposes


### PR DESCRIPTION
When we create a new **hr16** build with this command : 

`civibuild create hr16 --civi-ver 4.7 --url http://localhost:8900` , It doesn't work   because **civicrm-drupal** repo doesn't have a branch named : **7.x-4.7** , the only one related is **7.x-4.7.7-rc** unlike previous civicrm versions where you can find 7.x-4.6, 7.x-4.5 ... etc . Also there no branches in **civicrm** or **civicrm-packages** repos  named 4.7 , the only ones related are named 4.7.7-rc .

also I changed all the repos to get checked out by tag not by branch name to insure stability since when we tried to checkout the latest civicrm stable version which is 4.7.7 like this :
`civibuild create hr16 --civi-ver 4.7.7 --url http://localhost:8900`
The following error was thrown :

`WD php: CRM_Core_Exception: Invalid Entity Filter in CRM_Core_BAO_CustomGroup::validateSubTypeByEntity()     [error]
(line 658 of
/Users/testuser/GitHub/buildkit/build/hr16/sites/all/modules/civicrm/CRM/Core/BAO/CustomGroup.php).
Cannot modify header information - headers already sent by (output started at                                [warning]
/Users/testuser/GitHub/buildkit/vendor/drush/drush/includes/output.inc:38) bootstrap.inc:1232
CRM_Core_Exception: Invalid Entity Filter in CRM_Core_BAO_CustomGroup::validateSubTypeByEntity() (line 658 of /Users/testuser/GitHub/buildkit/build/hr16/sites/all/modules/civicrm/CRM/Core/BAO/CustomGroup.php).
Drush command terminated abnormally due to an unrecoverable error.                                           [error]` 

but when trying to create a build with  4.7.6 :

`civibuild create hr16 --civi-ver 4.7.6 --url http://localhost:8900`

everything was working perfectly 