### PR TITLE
PCHR-655: patch to sort out pagination issue with views_merge_rows

### DIFF
--- a/app/config/hr15/drush.make.tmpl
+++ b/app/config/hr15/drush.make.tmpl
@@ -198,7 +198,7 @@ projects[views_merge_rows][subdir] = civihr-contrib-required
 projects[views_merge_rows][version] = "1.0-rc1"
 
 ; Patch for pagination
-projects[views_merge_rows][patch][] = "https://www.drupal.org/files/issues/views_merge_rows-views_merge_rows_and_pagination-2188939-3_0.patch"
+projects[views_merge_rows][patch][] = "https://www.drupal.org/files/issues/views_merge_rows-views_merge_rows_pagination-2724691-1_0.patch"
 
 projects[role_export][subdir] = civihr-contrib-required
 projects[role_export][version] = "1.0"

--- a/app/config/hr16/drush.make.tmpl
+++ b/app/config/hr16/drush.make.tmpl
@@ -197,7 +197,7 @@ projects[views_merge_rows][subdir] = civihr-contrib-required
 projects[views_merge_rows][version] = "1.0-rc1"
 
 ; Patch for pagination
-projects[views_merge_rows][patch][] = "https://www.drupal.org/files/issues/views_merge_rows-views_merge_rows_and_pagination-2188939-3_0.patch"
+projects[views_merge_rows][patch][] = "https://www.drupal.org/files/issues/views_merge_rows-views_merge_rows_pagination-2724691-1_0.patch"
 
 projects[role_export][subdir] = civihr-contrib-required
 projects[role_export][version] = "1.0"


### PR DESCRIPTION
**Issue:**
On staff directory, even if you choose different number of items to show per page, that number seems to be ignored. (e.g. select 10 per page and get 3 result on the first page and 5 result next page.

**Reason:**
It was happening because views_merge_rows was not able to handle pagination correctly. The patch sorts out that issue.