### PR TITLE
Fix hr16 civicrmdrupal tag version

### DIFF
--- a/app/config/hr16/drush.make.tmpl
+++ b/app/config/hr16/drush.make.tmpl
@@ -26,7 +26,7 @@ libraries[civicrmdrupal][destination] = modules
 libraries[civicrmdrupal][directory_name] = civicrm/drupal
 libraries[civicrmdrupal][download][type] = git
 libraries[civicrmdrupal][download][url] = %%CACHE_DIR%%/civicrm/civicrm-drupal.git
-libraries[civicrmdrupal][download][tag] = 7.x--%%CIVI_VERSION%%
+libraries[civicrmdrupal][download][tag] = 7.x-%%CIVI_VERSION%%
 libraries[civicrmdrupal][overwrite] = TRUE
 
 libraries[civicrmpackages][destination] = modules


### PR DESCRIPTION
just removing one of the dashes from the tag name which cause the checkout process to fail during the creation of a new buildkit instance based on hr16 .