### PR TITLE
allow to pass civihr version as civibuild parameter

### DIFF
--- a/src/civibuild.parse.sh
+++ b/src/civibuild.parse.sh
@@ -261,6 +261,11 @@ function civibuild_parse() {
         shift
         ;;
 
+      --hr-ver)
+        HR_VERSION="$1"
+        shift
+        ;;
+
       *)
         if [ "${OPTION::1}" == "-" ]; then
           echo "Unrecognized option: $OPTION"


### PR DESCRIPTION
Its important for us at @compucorp to be able pass civihr version as civibuild parameter specially when creating multiple civihr websites ( instances ) and since civihr is still part of  buildkit I think it make sense to submit this PR here.