### PR TITLE
app/config/messages - Provide a better template for `parameters.yml`

### DIFF
--- a/app/config/messages/install.sh
+++ b/app/config/messages/install.sh
@@ -29,6 +29,9 @@ parameters:
     mailer_password: null
     locale: en
     secret: '$(cvutil_makepasswd 32)'
+    civicrm_org_url: 'https://civicrm.org'
+    civicrm_api_key: 'FIXME'
+    civicrm_org_key: 'FIXME'
 EOSETTING
 
 pushd "$WEB_ROOT" >> /dev/null


### PR DESCRIPTION
I'm not really sure what to do here to make something that "just works".
Maybe it should point to a demo site (`dmaster.demo.civicrm.org`)?

In any event, the FIXME values are at least a bit better -- providing
a cue to the reader that something is missing.

@colemanw, any thoughts on what makes a better default when setting up
`civicrm-community-messages`?