### PR TITLE
(Don't merge yet) Allow to checkout repos by bransh or tag

### DIFF
--- a/app/config/drupal-demo/drush.make.tmpl
+++ b/app/config/drupal-demo/drush.make.tmpl
@@ -26,14 +26,14 @@ libraries[civicrmdrupal][destination] = modules
 libraries[civicrmdrupal][directory_name] = civicrm/drupal
 libraries[civicrmdrupal][download][type] = git
 libraries[civicrmdrupal][download][url] = %%CACHE_DIR%%/civicrm/civicrm-drupal.git
-libraries[civicrmdrupal][download][branch] = 7.x-%%CIVI_VERSION%%
+libraries[civicrmdrupal][download][%%CHECKOUT%%] = 7.x-%%CIVI_VERSION%%
 libraries[civicrmdrupal][overwrite] = TRUE
 
 libraries[civicrmpackages][destination] = modules
 libraries[civicrmpackages][directory_name] = civicrm/packages
 libraries[civicrmpackages][download][type] = git
 libraries[civicrmpackages][download][url] = %%CACHE_DIR%%/civicrm/civicrm-packages.git
-libraries[civicrmpackages][download][branch] = %%CIVI_VERSION%%
+libraries[civicrmpackages][download][%%CHECKOUT%%] = %%CIVI_VERSION%%
 libraries[civicrmpackages][overwrite] = TRUE
 
 ; Download available l10n releases (may be outdated)
@@ -54,7 +54,7 @@ libraries[civicrm][destination] = modules
 libraries[civicrm][directory_name] = civicrm
 libraries[civicrm][download][type] = git
 libraries[civicrm][download][url] = %%CACHE_DIR%%/civicrm/civicrm-core.git
-libraries[civicrm][download][branch] = %%CIVI_VERSION%%
+libraries[civicrm][download][%%CHECKOUT%%] = %%CIVI_VERSION%%
 libraries[civicrm][overwrite] = TRUE
 
 ; ****************************************

--- a/app/config/hr15/drush.make.tmpl
+++ b/app/config/hr15/drush.make.tmpl
@@ -26,7 +26,7 @@ libraries[civicrmdrupal][destination] = modules
 libraries[civicrmdrupal][directory_name] = civicrm/drupal
 libraries[civicrmdrupal][download][type] = git
 libraries[civicrmdrupal][download][url] = %%CACHE_DIR%%/civicrm/civicrm-drupal.git
-libraries[civicrmdrupal][download][branch] = 7.x-%%CIVI_VERSION%%
+libraries[civicrmdrupal][download][%%CHECKOUT%%] = 7.x-%%CIVI_VERSION%%
 libraries[civicrmdrupal][overwrite] = TRUE
 
 ; Backport patch from https://issues.civicrm.org/jira/browse/CRM-16461 (add bash check only if CIVI_VERSION = 4.5)
@@ -36,7 +36,7 @@ libraries[civicrmpackages][destination] = modules
 libraries[civicrmpackages][directory_name] = civicrm/packages
 libraries[civicrmpackages][download][type] = git
 libraries[civicrmpackages][download][url] = %%CACHE_DIR%%/civicrm/civicrm-packages.git
-libraries[civicrmpackages][download][branch] = %%CIVI_VERSION%%
+libraries[civicrmpackages][download][%%CHECKOUT%%] = %%CIVI_VERSION%%
 libraries[civicrmpackages][overwrite] = TRUE
 
 libraries[civihr][destination] = modules
@@ -64,7 +64,7 @@ libraries[civicrm][destination] = modules
 libraries[civicrm][directory_name] = civicrm
 libraries[civicrm][download][type] = git
 libraries[civicrm][download][url] = %%CACHE_DIR%%/civicrm/civicrm-core.git
-libraries[civicrm][download][branch] = %%CIVI_VERSION%%
+libraries[civicrm][download][%%CHECKOUT%%] = %%CIVI_VERSION%%
 libraries[civicrm][overwrite] = TRUE
 
 ; ****************************************

--- a/app/config/hr16/drush.make.tmpl
+++ b/app/config/hr16/drush.make.tmpl
@@ -26,14 +26,14 @@ libraries[civicrmdrupal][destination] = modules
 libraries[civicrmdrupal][directory_name] = civicrm/drupal
 libraries[civicrmdrupal][download][type] = git
 libraries[civicrmdrupal][download][url] = %%CACHE_DIR%%/civicrm/civicrm-drupal.git
-libraries[civicrmdrupal][download][tag] = 7.x-%%CIVI_VERSION%%
+libraries[civicrmdrupal][download][%%CHECKOUT%%] = 7.x-%%CIVI_VERSION%%
 libraries[civicrmdrupal][overwrite] = TRUE
 
 libraries[civicrmpackages][destination] = modules
 libraries[civicrmpackages][directory_name] = civicrm/packages
 libraries[civicrmpackages][download][type] = git
 libraries[civicrmpackages][download][url] = %%CACHE_DIR%%/civicrm/civicrm-packages.git
-libraries[civicrmpackages][download][tag] = %%CIVI_VERSION%%
+libraries[civicrmpackages][download][%%CHECKOUT%%] = %%CIVI_VERSION%%
 libraries[civicrmpackages][overwrite] = TRUE
 
 libraries[civihr][destination] = modules
@@ -61,7 +61,7 @@ libraries[civicrm][destination] = modules
 libraries[civicrm][directory_name] = civicrm
 libraries[civicrm][download][type] = git
 libraries[civicrm][download][url] = %%CACHE_DIR%%/civicrm/civicrm-core.git
-libraries[civicrm][download][tag] = %%CIVI_VERSION%%
+libraries[civicrm][download][%%CHECKOUT%%] = %%CIVI_VERSION%%
 libraries[civicrm][overwrite] = TRUE
 
 ; ****************************************

--- a/src/civibuild.aliases.sh
+++ b/src/civibuild.aliases.sh
@@ -28,7 +28,7 @@ function civibuild_alias_resolve() {
     d45)         SITE_TYPE=drupal-demo      ; CIVI_VERSION=4.5       ; CMS_TITLE="CiviCRM 4.5 Demo on Drupal"        ; VOL_VERSION=v4.5-1.4.0   ; DISC_VERSION=4.4      ;;
     d46)         SITE_TYPE=drupal-demo      ; CIVI_VERSION=4.6       ; CMS_TITLE="CiviCRM 4.6 Demo on Drupal"        ; VOL_VERSION=v4.5-1.4.0   ; DISC_VERSION=master   ; RULES_VERSION=master   ;;
     d47)         SITE_TYPE=drupal-demo      ; CIVI_VERSION=master    ; CMS_TITLE="CiviCRM 4.7 Demo on Drupal"        ; VOL_VERSION=master       ; DISC_VERSION=master   ;;
-    dmaster)     SITE_TYPE=drupal-demo      ; CIVI_VERSION=master    ; CMS_TITLE="CiviCRM Sandbox on Drupal"         ; VOL_VERSION=master       ; DISC_VERSION=master   ;;
+    dmaster)     SITE_TYPE=drupal-demo      ; CIVI_VERSION=master    ; CMS_TITLE="CiviCRM Sandbox on Drupal"         ; VOL_VERSION=master       ; DISC_VERSION=master        ; CHECKOUT=branch    ;;
 
     d7-43)       SITE_TYPE=drupal-clean     ; CIVI_VERSION=4.3       ; CMS_TITLE="CiviCRM 4.3 Demo on Drupal 7"      ;;
     d7-44)       SITE_TYPE=drupal-clean     ; CIVI_VERSION=4.4       ; CMS_TITLE="CiviCRM 4.4 Demo on Drupal 7"      ;;
@@ -73,8 +73,8 @@ function civibuild_alias_resolve() {
 
     hr13)        SITE_TYPE=hrdemo           ; CIVI_VERSION=4.5       ; CMS_TITLE="CiviHR 1.3 Demo"                   ; HR_VERSION=1.3        ;;
     hr14)        SITE_TYPE=hrdemo           ; CIVI_VERSION=4.5       ; CMS_TITLE="CiviHR 1.4 Demo"                   ; HR_VERSION=1.4        ;;
-    hr15)        SITE_TYPE=hr15             ; CIVI_VERSION=4.6       ; CMS_TITLE="CiviHR 1.5 Demo"                   ; HR_VERSION=master     ;;
-    hr16)        SITE_TYPE=hr16             ; CIVI_VERSION=4.7.6     ; CMS_TITLE="CiviHR 1.6 Demo"                   ; HR_VERSION=PCHR-863-migrate-to-4.7     ;;
+    hr15)        SITE_TYPE=hr15             ; CIVI_VERSION=4.6       ; CMS_TITLE="CiviHR 1.5 Demo"                   ; HR_VERSION=master    ; CHECKOUT=branch   ;;
+    hr16)        SITE_TYPE=hr16             ; CIVI_VERSION=4.7.6     ; CMS_TITLE="CiviHR 1.6 Demo"                   ; HR_VERSION=PCHR-863-migrate-to-4.7     ; CHECKOUT=tag   ;;
     hrmaster)    SITE_TYPE=hr15             ; CIVI_VERSION=master    ; CMS_TITLE="CiviHR Sandbox"                    ; HR_VERSION=master     ;;
 
     bempty)      SITE_TYPE=backdrop-empty   ; CIVI_VERSION=none      ; CMS_TITLE="Backdrop Sandbox"                  ;;

--- a/src/civibuild.parse.sh
+++ b/src/civibuild.parse.sh
@@ -261,6 +261,11 @@ function civibuild_parse() {
         shift
         ;;
 
+      --checkout)
+        CHECKOUT="$1"
+        shift
+        ;;
+
       --hr-ver)
         HR_VERSION="$1"
         shift


### PR DESCRIPTION
Its really useful sometimes to create a new civicrm build via the buildkit using a specific tag instead of branch , This PR add a new option called **checkout** which allow you to specify how the repositories going to be checked out either by tag or branch name .

Examples :

create civicrm drupal demo instance using civicrm 4.7.7 release
```
civibuild d4777 --type drupal-demo --civi-ver 4.7.7 --checkout tag -url http://localhost:8135
```


create civicrm drupal demo instance using latest master branch
```
civibuild dmaster --type drupal-demo --civi-ver master --checkout branch -url http://localhost:8135
```

create civicrm drupal demo instance using 4.7 branch
```
civibuild d47 --type drupal-demo --civi-ver 4.7 --checkout branch -url http://localhost:8135
```

This option for now work for the following build types :

- drupal-demo
- hr15
- hr16