### PR TITLE
`civibuild --patch` -- Ignore whitespace when applying patches

### DIFF
--- a/src/civibuild.app.sh
+++ b/src/civibuild.app.sh
@@ -145,7 +145,7 @@ function civibuild_app_download() {
       fi
       if [ -n "$PATCHES" ]; then
         pushd "$WEB_ROOT" >> /dev/null
-          if ! git scan automerge --rebuild --url-split='|' "$PATCHES" ; then
+          if ! git scan automerge --rebuild --url-split='|' "$PATCHES" --passthru='--ignore-whitespace' ; then
             echo "Failed to apply patch(es)"
             exit 95
           fi


### PR DESCRIPTION
For example, when making a build which includes the patch
https://github.com/civicrm/civicrm-packages/pull/150 , it fails
due to some new-line issues.