### PR TITLE
Update radix_theme version in hr16

### DIFF
--- a/app/config/hr16/drush.make.tmpl
+++ b/app/config/hr16/drush.make.tmpl
@@ -246,7 +246,7 @@ libraries[civihr_employee_portal][overwrite] = TRUE
 ; ****************************************
 
 ; Download Radix base theme
-projects[radix][version] = "3.0-rc2"
+projects[radix][version] = "3.4"
 
 ; CiviHR Radix based default subtheme (dependent on the Radix theme)
 libraries[civihr_employee_portal_theme][destination] = themes


### PR DESCRIPTION
A recent update in Drupal 7.50 changed the behavior drupal_get_filename to
throw an error when a file is missing. This caused some errors in the SSP,
because the old rc version of the theme was trying to handle files from
the panapoly_admin module without checking first if the module was installed.