### PR TITLE
Enable username_to_external_id module during hr15+hr16 installation

### DIFF
--- a/app/config/hr15/install.sh
+++ b/app/config/hr15/install.sh
@@ -222,6 +222,7 @@ pushd "${WEB_ROOT}/sites/${DRUPAL_SITE_DIR}" >> /dev/null
   drush en front_page -y
   drush en civicrmtheme -y
   drush en civihr_employee_portal_features -y
+  drush en username_to_external_id -y
 
   setup_themes
   create_default_users

--- a/app/config/hr16/install.sh
+++ b/app/config/hr16/install.sh
@@ -222,6 +222,7 @@ pushd "${WEB_ROOT}/sites/${DRUPAL_SITE_DIR}" >> /dev/null
   drush en front_page -y
   drush en civicrmtheme -y
   drush en civihr_employee_portal_features -y
+  drush en username_to_external_id -y
 
   setup_themes
   create_default_users


### PR DESCRIPTION
This affect only hr16 and hr15 build types (civihr) . 

I enable username_to_external_id module which is shipped with civihr and used to fill the contanct external_id field with it's drupal username if exists.