### PR TITLE
PCHR-959: Update webform_civicrm version

### DIFF
--- a/app/config/doctrine/drush.make.tmpl
+++ b/app/config/doctrine/drush.make.tmpl
@@ -72,10 +72,10 @@ projects[redirect][subdir] = contrib
 projects[redirect][version] = 1.0-rc1
 
 projects[webform][subdir] = contrib
-projects[webform][version] = 3.19
+projects[webform][version] = 4.12
 
 projects[webform_civicrm][subdir] = contrib
-projects[webform_civicrm][version] = 3.6
+projects[webform_civicrm][version] = 4.16
 
 projects[views][subdir] = contrib
 projects[views][version] = 3.7

--- a/app/config/drupal-demo/drush.make.tmpl
+++ b/app/config/drupal-demo/drush.make.tmpl
@@ -72,13 +72,13 @@ projects[redirect][subdir] = contrib
 projects[redirect][version] = 1.0-rc1
 
 projects[webform][subdir] = contrib
-projects[webform][version] = 4.1
+projects[webform][version] = 4.12
 
 projects[options_element][subdir] = contrib
 projects[options_element][version] = 1.12
 
 projects[webform_civicrm][subdir] = contrib
-projects[webform_civicrm][version] = 4.9
+projects[webform_civicrm][version] = 4.16
 
 projects[views][subdir] = contrib
 projects[views][version] = 3.8

--- a/app/config/hr15/drush.make.tmpl
+++ b/app/config/hr15/drush.make.tmpl
@@ -85,7 +85,7 @@ projects[webform][subdir] = contrib
 projects[webform][version] = 4.12
 
 projects[webform_civicrm][subdir] = contrib
-projects[webform_civicrm][version] = "4.x-dev"
+projects[webform_civicrm][version] = "4.16"
 
 projects[views][subdir] = contrib
 projects[views][version] = 3.11

--- a/app/config/hr16/drush.make.tmpl
+++ b/app/config/hr16/drush.make.tmpl
@@ -82,7 +82,7 @@ projects[webform][subdir] = contrib
 projects[webform][version] = 4.12
 
 projects[webform_civicrm][subdir] = contrib
-projects[webform_civicrm][version] = "4.x-dev"
+projects[webform_civicrm][version] = "4.16"
 
 projects[views][subdir] = contrib
 projects[views][version] = 3.11

--- a/app/config/hrdemo/drush.make.tmpl
+++ b/app/config/hrdemo/drush.make.tmpl
@@ -79,10 +79,10 @@ projects[redirect][subdir] = contrib
 projects[redirect][version] = 1.0-rc1
 
 projects[webform][subdir] = contrib
-projects[webform][version] = 3.19
+projects[webform][version] = 4.12
 
 projects[webform_civicrm][subdir] = contrib
-projects[webform_civicrm][version] = 3.6
+projects[webform_civicrm][version] = 4.16
 
 projects[views][subdir] = contrib
 projects[views][version] = 3.7

--- a/app/config/symfony/drush.make.tmpl
+++ b/app/config/symfony/drush.make.tmpl
@@ -72,10 +72,10 @@ projects[redirect][subdir] = contrib
 projects[redirect][version] = 1.0-rc1
 
 projects[webform][subdir] = contrib
-projects[webform][version] = 3.19
+projects[webform][version] = 4.12
 
 projects[webform_civicrm][subdir] = contrib
-projects[webform_civicrm][version] = 3.6
+projects[webform_civicrm][version] = 4.16
 
 projects[views][subdir] = contrib
 projects[views][version] = 3.7


### PR DESCRIPTION
@colemanw just [released](https://github.com/colemanw/webform_civicrm/pull/43#issuecomment-237612031) a new stable version (4.16) of the [webform_civicrm](https://www.drupal.org/project/webform_civicrm) module, which contains a couple of patches that we submitted over the course of these past months, so we can drop the dependency to the dev version of the module instead