### PR TITLE
PCHR-1185: Remove refrence to hrjob extenstion

### DIFF
--- a/app/config/hr16/install.sh
+++ b/app/config/hr16/install.sh
@@ -70,9 +70,6 @@ function install_civihr() {
 
   ## (with sample data - if required)
   # bash ${CIVI_CORE}/tools/extensions/civihr/bin/drush-install.sh --with-sample-data
-
-  ## Disable / Uninstall old extensions (temporary should be removed when we don't need the old HRjob anymore)
-  drush cvapi extension.disable keys=org.civicrm.hrjob
 }
 
 ##


### PR DESCRIPTION
hrjob extension is going to be removed in another PR to civihr 1.6 so no need to disable it here anymore.