### PR TITLE
Exclude DAO,examples and tools directories via question mark regex in clivilint

### DIFF
--- a/bin/civilint
+++ b/bin/civilint
@@ -48,11 +48,10 @@ function split_files() {
   touch "$phpfiles" "$jsfiles" "$skipfiles"
 
   while read file; do
-    absfile=$(absdirname "$file")/$(basename "$file")
     if [ ! -e "$file" ]; then
       echo "$file" >> "$skipfiles"
 
-    elif [[ "$absfile" =~ (/DAO/|/examples/|/tools/) ]]; then
+    elif [[ "$file" =~ (/?DAO/|/?examples/|/?tools/) ]]; then
       echo "$file" >> "$skipfiles"
 
     elif [[ "$file" =~ Trait\.php$ ]]; then


### PR DESCRIPTION
I changed the regex in **civilint** that exclude the **DAO,examples and tools** directories to use the question mark instead of using the absolute path .

It should still work for civicrm , and it helpful in our work with civihr since civihr is installed currently in **civicrm/tools** directory so it always get excluded by civilint.