### PR TITLE
CRM-19417 - cividist - Aggregate daily JSON data

### DIFF
--- a/bin/cividist
+++ b/bin/cividist
@@ -1,8 +1,16 @@
 #!/bin/bash
 set -e
 
+function absdirname() {
+  pushd $(dirname $0) >> /dev/null
+    pwd
+  popd >> /dev/null
+}
+
 ###############################################################################
 ## Variables and constants
+BINDIR=$(absdirname "$0")
+PRJDIR=$(dirname "$BINDIR")
 MAX_AGE=${MAX_AGE:-14}
 MAX_REFS=${MAX_REFS:-10000}
 GIT_REMOTE=${GIT_REMOTE:-origin}
@@ -197,6 +205,20 @@ function cividist_prune() {
 }
 
 ###############################################################################
+## cividist_aggregate <folder>
+function cividist_aggregate() {
+  pushd "$BY_DATE"
+    find -mindepth 1 -maxdepth 1 -type d | while read DATEDIR ; do
+      pushd "$DATEDIR" >> /dev/null
+        find -maxdepth 2 -name 'civicrm-*.json' | php "$PRJDIR/src/cividist-aggregate-json.php" > summary.json
+      popd >> /dev/null
+    done
+  popd >> /dev/null
+
+
+}
+
+###############################################################################
 function cividist_help() {
   echo "Maintain a rotating list of nightly tarballs."
   echo
@@ -216,6 +238,9 @@ function cividist_help() {
   echo
   echo "Remove any old/orphaned tarballs"
   echo "  usage: $(basename $0) prune"
+  echo
+  echo "Aggregate any JSON summaries about releases"
+  echo "  usage: $(basename $0) aggregate"
   echo
   echo "See also: $DOCURL"
 }
@@ -301,6 +326,9 @@ pushd $SRC >> /dev/null
       ;;
     prune)
       cividist_prune
+      ;;
+    aggregate)
+      cividist_aggregate "$@"
       ;;
     *)
       cividist_help

--- a/bin/cividist
+++ b/bin/cividist
@@ -205,17 +205,15 @@ function cividist_prune() {
 }
 
 ###############################################################################
-## cividist_aggregate <folder>
+## cividist_aggregate <base-url>
 function cividist_aggregate() {
   pushd "$BY_DATE"
     find -mindepth 1 -maxdepth 1 -type d | while read DATEDIR ; do
       pushd "$DATEDIR" >> /dev/null
-        find -maxdepth 2 -name 'civicrm-*.json' | php "$PRJDIR/src/cividist-aggregate-json.php" > summary.json
+        find -maxdepth 2 -name 'civicrm-*.json' | php "$PRJDIR/src/cividist-aggregate-json.php" "$1" > summary.json
       popd >> /dev/null
     done
   popd >> /dev/null
-
-
 }
 
 ###############################################################################
@@ -240,7 +238,7 @@ function cividist_help() {
   echo "  usage: $(basename $0) prune"
   echo
   echo "Aggregate any JSON summaries about releases"
-  echo "  usage: $(basename $0) aggregate"
+  echo "  usage: $(basename $0) aggregate <base-url>"
   echo
   echo "See also: $DOCURL"
 }
@@ -328,7 +326,7 @@ pushd $SRC >> /dev/null
       cividist_prune
       ;;
     aggregate)
-      cividist_aggregate "$@"
+      cividist_aggregate "$2"
       ;;
     *)
       cividist_help

--- a/src/cividist-aggregate-json.php
+++ b/src/cividist-aggregate-json.php
@@ -1,13 +1,16 @@
 <?php
+$baseUrl = !empty($argv[1]) ? $argv[1] : '.';
 $files = explode("\n", file_get_contents('php://stdin'));
 
 $versions = array();
 foreach ($files as $file) {
-  if (empty($file)) continue;
+  if (empty($file)) {
+    continue;
+  }
   $name = basename(dirname($file));
   $versions[$name] = json_decode(file_get_contents($file), 1);
   $versions[$name] = strip_git_remote($versions[$name]);
-  $versions[$name] = apply_url_prefix($versions[$name], "$name/");
+  $versions[$name] = regen_tar_urls($versions[$name], dirname($file), "$baseUrl/$name");
 }
 
 echo json_encode($versions, defined('JSON_PRETTY_PRINT') ? JSON_PRETTY_PRINT : 0);
@@ -33,4 +36,62 @@ function apply_url_prefix($data, $prefix) {
     $data['tar'][$key] = $prefix . $data['tar'][$key];
   }
   return $data;
+}
+
+/**
+ * Update URLs, changing "foo.zip" to "subdir/foo.zip".
+ * @param array $data
+ *   Full description of the release (version, git commits, tar files, etc)
+ * @param string $localPath
+ *   The local path of the released files
+ * @param string $remoteUrl
+ *   The remote URL of the released files.
+ * @return array
+ *   Updated version of $data.
+ */
+function regen_tar_urls($data, $localPath, $remoteUrl) {
+  $files = (array) glob("$localPath/civicrm-*");
+  $tarUrls = array();
+  foreach ($files as $file) {
+    $basename = basename($file);
+    $key = classify_tar_file($basename);
+    if ($key) {
+      $tarUrls[$key] = $remoteUrl . '/' . $basename;
+    }
+  }
+  $data['tar'] = $tarUrls;
+
+  return $data;
+}
+
+/**
+ * @param string $basename
+ *   Ex: 'civicrm-4.7.13-drupal.tar.gz', 'civicrm-4.7.13-wordpress-20160901.zip'.
+ * @return string
+ *   Ex: 'Drupal', 'WordPress'
+ */
+function classify_tar_file($basename) {
+  switch (TRUE) {
+    case (boolean) preg_match(';civicrm-[\d\.]+-drupal6(\-\d+)?.tar.gz;', $basename);
+      return 'Drupal6';
+
+    case (boolean) preg_match(';civicrm-[\d\.]+-drupal(\-\d+)?.tar.gz;', $basename);
+      return 'Drupal';
+
+    case (boolean) preg_match(';civicrm-[\d\.]+-backdrop(\-unstable)?(|\-\d+)?.tar.gz;', $basename);
+      return 'Backdrop';
+
+    case (boolean) preg_match(';civicrm-[\d\.]+-joomla(\-\d+)?.zip;', $basename);
+      return 'Joomla';
+
+    case (boolean) preg_match(';civicrm-[\d\.]+-wordpress(\-\d+)?.zip;', $basename);
+      return 'WordPress';
+
+    case (boolean) preg_match(';civicrm-[\d\.]+-l10n(\-\d+)?.tar.gz;', $basename);
+      return 'L10n';
+
+    default:
+      return NULL;
+
+  }
 }

--- a/src/cividist-aggregate-json.php
+++ b/src/cividist-aggregate-json.php
@@ -1,0 +1,36 @@
+<?php
+$files = explode("\n", file_get_contents('php://stdin'));
+
+$versions = array();
+foreach ($files as $file) {
+  if (empty($file)) continue;
+  $name = basename(dirname($file));
+  $versions[$name] = json_decode(file_get_contents($file), 1);
+  $versions[$name] = strip_git_remote($versions[$name]);
+  $versions[$name] = apply_url_prefix($versions[$name], "$name/");
+}
+
+echo json_encode($versions, defined('JSON_PRETTY_PRINT') ? JSON_PRETTY_PRINT : 0);
+
+##############################
+
+/**
+ * Simplify git branch names, changing "refs/remotes/origin/master" to
+ * to just "master".
+ */
+function strip_git_remote($data) {
+  foreach (array_keys($data['git']) as $key) {
+    $data['git'][$key] = str_replace('refs/remotes/origin/', '', $data['git'][$key]);
+  }
+  return $data;
+}
+
+/**
+ * Update URLs, changing "foo.zip" to "subdir/foo.zip".
+ */
+function apply_url_prefix($data, $prefix) {
+  foreach (array_keys($data['tar']) as $key) {
+    $data['tar'][$key] = $prefix . $data['tar'][$key];
+  }
+  return $data;
+}


### PR DESCRIPTION
With this PR, we'll publish a file for each day which summarizes the list of tarballs produced by the nightly build system.

This will help downstream integration testers automatically pick the most recent RC.

--
* [CRM-19417: Improve automation of RC testing on real world databases](https://issues.civicrm.org/jira/browse/CRM-19417)