### PR TITLE
PCHR-1495: Apply available drupal updates

### DIFF
--- a/app/config/hr16/drush.make.tmpl
+++ b/app/config/hr16/drush.make.tmpl
@@ -87,7 +87,6 @@ projects[webform_civicrm][version] = "4.16"
 projects[views][subdir] = contrib
 projects[views][version] = 3.14
 projects[views][patch][] = "https://www.drupal.org/files/issues/views-exposed_forms_ajax_support-1183418-73.patch"
-;projects[views][patch][] = "https://www.drupal.org/files/issues/views-exposed-ajax-not-working-2425099-52.patch"
 
 projects[login_destination][subdir] = contrib
 projects[login_destination][version] = "1.1"

--- a/app/config/hr16/drush.make.tmpl
+++ b/app/config/hr16/drush.make.tmpl
@@ -85,9 +85,9 @@ projects[webform_civicrm][subdir] = contrib
 projects[webform_civicrm][version] = "4.16"
 
 projects[views][subdir] = contrib
-projects[views][version] = 3.11
+projects[views][version] = 3.14
 projects[views][patch][] = "https://www.drupal.org/files/issues/views-exposed_forms_ajax_support-1183418-73.patch"
-projects[views][patch][] = "https://www.drupal.org/files/issues/views-exposed-ajax-not-working-2425099-52.patch"
+;projects[views][patch][] = "https://www.drupal.org/files/issues/views-exposed-ajax-not-working-2425099-52.patch"
 
 projects[login_destination][subdir] = contrib
 projects[login_destination][version] = "1.1"
@@ -126,13 +126,13 @@ projects[civicrm_entity][subdir] = civihr-contrib-required
 projects[civicrm_entity][version] = "2.x-dev"
 
 projects[features][subdir] = civihr-contrib-required
-projects[features][version] = "2.3"
+projects[features][version] = "2.10"
 
 projects[jquery_update][subdir] = civihr-contrib-required
-projects[jquery_update][version] = "2.5"
+projects[jquery_update][version] = "2.7"
 
 projects[panels][subdir] = civihr-contrib-required
-projects[panels][version] = "3.5"
+projects[panels][version] = "3.7"
 
 projects[rules][subdir] = civihr-contrib-required
 projects[rules][version] = "2.8"
@@ -219,7 +219,7 @@ projects[views_json_query][download][type] = "git"
 projects[views_json_query][patch][] = "https://raw.githubusercontent.com/compucorp/civihr-employee-portal/master/patches/views_json_query_civihr-v1.patch"
 
 projects[views_data_export][subdir] = civihr-contrib-required
-projects[views_data_export][version] = 3.0-beta8
+projects[views_data_export][version] = 3.1
 
 projects[views_bulk_operations][subdir] = civihr-contrib-required 
 projects[views_bulk_operations][version] = 3.3


### PR DESCRIPTION
- Updaing versions of Drupal modules: jQuery Update, Views, Views data export, Features, Panels for hr16 config.
- Removing views-exposed-ajax-not-working-2425099-52.patch as it's not needed for current Views module version.