### PR TITLE
civilint - Allow execution in a git subdir

### DIFF
--- a/bin/civilint
+++ b/bin/civilint
@@ -132,7 +132,10 @@ fi
 ## Capture the list of files
 TMP=$(mktempdir)
 if [ -z "$1" ]; then
-  if [ ! -d .git ]; then
+  GITROOT=$(git rev-parse --show-toplevel)
+  if [ -d "$GITROOT" ]; then
+    cd "$GITROOT"
+  else
     echo "ERROR: Cannot check for uncommitted changes in git. Please change to the git root."
     echo
     show_help


### PR DESCRIPTION
If you check out a git repo, go to a subdir, edit a file, and run
`civilint`, then you would expect it to scan that file...  but it actually
fails.

There is a subtlety in what the behavior should be -- e.g.  does it work
like `git status` or `git diff` (which check the whole repo) or like `find`
or `grep -r` (which look under the current folder).

As it happens, it's much easier to implement the first behavior, so that's
what this PR does...