### PR TITLE
[do-not-merge] PCHR-1247: Added Leave and Absences Feature module to enable using drush cmd.

### DIFF
--- a/app/config/hr16/install.sh
+++ b/app/config/hr16/install.sh
@@ -114,7 +114,7 @@ pushd "${WEB_ROOT}/sites/${DRUPAL_SITE_DIR}" >> /dev/null
 
   install_civihr
 
-  drush -y en civicrmtheme civihr_employee_portal_features civihr_default_permissions username_to_external_id
+  drush -y en civicrmtheme civihr_employee_portal_features civihr_default_permissions username_to_external_id leave_and_absences_feature
 
   setup_themes
   create_default_users


### PR DESCRIPTION
Why this should not be merged ? 
We are waiting for one of the CiviHR branch to be passed to staging , so once la-milestone-3 branch makes it way to staging this should be merged once CiviHR 1.7 is released.

Added Leave and Absences feature module to be enabled automatically whenever a new CiviHR site build happens using drush feature enablement.
