### PR TITLE
PCHR-1617 - External ID field update

### DIFF
--- a/app/config/hr16/install.sh
+++ b/app/config/hr16/install.sh
@@ -114,7 +114,7 @@ pushd "${WEB_ROOT}/sites/${DRUPAL_SITE_DIR}" >> /dev/null
 
   install_civihr
 
-  drush -y en civicrmtheme civihr_employee_portal_features civihr_default_permissions username_to_external_id
+  drush -y en civicrmtheme civihr_employee_portal_features civihr_default_permissions
 
   setup_themes
   create_default_users


### PR DESCRIPTION
Removing 'username_to_external_id' module from list of drupal enabled modules.