### PR TITLE
PCHR-1663: MailSystem 7.x-2.34 Patch Application

### DIFF
--- a/app/config/hr16/drush.make.tmpl
+++ b/app/config/hr16/drush.make.tmpl
@@ -180,6 +180,7 @@ projects[mimemail][version] = "1.0-beta3"
 
 projects[mailsystem][subdir] = civihr-contrib-required
 projects[mailsystem][version] = "2.34"
+projects[mailsystem][patch][] = "https://www.drupal.org/files/issues/mailsystem-newclass-wsod-2563443-16-7.x-2.34.patch"
 
 projects[views_autocomplete_filters][subdir] = civihr-contrib-required
 projects[views_autocomplete_filters][version] = "1.2"


### PR DESCRIPTION
Latest version of MailSystem module was breaking the application on creating a new mailing class using admin interface. The problem was, when either private:// or public:// resolved to a route outside of drupal root directory, the absolute path of the file was being saved to registry, breaking the application on class instantiation.  Solved by calculating route relative to drupal root path in a patch that now has to be applied on CiviHR installation.

Patch has been submitted to module maintainers, on issue:
https://www.drupal.org/node/2563443

Patch for MailSystem 7.x-2.34:
https://www.drupal.org/files/issues/mailsystem-newclass-wsod-2563443-16-7.x-2.34.patch