### PR TITLE
PCHR-1752 - Adding features_extra module and executing features-revert after enabling SSP features.

### DIFF
--- a/app/config/hr16/drush.make.tmpl
+++ b/app/config/hr16/drush.make.tmpl
@@ -124,6 +124,9 @@ projects[civicrm_entity][version] = "2.x-dev"
 projects[features][subdir] = civihr-contrib-required
 projects[features][version] = "2.10"
 
+projects[features_extra][subdir] = civihr-contrib-required
+projects[features_extra][version] = "1.0"
+
 projects[jquery_update][subdir] = civihr-contrib-required
 projects[jquery_update][version] = "2.7"
 

--- a/app/config/hr16/install.sh
+++ b/app/config/hr16/install.sh
@@ -115,6 +115,7 @@ pushd "${WEB_ROOT}/sites/${DRUPAL_SITE_DIR}" >> /dev/null
   install_civihr
 
   drush -y en civicrmtheme civihr_employee_portal_features civihr_default_permissions
+  drush -y features-revert civihr_employee_portal_features
 
   setup_themes
   create_default_users


### PR DESCRIPTION
I've added features_extra module to the drush.make.tmpl config to be able to export blocks using features (it requires to use fe_block submodule from features_extra).

Also I've added features reverting after SSP features are enabled in the install.sh script (to make sure that there are all feature code changes reflected in database).