### PR TITLE
Adding no-sample-data option to install civi without sample data

### DIFF
--- a/src/civibuild.aliases.sh
+++ b/src/civibuild.aliases.sh
@@ -74,7 +74,8 @@ function civibuild_alias_resolve() {
     hr13)        SITE_TYPE=hrdemo           ; CIVI_VERSION=4.5       ; CMS_TITLE="CiviHR 1.3 Demo"                   ; HR_VERSION=1.3        ;;
     hr14)        SITE_TYPE=hrdemo           ; CIVI_VERSION=4.5       ; CMS_TITLE="CiviHR 1.4 Demo"                   ; HR_VERSION=1.4        ;;
     hr15)        SITE_TYPE=hr15             ; CIVI_VERSION=4.5       ; CMS_TITLE="CiviHR 1.5 Demo"                   ; HR_VERSION=1.5     ;;
-    hr16)        SITE_TYPE=hr16             ; CIVI_VERSION=4.7.9     ; CMS_TITLE="CiviHR 1.6 Demo"                   ; HR_VERSION=master    ;;
+    hr16)        SITE_TYPE=hr16             ; CIVI_VERSION=4.7.9     ; CMS_TITLE="CiviHR 1.6 Demo"                   ; HR_VERSION=master    ;
+NO_SAMPLE_DATA=1       ;;
     hrmaster)    SITE_TYPE=hr15             ; CIVI_VERSION=master    ; CMS_TITLE="CiviHR Sandbox"                    ; HR_VERSION=master     ;;
 
     bempty)      SITE_TYPE=backdrop-empty   ; CIVI_VERSION=none      ; CMS_TITLE="Backdrop Sandbox"                  ;;

--- a/src/civibuild.app.sh
+++ b/src/civibuild.app.sh
@@ -34,6 +34,11 @@ Description: Download and/or install the application
   --demo-pass         Password for the CMS's demo user
   --demo-email        Email of the CMS's demo user
 
+  --sample-data       If set : will install civicrm along with sample data  
+                      (with civicrm_generated.sql).
+                      If is not set : will install civicrm with required
+                      data only (with civicrm_data.sql).
+
   --force             If necessary, destroy pre-existing files/directories/DBs
                       (For "reinstall", "--force" is implicit.)
 

--- a/src/civibuild.lib.sh
+++ b/src/civibuild.lib.sh
@@ -472,7 +472,9 @@ function civicrm_install() {
 
   pushd "$CIVI_CORE" >> /dev/null
     ## Does this build include development support (eg git or tarball-based)?
-    if [ -e "xml" -a -e "bin/setup.sh" ]; then
+    if [ "$NO_SAMPLE_DATA" == "1" ]; then
+      env SITE_ID="$SITE_ID" bash ./bin/setup.sh -Dgsdf
+    elif [ -e "xml" -a -e "bin/setup.sh" ]; then
       env SITE_ID="$SITE_ID" bash ./bin/setup.sh
     elif [ -e "sql/civicrm.mysql" -a -e "sql/civicrm_generated.mysql" ]; then
       cat sql/civicrm.mysql sql/civicrm_generated.mysql | eval mysql $CIVI_DB_ARGS

--- a/src/civibuild.lib.sh
+++ b/src/civibuild.lib.sh
@@ -472,12 +472,14 @@ function civicrm_install() {
 
   pushd "$CIVI_CORE" >> /dev/null
     ## Does this build include development support (eg git or tarball-based)?
-    if [ "$NO_SAMPLE_DATA" == "1" ]; then
+    if [ -e "xml" -a -e "bin/setup.sh" -n "$NO_SAMPLE_DATA" ]; then
       env SITE_ID="$SITE_ID" bash ./bin/setup.sh -Dgsdf
-    elif [ -e "xml" -a -e "bin/setup.sh" ]; then
+    elif [ -e "xml" -a -e "bin/setup.sh" -z "$NO_SAMPLE_DATA" ]; then
       env SITE_ID="$SITE_ID" bash ./bin/setup.sh
-    elif [ -e "sql/civicrm.mysql" -a -e "sql/civicrm_generated.mysql" ]; then
+    elif [ -e "sql/civicrm.mysql" -a -e "sql/civicrm_generated.mysql" -z "$NO_SAMPLE_DATA"]; then
       cat sql/civicrm.mysql sql/civicrm_generated.mysql | eval mysql $CIVI_DB_ARGS
+    elif [ -e "sql/civicrm.mysql" -a -e "sql/civicrm_data.mysql" -n "$NO_SAMPLE_DATA" ]; then
+      cat sql/civicrm.mysql sql/civicrm_data.mysql | eval mysql $CIVI_DB_ARGS
     else
       echo "Failed to locate civi SQL files"
     fi

--- a/src/civibuild.parse.sh
+++ b/src/civibuild.parse.sh
@@ -261,6 +261,11 @@ function civibuild_parse() {
         shift
         ;;
 
+      --no-sample-data)
+        NO_SAMPLE_DATA="$1"
+        shift
+        ;;
+
       --hr-ver)
         HR_VERSION="$1"
         shift


### PR DESCRIPTION
A new option is added (no-sample-date) which allows installing civicrm without any sample data (so installing civicrm with civicrm.sql only and without civicrm_generated.sql).

This option is also set to be disabled for hr16 build type by default.

Example usage :

typical installation **with** sample data (nothing changed)

```bash
civibuild create--type drupal-demo --url http://localhost:1234
```

OR 

```bash
civibuild create--type drupal-demo --url http://localhost:1234  --no-sample-data 0
```

Install **without** sample data :
```bash
civibuild create--type drupal-demo --url http://localhost:1234  --no-sample-data 1
```