### PR TITLE
phpunit-xml-cleanup - Exclude PHPUnit 3.x-specific elements

### DIFF
--- a/bin/phpunit-xml-cleanup
+++ b/bin/phpunit-xml-cleanup
@@ -13,5 +13,8 @@ foreach ($files as $file) {
   $content = file_get_contents($file);
   #$content = str_replace($sep, '&#x0001;', $content);
   $content = str_replace($sep, '', $content);
+  $content = preg_replace('/(<testsuite.*) fullPackage="[^"]+" /', '$1 ', $content);
+  $content = preg_replace('/(<testsuite.*) subpackage="[^"]+" /', '$1 ', $content);
+  $content = preg_replace('/(<testsuite.*) namespace="[^"]+" /', '$1 ', $content);
   file_put_contents($file, $content);
 }


### PR DESCRIPTION
When running PHPUnit on Civi 4.6, the JUnit-XML output includes extraneous elements
which seem to cause problems on current Jenkins.