### PR TITLE
Extract civicrm_apply_demo_defaults. Supply default org address.

### DIFF
--- a/app/config/backdrop-demo/install.sh
+++ b/app/config/backdrop-demo/install.sh
@@ -29,4 +29,5 @@ civicrm_install
 
 pushd "$CMS_ROOT" >> /dev/null
   php "$SITE_CONFIG_DIR/module-enable.php" civicrm
+  civicrm_apply_demo_defaults
 popd >> /dev/null

--- a/app/config/drupal-demo/install.sh
+++ b/app/config/drupal-demo/install.sh
@@ -46,8 +46,7 @@ pushd "${WEB_ROOT}/sites/${DRUPAL_SITE_DIR}" >> /dev/null
   echo '{"enable_components":["CiviEvent","CiviContribute","CiviMember","CiviMail","CiviReport","CiviPledge","CiviCase","CiviCampaign","CiviGrant"]}' \
     | drush cvapi setting.create --in=json
   ## Note: CiviGrant disabled by default. If you enable, update the permissions as well.
-  drush cvapi setting.create versionCheck=0 debug=1
-  drush cvapi MailSettings.create id=1 is_default=1 domain=example.org debug=1
+  civicrm_apply_demo_defaults
 
   ## Setup theme
   #above# drush -y en garland

--- a/app/config/drupal8-clean/install.sh
+++ b/app/config/drupal8-clean/install.sh
@@ -47,10 +47,9 @@ pushd "${WEB_ROOT}/sites/${DRUPAL_SITE_DIR}" >> /dev/null
   drush8 cc drush -y
 
   ## Setup CiviCRM
-  echo '{"enable_components":["CiviEvent","CiviContribute","CiviMember","CiviMail","CiviReport","CiviPledge","CiviCase","CiviCampaign"]}' \
-    | drush8 cvapi setting.create --in=json
-  drush8 cvapi setting.create versionCheck=0 debug=1
-  drush8 cvapi MailSettings.create id=1 is_default=1 domain=example.org debug=1
+  #echo '{"enable_components":["CiviEvent","CiviContribute","CiviMember","CiviMail","CiviReport","CiviPledge","CiviCase","CiviCampaign"]}' \
+  #  | drush8 cvapi setting.create --in=json
+  #civicrm_apply_demo_defaults
 
   ## Setup theme
   #above# drush8 -y en garland

--- a/app/config/drupal8-clean/install.sh
+++ b/app/config/drupal8-clean/install.sh
@@ -46,7 +46,7 @@ pushd "${WEB_ROOT}/sites/${DRUPAL_SITE_DIR}" >> /dev/null
   ## make sure drush functions are loaded
   drush8 cc drush -y
 
-  ## Setup CiviCRM
+  ## Setup CiviCRM -- But not in 'clean' config!
   #echo '{"enable_components":["CiviEvent","CiviContribute","CiviMember","CiviMail","CiviReport","CiviPledge","CiviCase","CiviCampaign"]}' \
   #  | drush8 cvapi setting.create --in=json
   #civicrm_apply_demo_defaults

--- a/app/config/drupal8-demo/install.sh
+++ b/app/config/drupal8-demo/install.sh
@@ -49,8 +49,7 @@ pushd "${WEB_ROOT}/sites/${DRUPAL_SITE_DIR}" >> /dev/null
   ## Setup CiviCRM
   echo '{"enable_components":["CiviEvent","CiviContribute","CiviMember","CiviMail","CiviReport","CiviPledge","CiviCase","CiviCampaign"]}' \
     | drush8 cvapi setting.create --in=json
-  drush8 cvapi setting.create versionCheck=0 debug=1
-  drush8 cvapi MailSettings.create id=1 is_default=1 domain=example.org debug=1
+  civicrm_apply_demo_defaults
 
   ## Setup theme
   #above# drush8 -y en garland

--- a/app/config/wp-demo/install.sh
+++ b/app/config/wp-demo/install.sh
@@ -54,6 +54,8 @@ wp eval '$home = get_page_by_title("Welcome to CiviCRM with WordPress"); update_
 wp plugin activate civicrm
 wp plugin activate civicrm-demo-wp
 
+civicrm_apply_demo_defaults
+
 wp role create civicrm_admin 'CiviCRM Administrator'
 wp cap add civicrm_admin \
   read \

--- a/src/civibuild.lib.sh
+++ b/src/civibuild.lib.sh
@@ -498,6 +498,35 @@ EOSQL
 }
 
 ###############################################################################
+## Appy more default values
+function civicrm_apply_demo_defaults() {
+  if cv ev 'exit(version_compare(CRM_Utils_System::version(), "4.7.0", "<") ?0:1);' ; then
+    cv api setting.create versionCheck=0 debug=1
+  fi
+  cv api MailSettings.create id=1 is_default=1 domain=example.org debug=1
+  if [ -z "$NO_SAMPLE_DATA" ]; then
+    cv -vv ev 'eval(file_get_contents("php://stdin"));' <<EOPHP
+      \$cid = civicrm_api3('Domain', 'getvalue', array(
+        'id' => 1,
+        'return' => 'contact_id'
+      ));
+      civicrm_api3('Address', 'create', array(
+        'contact_id' => \$cid,
+        'location_type_id' => 1,
+        'street_address' => '123 Some St',
+        'city' => 'Hereville',
+        'country_id' => 'US',
+        'state_province_id' => 'California',
+        'postal_code' => '94100',
+        'options' => array(
+          'match' => array('contact_id', 'location_type_id'),
+        ),
+      ));
+EOPHP
+  fi
+}
+
+###############################################################################
 ## Generate a "civicrm.settings.php" file
 function civicrm_make_settings_php() {
   cvutil_assertvars civicrm_make_settings_php CIVI_SETTINGS CIVI_CORE CIVI_UF CIVI_TEMPLATEC CMS_URL CIVI_SITE_KEY


### PR DESCRIPTION
Considerations:
 1. When demoing CiviMail, we need an example snailmail address to show mandatory tokens.
 2. This is conceptually similar to other parts of the setup process (e.g. the `setting.create` and `MailSettings.create`) in that all of them should apply to `*-demo` builds but not `*-clean` builds. Consolidate these.
 3. These settings were applied a bit inconsistently between different demo types. With this patch, the
    goal is
    1. Any "demo" build (`backdrop-demo`, `drupal-demo`, `drupal8-demo`, `wp-demo`) should apply these defaults
    2. Any "clean" build (`backdrop-clean`, `drupal-clean`, `drupal8-clean`) should just use the same default
       as other fresh installation.