### PR TITLE
PCHR-1975: Added new default role civihr_admin_local for the new sites.

### DIFF
--- a/app/config/hr16/install.sh
+++ b/app/config/hr16/install.sh
@@ -13,6 +13,8 @@ function create_default_users() {
 
   drush -y user-create --password="civihr_admin" --mail="civihr_admin@compucorp.co.uk" "civihr_admin"
   drush -y user-add-role civihr_admin "civihr_admin"
+
+  drush -y user-add-role civihr_admin_local "civihr_admin_local"
 }
 
 ##


### PR DESCRIPTION
***Task***
Create new default role "civihr_admin_local" for all the new civihr sites.

***Solution***
Created new role using drush under create_default_users function.