### PR TITLE
civibuild - Implement option "--ext" to download extensions

### DIFF
--- a/src/civibuild.app.sh
+++ b/src/civibuild.app.sh
@@ -21,6 +21,7 @@ Description: Download and/or install the application
   --civi-ver <ver>    The branch or tag of CiviCRM desired (master, 4.4, 4.3, 4.3.0, etc) [Optional]
   --cms-ver <ver>     The release of the CMS desired [Optional]
   --dl <path>=<url>   Download and extract zip/tar files [Optional]
+  --ext <ext>         Download an extension [Optional]
   --patch <spec>      Apply git patch immediately after downloading [Optional]
                       Ex: "https://github.com/civicrm/civicrm-core/pull/8022"
                       Ex: ";civicrm-packages;/my/local/change-for-packages.patch"
@@ -206,6 +207,15 @@ function civibuild_app_install() {
     IS_INSTALLED=1
   else
     echo "Already installed ${SITE_NAME}/${SITE_ID}"
+  fi
+
+  if [ -n "$EXT_DLS" ]; then
+    pushd "$WEB_ROOT" >> /dev/null
+      if ! cv dl -k $EXT_DLS ; then
+        echo "Failed to download or enable extensions ($EXT_DLS)"
+        exit 92
+      fi
+    popd >> /dev/null
   fi
 
   _amp_snapshot_restore_test

--- a/src/civibuild.defaults.sh
+++ b/src/civibuild.defaults.sh
@@ -100,6 +100,9 @@ PATCHES=
 ## Ex: "relpath=https://example.com/file.zip"
 EXTRA_DLS=
 
+## Space-delimited list of extensions to download (via cv/civicrm.org)
+EXT_DLs=
+
 ## A template for picking the default URL (using variable "SITE_NAME").
 ## Ex: "http://%SITE_NAME%.dev"
 ## Ex: "%AUTO%"
@@ -255,6 +258,7 @@ PERSISTENT_VARS="
   TEST_DB_DSN TEST_DB_USER TEST_DB_PASS TEST_DB_HOST TEST_DB_PORT TEST_DB_NAME TEST_DB_ARGS
   CIVI_SETTINGS CIVI_FILES CIVI_TEMPLATEC CIVI_UF
   IS_INSTALLED
+  EXT_DLS
   SITE_TOKEN SITE_TYPE
 "
 # ignore: runtime options like CIVI_SQL_SKIP and FORCE_DOWNLOAD

--- a/src/civibuild.parse.sh
+++ b/src/civibuild.parse.sh
@@ -186,6 +186,11 @@ function civibuild_parse() {
         shift
         ;;
 
+      --ext)
+        EXT_DLS="$EXT_DLS $1"
+        shift
+        ;;
+
       --force)
         FORCE_DOWNLOAD=1
         FORCE_INSTALL=1


### PR DESCRIPTION
With this option, `civibuild create` or `civibuild install` will
automatically download/enable an extension. For example:

```bash
civibuild create dmosaico --type drupal-clean --ext "shoreditch flexmailer mosaico"
```