### PR TITLE
civi-download-tools - Add support for Ubuntu 16.10

### DIFF
--- a/bin/civi-download-tools
+++ b/bin/civi-download-tools
@@ -289,7 +289,7 @@ function get_system_installer() {
     source /etc/lsb-release
   fi
   case "$DISTRIB_CODENAME" in
-    precise|trusty|jessie|xenial)
+    precise|trusty|jessie|xenial|yakkety)
       echo "do_system_$DISTRIB_CODENAME"
       ;;
     *)
@@ -345,6 +345,33 @@ function do_system_xenial() {
   set -e
     PACKAGES="acl git wget unzip zip mysql-server mysql-client php7.0-cli php7.0-imap php7.0-ldap php7.0-curl php7.0-mysql php7.0-intl php7.0-gd php7.0-mcrypt php7.0-bcmath php7.0-mbstring php7.0-soap php7.0-zip php7.0-xml apache2 libapache2-mod-php7.0 nodejs-legacy npm"
     echo "Detected \"Ubuntu Xenial 16.04\"."
+    echo ""
+    echo "Task: $PACKAGES"
+    echo ""
+    echo "Warning: This system will not support php-mysql extension"
+    echo ""
+    if cvutil_confirm "Run automated installation? [Y/n] " y y; then
+      sudo apt-get update
+      sudo apt-get -y install $PACKAGES
+      sudo phpenmod bcmath
+      sudo phpenmod curl
+      sudo phpenmod imap
+      sudo phpenmod mcrypt
+      sudo phpenmod xml
+      sudo a2enmod rewrite
+      sudo apache2ctl restart
+    else
+      echo "Aborted" 1>&2
+      exit 1
+    fi
+  set +e
+}
+
+###############################################################################
+function do_system_yakkety() {
+  set -e
+    PACKAGES="acl git wget unzip zip mysql-server mysql-client php7.0-cli php7.0-imap php7.0-ldap php7.0-curl php7.0-mysql php7.0-intl php7.0-gd php7.0-mcrypt php7.0-bcmath php7.0-mbstring php7.0-soap php7.0-zip php7.0-xml apache2 libapache2-mod-php7.0 nodejs-legacy npm"
+    echo "Detected \"Ubuntu Yakkety 16.10\"."
     echo ""
     echo "Task: $PACKAGES"
     echo ""


### PR DESCRIPTION
So far, this seems to be identical to the previous release (Ubuntu 16.04).
I suppose there's a first time for everything.  :)