### PR TITLE
wp_install() - Set permissions on newer data dirs

### DIFF
--- a/src/civibuild.lib.sh
+++ b/src/civibuild.lib.sh
@@ -692,7 +692,7 @@ PHP
 
     ## Create WP data dirs
     cvutil_mkdir "wp-content/plugins/modules"
-    amp datadir "wp-content/plugins/files"
+    amp datadir "wp-content/plugins/files" "wp-content/uploads/"
 
     cvutil_inject_settings "wp-config.php" "wp-config.d"
   popd >> /dev/null


### PR DESCRIPTION
When using `civihydra` to test the 4.7.17-rc installation with WordPress and
Ubuntu 16.10, I found that he permissions on this folder weren't properly
set.

This mostly likely is stale reference since the default location of
`civicrm.settings.php` was changed.  I never noticed it on MAMP because it
doesn't affect you if the amp `perm_type` is `none` (single-user); it
would affect any two-user/multi-user `perm_type`s.