### PR TITLE
PCHR-1687: Install Masquerade Module

### DIFF
--- a/app/config/hr16/drush.make.tmpl
+++ b/app/config/hr16/drush.make.tmpl
@@ -191,6 +191,9 @@ projects[views_autocomplete_filters][version] = "1.2"
 projects[views_merge_rows][subdir] = civihr-contrib-required
 projects[views_merge_rows][version] = "1.0-rc1"
 
+projects[masquerade][subdir] = civihr-contrib-required
+projects[masquerade][version] = "1.0-rc7"
+
 ; Patch for pagination
 projects[views_merge_rows][patch][] = "https://www.drupal.org/files/issues/views_merge_rows-views_merge_rows_and_pagination-2188939-3_0.patch"
 projects[views_merge_rows][patch][] = "https://www.drupal.org/files/issues/views_merge_rows-views_merge_rows_pagination-2724691-2.patch"

--- a/app/config/hr16/install.sh
+++ b/app/config/hr16/install.sh
@@ -107,7 +107,7 @@ pushd "${WEB_ROOT}/sites/${DRUPAL_SITE_DIR}" >> /dev/null
 
   drush -y updatedb
   drush -y dis overlay shortcut color
-  drush -y en administerusersbyrole role_delegation subpermissions civicrm toolbar locale seven userprotect
+  drush -y en administerusersbyrole role_delegation subpermissions civicrm toolbar locale seven userprotect masquerade
 
   ## Setup welcome page
   drush -y scr "$SITE_CONFIG_DIR/install-welcome.php"


### PR DESCRIPTION
Masquerade module is to be installed by default on installation of CiviHR.  Added a copuple lines to drush make file so masquerade module is installed.