### PR TITLE
PCHR-1728: Add SMTP Module to Makefile

### DIFF
--- a/app/config/hr16/drush.make.tmpl
+++ b/app/config/hr16/drush.make.tmpl
@@ -211,6 +211,10 @@ projects[browserclass][version] = 1.7
 projects[conditional_styles][subdir] = civihr-contrib-required
 projects[conditional_styles][version] = 2.2
 
+; SMTP Module
+projects[smtp][subdir] = civihr-contrib-required
+projects[smtp][version] = 1.6
+
 ; ****************************************
 ; Compucorp custom drupal modules
 ; ****************************************

--- a/app/config/hr16/install.sh
+++ b/app/config/hr16/install.sh
@@ -107,7 +107,7 @@ pushd "${WEB_ROOT}/sites/${DRUPAL_SITE_DIR}" >> /dev/null
 
   drush -y updatedb
   drush -y dis overlay shortcut color
-  drush -y en administerusersbyrole role_delegation subpermissions civicrm toolbar locale seven userprotect masquerade
+  drush -y en administerusersbyrole role_delegation subpermissions civicrm toolbar locale seven userprotect masquerade smtp
 
   ## Setup welcome page
   drush -y scr "$SITE_CONFIG_DIR/install-welcome.php"


### PR DESCRIPTION
## Problem
SMTP module had to be installed manually on every CiviHR installation.

## Solution
Added SMTP module to projects to be installed in drush makefile for CiviHR (hr16).