### PR TITLE
Remove warning about php-mysql during install

### DIFF
--- a/bin/civi-download-tools
+++ b/bin/civi-download-tools
@@ -350,8 +350,6 @@ function do_system_xenial() {
     echo ""
     echo "Task: $PACKAGES"
     echo ""
-    echo "Warning: This system will not support php-mysql extension"
-    echo ""
     if cvutil_confirm "Run automated installation? [Y/n] " y y; then
       sudo apt-get update
       sudo apt-get -y install $PACKAGES


### PR DESCRIPTION
I installed buildkit on a new system today and got hung up because of this warning message: 

> "Warning: This system will not support php-mysql extension"

I think this additional information is actually a disservice to the user because

* It doesn't explain how this affects the user. It's not actionable. 
* It causes additional stress during an already stressful process.
* It can be a red herring if the user has unrelated problems during the installation process (as was the case for me today)

I think if we're going to keep this warning message in, we should explain more to the user about the *implications* of the system not supporting php-mysql (which, personally, I don't understand).