### PR TITLE
PCHR-2022: Add the hr17 build type

### DIFF
--- a/app/config/hr17/download.sh
+++ b/app/config/hr17/download.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+## download.sh -- Download Drupal and CiviCRM
+
+###############################################################################
+
+git_cache_setup "https://github.com/civicrm/civihr.git" "$CACHE_DIR/civicrm/civihr.git"
+
+[ -z "$CMS_VERSION" ] && CMS_VERSION=7.x
+[ -z "$CIVI_VERSION" ] && CIVI_VERSION=4.4
+[ -z "$HR_VERSION" ] && HR_VERSION=master
+
+MAKEFILE="${TMPDIR}/${SITE_TYPE}/${SITE_NAME}/${SITE_ID}.make"
+cvutil_makeparent "$MAKEFILE"
+cat "$SITE_CONFIG_DIR/drush.make.tmpl" \
+  | sed "s;%%CACHE_DIR%%;${CACHE_DIR};" \
+  | sed "s;%%CIVI_VERSION%%;${CIVI_VERSION};" \
+  | sed "s;%%CMS_VERSION%%;${CMS_VERSION};" \
+  | sed "s;%%HR_VERSION%%;${HR_VERSION};" \
+  > "$MAKEFILE"
+
+drush -y make --concurrency=5 --working-copy "$MAKEFILE" "$WEB_ROOT"

--- a/app/config/hr17/drush.make.tmpl
+++ b/app/config/hr17/drush.make.tmpl
@@ -1,0 +1,285 @@
+; A drush makefile for CiviCRM.
+; Call using:
+; drush make --working-copy civicrm.make
+
+; drush make API version
+api = 2
+
+; Drupal core
+core = %%CMS_VERSION%%
+
+; ****************************************
+; Drupal core
+; ****************************************
+
+projects[] = drupal
+
+; ****************************************
+; CiviCRM core
+; ****************************************
+
+libraries[civicrmdrupal][destination] = modules
+libraries[civicrmdrupal][directory_name] = civicrm/drupal
+libraries[civicrmdrupal][download][type] = git
+libraries[civicrmdrupal][download][url] = %%CACHE_DIR%%/civicrm/civicrm-drupal.git
+libraries[civicrmdrupal][download][tag] = 7.x-%%CIVI_VERSION%%
+libraries[civicrmdrupal][overwrite] = TRUE
+
+libraries[civicrmpackages][destination] = modules
+libraries[civicrmpackages][directory_name] = civicrm/packages
+libraries[civicrmpackages][download][type] = git
+libraries[civicrmpackages][download][url] = %%CACHE_DIR%%/civicrm/civicrm-packages.git
+libraries[civicrmpackages][download][tag] = %%CIVI_VERSION%%
+libraries[civicrmpackages][overwrite] = TRUE
+
+libraries[civihr][destination] = modules
+libraries[civihr][directory_name] = civicrm/tools/extensions/civihr
+libraries[civihr][download][type] = git
+libraries[civihr][download][url] = %%CACHE_DIR%%/civicrm/civihr.git
+libraries[civihr][download][branch] = %%HR_VERSION%%
+libraries[civihr][overwrite] = TRUE
+
+libraries[civicrm][destination] = modules
+libraries[civicrm][directory_name] = civicrm
+libraries[civicrm][download][type] = git
+libraries[civicrm][download][url] = %%CACHE_DIR%%/civicrm/civicrm-core.git
+libraries[civicrm][download][tag] = %%CIVI_VERSION%%
+libraries[civicrm][overwrite] = TRUE
+
+; ****************************************
+; Runtime Modules
+; ****************************************
+
+projects[civicrm_error][subdir] = contrib
+projects[civicrm_error][version] = 2.0-rc3
+
+projects[libraries][subdir] = contrib
+projects[libraries][version] = 2.2
+
+projects[redirect][subdir] = contrib
+projects[redirect][version] = 1.0-rc1
+
+projects[webform][subdir] = contrib
+projects[webform][version] = 4.12
+
+projects[webform_civicrm][subdir] = contrib
+projects[webform_civicrm][version] = "4.16"
+
+projects[views][subdir] = contrib
+projects[views][version] = 3.14
+projects[views][patch][] = "https://www.drupal.org/files/issues/views-exposed_forms_ajax_support-1183418-73.patch"
+
+projects[userprotect][subdir] = contrib
+projects[userprotect][version] = "1.1"
+
+; ****************************************
+; Developer modules
+; ****************************************
+
+projects[devel][subdir] = contrib
+projects[devel][version] = 1.5
+
+libraries[civicrmdeveloper][destination] = modules
+libraries[civicrmdeveloper][directory_name] = contrib/civicrm_developer
+libraries[civicrmdeveloper][download][type] = git
+libraries[civicrmdeveloper][download][url] = %%CACHE_DIR%%/eileenmcnaughton/civicrm_developer.git
+libraries[civicrmdeveloper][download][branch] = master
+libraries[civicrmdeveloper][overwrite] = TRUE
+
+; ****************************************
+; Compucorp contrib modules
+; ****************************************
+
+projects[ctools][subdir] = civihr-contrib-required
+projects[ctools][version] = "1.9"
+
+projects[date][subdir] = civihr-contrib-required
+projects[date][version] = "2.8"
+
+projects[entity][subdir] = civihr-contrib-required
+projects[entity][version] = "1.6"
+
+projects[civicrm_entity][subdir] = civihr-contrib-required
+projects[civicrm_entity][version] = "2.x-dev"
+
+projects[features][subdir] = civihr-contrib-required
+projects[features][version] = "2.10"
+
+projects[features_extra][subdir] = civihr-contrib-required
+projects[features_extra][version] = "1.0"
+
+projects[jquery_update][subdir] = civihr-contrib-required
+projects[jquery_update][version] = "2.7"
+
+projects[panels][subdir] = civihr-contrib-required
+projects[panels][version] = "3.7"
+
+projects[rules][subdir] = civihr-contrib-required
+projects[rules][version] = "2.8"
+
+projects[tipsy][subdir] = civihr-contrib-required
+projects[tipsy][version] = "1.0-rc1"
+
+projects[strongarm][subdir] = civihr-contrib-required
+projects[strongarm][version] = "2.0"
+
+projects[views_block_area][subdir] = civihr-contrib-required
+projects[views_block_area][version] = "1.1"
+
+projects[views_tooltip][subdir] = civihr-contrib-required
+projects[views_tooltip][version] = "1.x-dev"
+
+projects[xautoload][subdir] = civihr-contrib-required
+projects[xautoload][version] = "5.1"
+
+projects[radix_layouts][subdir] = civihr-contrib-required
+projects[radix_layouts][version] = "3.3"
+
+projects[uuid][subdir] = civihr-contrib-required
+projects[uuid][version] = "1.0-alpha6"
+
+projects[node_export][subdir] = civihr-contrib-required
+projects[node_export][version] = "3.0"
+
+projects[fancy_login][subdir] = civihr-contrib-required
+projects[fancy_login][version] = "3.0-beta6"
+
+projects[jcarousel][subdir] = civihr-contrib-required
+projects[jcarousel][version] = "2.7"
+
+projects[download][subdir] = civihr-contrib-required
+projects[download][version] = "2.5"
+
+projects[views_fieldsets][subdir] = civihr-contrib-required
+projects[views_fieldsets][version] = "2.1"
+
+projects[options_element][subdir] = civihr-contrib-required
+projects[options_element][version] = "1.12"
+
+projects[views_datasource][subdir] = civihr-contrib-required
+projects[views_datasource][version] = "1.0-alpha2"
+
+projects[mimemail][subdir] = civihr-contrib-required
+projects[mimemail][version] = "1.0-beta3"
+
+projects[mailsystem][subdir] = civihr-contrib-required
+projects[mailsystem][version] = "2.34"
+projects[mailsystem][patch][] = "https://www.drupal.org/files/issues/mailsystem-newclass-wsod-2563443-16-7.x-2.34.patch"
+
+projects[views_autocomplete_filters][subdir] = civihr-contrib-required
+projects[views_autocomplete_filters][version] = "1.2"
+
+projects[views_merge_rows][subdir] = civihr-contrib-required
+projects[views_merge_rows][version] = "1.0-rc1"
+
+projects[masquerade][subdir] = civihr-contrib-required
+projects[masquerade][version] = "1.0-rc7"
+
+projects[logintoboggan][subdir] = civihr-contrib-required
+projects[logintoboggan][version] = "1.5"
+
+; Patch for pagination
+projects[views_merge_rows][patch][] = "https://www.drupal.org/files/issues/views_merge_rows-views_merge_rows_and_pagination-2188939-3_0.patch"
+projects[views_merge_rows][patch][] = "https://www.drupal.org/files/issues/views_merge_rows-views_merge_rows_pagination-2724691-2.patch"
+
+projects[role_export][subdir] = civihr-contrib-required
+projects[role_export][version] = "1.0"
+
+projects[administerusersbyrole][subdir] = civihr-contrib-required
+projects[administerusersbyrole][version] = "2.0-rc1"
+
+projects[taxonomy_access_fix][subdir] = civihr-contrib-required
+projects[taxonomy_access_fix][version] = "2.2"
+
+projects[chain_menu_access][subdir] = civihr-contrib-required
+projects[chain_menu_access][version] = "2.0"
+
+projects[role_delegation][subdir] = civihr-contrib-required
+projects[role_delegation][version] = "1.1"
+
+projects[views_json_query][subdir] = civihr-contrib-required
+projects[views_json_query][version] = 1.x-dev
+projects[views_json_query][download][type] = "git"
+projects[views_json_query][patch][] = "https://raw.githubusercontent.com/compucorp/civihr-employee-portal/master/patches/views_json_query_civihr-v1.patch"
+
+projects[views_data_export][subdir] = civihr-contrib-required
+projects[views_data_export][version] = 3.1
+
+projects[views_bulk_operations][subdir] = civihr-contrib-required
+projects[views_bulk_operations][version] = 3.3
+
+projects[browserclass][subdir] = civihr-contrib-required
+projects[browserclass][version] = 1.7
+
+projects[conditional_styles][subdir] = civihr-contrib-required
+projects[conditional_styles][version] = 2.2
+
+; SMTP Module
+projects[smtp][subdir] = civihr-contrib-required
+projects[smtp][version] = 1.6
+
+; ****************************************
+; Compucorp custom drupal modules
+; ****************************************
+
+libraries[civihr_employee_portal][destination] = modules
+libraries[civihr_employee_portal][directory_name] = civihr-custom
+libraries[civihr_employee_portal][download][type] = git
+libraries[civihr_employee_portal][download][url] = https://github.com/compucorp/civihr-employee-portal
+libraries[civihr_employee_portal][download][branch] = %%HR_VERSION%%
+libraries[civihr_employee_portal][overwrite] = TRUE
+
+; ****************************************
+; Compucorp custom drupal theme
+; ****************************************
+
+; Download Radix base theme
+projects[radix][version] = "3.4"
+
+; CiviHR Radix based default subtheme (dependent on the Radix theme)
+libraries[civihr_employee_portal_theme][destination] = themes
+libraries[civihr_employee_portal_theme][download][type] = git
+libraries[civihr_employee_portal_theme][download][url] = https://github.com/compucorp/civihr-employee-portal-theme
+libraries[civihr_employee_portal_theme][download][branch] = %%HR_VERSION%%
+libraries[civihr_employee_portal_theme][overwrite] = TRUE
+
+; ****************************************
+; Boostrap theme
+; ****************************************
+
+; Download Radix base theme
+projects[bootstrap][version] = "3.1"
+
+; ****************************************
+; Compucorp custom civicrm extensions
+; ****************************************
+
+libraries[civihr_tasks][destination] = modules/civicrm/tools/extensions
+libraries[civihr_tasks][download][type] = git
+libraries[civihr_tasks][download][url] = https://github.com/compucorp/civihr-tasks-assignments
+libraries[civihr_tasks][download][branch] = %%HR_VERSION%%
+libraries[civihr_tasks][overwrite] = TRUE
+
+; ****************************************
+; Compucorp forks of civicrm modules (for internal development cycle)
+; ****************************************
+
+libraries[org.civicrm.shoreditch][destination] = modules/civicrm/tools/extensions
+libraries[org.civicrm.shoreditch][download][type] = git
+libraries[org.civicrm.shoreditch][download][url] = https://github.com/compucorp/org.civicrm.shoreditch
+libraries[org.civicrm.shoreditch][overwrite] = TRUE
+
+libraries[org.civicrm.styleguide][destination] = modules/civicrm/tools/extensions
+libraries[org.civicrm.styleguide][download][type] = git
+libraries[org.civicrm.styleguide][download][url] = https://github.com/compucorp/org.civicrm.styleguide
+libraries[org.civicrm.styleguide][overwrite] = TRUE
+
+; ****************************************
+; Compucorp custom libraries for Drupal
+; ****************************************
+
+libraries[pclzip][destination] = libraries
+libraries[pclzip][download][type] = git
+libraries[pclzip][download][url] = https://github.com/ivanlanin/pclzip
+libraries[pclzip][download][branch] = master
+libraries[pclzip][overwrite] = TRUE

--- a/app/config/hr17/install-welcome.php
+++ b/app/config/hr17/install-welcome.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * @file
+ *
+ * Register the "welcome" node (node/1)
+ */
+
+$node = node_load(1);
+if ($node === FALSE) {
+  $node = new stdClass();
+  $node->type = 'page';
+  node_object_prepare($node);
+}
+
+$node->title    = 'Welcome to ' . variable_get('site_name');
+$node->language = LANGUAGE_NONE;
+$node->body[$node->language][0]['value']   = '
+<p>CiviHR is an integrated Human Resource Management application designed to meet the needs of non-profit and third sector organizations.</p>
+
+<p>To login as a HR administrator:
+<strong>Username:</strong> civihr_admin
+<strong>Password:</strong> civihr_admin</p>
+
+<p>To login as a staff member:
+<strong>Username:</strong> civihr_staff
+<strong>Password:</strong> civihr_staff</p>
+
+<p>To login as a staff manager:
+<strong>Username:</strong> civihr_manager
+<strong>Password:</strong> civihr_manager</p>
+
+<p><strong>Any data you enter on this demo site is "publicly available" due to the open login. Please do not enter real email addresses or other personal information.</strong> The demo database is reset periodically.</p>
+
+<h3>New to CiviHR?</h3>
+ CiviHR will be developed in multiple phases. So far it comprises of the following functionality:
+<ul>
+<li>Directory - a listing of the people who work for an organisation (paid and unpaid)
+ <li>Staff Contact Details</li>
+ <li>Identification</li>
+ <li>Medical & Disability</li>
+ <li>Visas & Work Permits</li>
+ <li>Emergency Contacts</li>
+ <li>Job Positions & Job Roles</li>
+ <li>Skills & Qualifications</li>
+ <li>Education & Employment History</li>
+ <li>Simple Remuneration Recording</li>
+ <li>Recording of Leave and Absences</li>
+ <li>Workflows to manage Joining, Probation and Exiting</li>
+ <li>Recruitment with an online job application process</li>
+</ul>
+
+For more information, please post your queries on the <strong><a href="http://forum.civicrm.org/index.php/board,87.0.html" target="_blank">CiviHR forum board</a></strong>. To stay updated about new developments in CiviHR, please subscribe to the <strong><a href="https://civicrm.org/civicrm-blog-categories/civihr" target="_blank" title="CiviHR Blog - opens in a new window">CiviHR blog</a></strong>.
+
+Want to install your own copy of CiviHR? <a href="https://civicrm.org/extensions/civihr" target="_blank">Information about downloading and installation can be found here</a>.
+';
+
+// <h3>This is the development sandbox</h3>
+// This sandbox represents the upcoming release - a work-in-progress. Unless you are interested in tracking development real-time, you might prefer to <a href="http://civihr.demo.civicrm.org/">explore CiviHR\'s current capabilities using the stable demo</a>.</p>
+
+$node->body[$node->language][0]['summary'] = text_summary($node->body[$node->language][0]['value']);
+$node->body[$node->language][0]['format']  = 'filtered_html';
+
+$node->path = array('alias' => 'welcome');
+
+node_save($node);

--- a/app/config/hr17/install.sh
+++ b/app/config/hr17/install.sh
@@ -1,0 +1,132 @@
+#!/bin/bash
+
+## install.sh -- Create config files and databases; fill the databases
+
+##
+# Creates the default CiviHR users
+function create_default_users() {
+  drush -y user-create --password="civihr_staff" --mail="civihr_staff@compucorp.co.uk" "civihr_staff"
+  drush -y user-add-role civihr_staff "civihr_staff"
+
+  drush -y user-create --password="civihr_manager" --mail="civihr_manager@compucorp.co.uk" "civihr_manager"
+  drush -y user-add-role civihr_manager "civihr_manager"
+
+  drush -y user-create --password="civihr_admin" --mail="civihr_admin@compucorp.co.uk" "civihr_admin"
+  drush -y user-add-role civihr_admin "civihr_admin"
+}
+
+##
+# Creates the "Personal" Location Type
+function create_personal_location_type() {
+  drush cvapi LocationType.create sequential=1 name="Personal" display_name="Personal" vcard_name="PERSONAL" description="Place of Residence"
+}
+
+##
+# Deletes the "Name and address profile"
+function delete_name_and_address_profile() {
+  PROFILE_ID=`[[ $(drush cvapi UFGroup.getsingle return="id" title="Name and address") =~ \[id\].+([1-9]) ]] && echo ${BASH_REMATCH[1]}`
+
+  drush cvapi UFGroup.delete sequential=1 id=$PROFILE_ID
+}
+
+##
+# Disables the unused drupal blocks, leaving only the "main content" one active
+function disabled_unused_blocks() {
+  for block in 'navigation' 'form' 'powered-by' 'help' 'navigation' 'login' \
+    '2' '3' '5' '7'
+  do
+    drush block-disable --delta="$block"
+  done
+}
+
+##
+# Installs CiviHR extensions
+function install_civihr() {
+  ## (no sample data as default)
+  bash ${CIVI_CORE}/tools/extensions/civihr/bin/drush-install.sh ${CIVI_CORE}
+
+  ## (with sample data - if required)
+  # bash ${CIVI_CORE}/tools/extensions/civihr/bin/drush-install.sh --with-sample-data
+}
+
+##
+# Sets up the themes
+function setup_themes {
+  ## Drupal theme
+  drush -y en civihr_default_theme
+  drush -y vset theme_default civihr_default_theme
+
+  ## Civicrm and admin theme
+  drush -y vset admin_theme seven
+  drush -y vset civicrmtheme_theme_admin seven
+  drush -y vset civicrmtheme_theme_public seven
+}
+
+###############################################################################
+## Create virtual-host and databases
+
+amp_install
+
+###############################################################################
+## Grant access for the Drupal database user to access the Civi Database too
+
+eval mysql $CIVI_DB_ARGS <<EOSQL
+  GRANT ALL PRIVILEGES ON $CIVI_DB_NAME.* TO $CMS_DB_USER@'%';
+EOSQL
+
+###############################################################################
+## Setup Drupal (config files, database tables)
+
+drupal_install
+
+###############################################################################
+## Setup CiviCRM (config files, database tables)
+
+DRUPAL_SITE_DIR=$(_drupal_multisite_dir "$CMS_URL" "$SITE_ID")
+CIVI_DOMAIN_NAME="Demonstrators Anonymous"
+CIVI_DOMAIN_EMAIL="\"Demonstrators Anonymous\" <info@example.org>"
+CIVI_CORE="${WEB_ROOT}/sites/all/modules/civicrm"
+CIVI_SETTINGS="${WEB_ROOT}/sites/${DRUPAL_SITE_DIR}/civicrm.settings.php"
+CIVI_FILES="${WEB_ROOT}/sites/${DRUPAL_SITE_DIR}/files/civicrm"
+CIVI_TEMPLATEC="${CIVI_FILES}/templates_c"
+CIVI_UF="Drupal"
+
+## civicrm-core v4.7+ sets default ext dir; for older versions, we'll set our own.
+if [[ "$CIVI_VERSION" =~ ^4.[0123456](\.([0-9]|alpha|beta)+)?$ ]] ; then
+  CIVI_EXT_DIR="${WEB_ROOT}/sites/${DRUPAL_SITE_DIR}/ext"
+  CIVI_EXT_URL="${CMS_URL}/sites/${DRUPAL_SITE_DIR}/ext"
+fi
+
+civicrm_install
+
+###############################################################################
+## Extra configuration
+pushd "${WEB_ROOT}/sites/${DRUPAL_SITE_DIR}" >> /dev/null
+
+  drush -y dl drush_extras drush_taxonomyinfo
+
+  drush -y updatedb
+  drush -y dis overlay shortcut color
+  drush -y en administerusersbyrole role_delegation subpermissions civicrm toolbar locale seven userprotect masquerade smtp logintoboggan
+  drush vset logintoboggan_login_with_email 1
+
+  ## Setup welcome page
+  drush -y scr "$SITE_CONFIG_DIR/install-welcome.php"
+
+  install_civihr
+
+  drush -y en civicrmtheme civihr_employee_portal_features civihr_leave_absences leave_and_absences_features civihr_default_permissions
+  drush -y features-revert civihr_employee_portal_features
+
+  setup_themes
+  create_default_users
+  disabled_unused_blocks
+  create_personal_location_type
+  delete_name_and_address_profile
+
+  ## Create My Details and My Emergency Contact forms
+  drush refresh-node-export-files
+
+  ## Clear the cache
+  drush cc all
+popd >> /dev/null

--- a/app/config/hr17/uninstall.sh
+++ b/app/config/hr17/uninstall.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+## uninstall.sh -- Delete config files and databases
+
+###############################################################################
+
+if [ -f "$CIVI_SETTINGS" ]; then
+  chmod u+w $(dirname "$CIVI_SETTINGS")
+  rm -f "$CIVI_SETTINGS"
+fi
+
+drupal_uninstall
+amp_uninstall

--- a/src/civibuild.aliases.sh
+++ b/src/civibuild.aliases.sh
@@ -76,9 +76,9 @@ function civibuild_alias_resolve() {
 
     hr13)        SITE_TYPE=hrdemo           ; CIVI_VERSION=4.5       ; CMS_TITLE="CiviHR 1.3 Demo"                   ; HR_VERSION=1.3        ;;
     hr14)        SITE_TYPE=hrdemo           ; CIVI_VERSION=4.5       ; CMS_TITLE="CiviHR 1.4 Demo"                   ; HR_VERSION=1.4        ;;
-    hr15)        SITE_TYPE=hr15             ; CIVI_VERSION=4.5       ; CMS_TITLE="CiviHR 1.5 Demo"                   ; HR_VERSION=1.5     ;;
-    hr16)        SITE_TYPE=hr16             ; CIVI_VERSION=4.7.9     ; CMS_TITLE="CiviHR 1.6 Demo"                   ; HR_VERSION=master    ;
-NO_SAMPLE_DATA=1       ;;
+    hr15)        SITE_TYPE=hr15             ; CIVI_VERSION=4.5       ; CMS_TITLE="CiviHR 1.5 Demo"                   ; HR_VERSION=1.5        ;;
+    hr16)        SITE_TYPE=hr16             ; CIVI_VERSION=4.7.9     ; CMS_TITLE="CiviHR 1.6 Demo"                   ; HR_VERSION=master     ; NO_SAMPLE_DATA=1       ;;
+    hr17)        SITE_TYPE=hr17             ; CIVI_VERSION=4.7.18    ; CMS_TITLE="CiviHR 1.7 Demo"                   ; HR_VERSION=master     ; NO_SAMPLE_DATA=1       ;;
     hrmaster)    SITE_TYPE=hr15             ; CIVI_VERSION=master    ; CMS_TITLE="CiviHR Sandbox"                    ; HR_VERSION=master     ;;
 
     bempty)      SITE_TYPE=backdrop-empty   ; CIVI_VERSION=none      ; CMS_TITLE="Backdrop Sandbox"                  ;;


### PR DESCRIPTION
CiviHR 1.7 is just around the corner, and, in preparation for this new release, we'll also need a new build type.

The hr17 build type is pretty much a copy of hr16. The only difference is that it installs the `civihr_leave_absences` and the `leave_and_absences_features` features.

A new hr17 alias was also added and it uses CiviCRM 4.7.18 as it's default version, which is what we're currently using for CiviHR.