### PR TITLE
PCHR-2485: Install yoti with drush on civihr installation

### DIFF
--- a/app/config/hr16/drush.make.tmpl
+++ b/app/config/hr16/drush.make.tmpl
@@ -178,6 +178,9 @@ projects[masquerade][version] = "1.0-rc7"
 projects[logintoboggan][subdir] = civihr-contrib-required
 projects[logintoboggan][version] = "1.5"
 
+projects[yoti][subdir] = civihr-contrib-required
+projects[yoti][version] = "1.4"
+
 ; Patch for pagination
 projects[views_merge_rows][patch][] = "https://www.drupal.org/files/issues/views_merge_rows-views_merge_rows_and_pagination-2188939-3_0.patch"
 projects[views_merge_rows][patch][] = "https://www.drupal.org/files/issues/views_merge_rows-views_merge_rows_pagination-2724691-2.patch"

--- a/app/config/hr16/install.sh
+++ b/app/config/hr16/install.sh
@@ -107,7 +107,20 @@ pushd "${WEB_ROOT}/sites/${DRUPAL_SITE_DIR}" >> /dev/null
 
   drush -y updatedb
   drush -y dis overlay shortcut color
-  drush -y en administerusersbyrole role_delegation subpermissions civicrm toolbar locale seven userprotect masquerade smtp logintoboggan
+  drush -y en \
+    administerusersbyrole \
+    role_delegation \
+    subpermissions \
+    civicrm \
+    toolbar \
+    locale \
+    seven \
+    userprotect \
+    masquerade \
+    smtp \
+    logintoboggan \
+    yoti
+
   drush vset logintoboggan_login_with_email 1
 
   ## Setup welcome page


### PR DESCRIPTION
## Overview
We are using the old version yoti-connect, checked into the civihr-employee-portal codebase. This is harder to maintain and will switch to using `drush` to install the module and also update the version.

## Before
The installation script did not install yoti, it was stored in civihr-employee-portal

## After
Yoti is installed and enabled as part of the civihr installation.

## Notes
It may be confusing that there are sometimes references yoti-connect and other times just 'yoti'. The module was renamed in a later version.
