### PR TITLE
Remove phpunit3, replace with phpunit4 via composer

### DIFF
--- a/bin/civi-download-tools
+++ b/bin/civi-download-tools
@@ -22,7 +22,6 @@ CIVIXURL="https://download.civicrm.org/civix/civix.phar-2017-10-09-650c46da"
 CVURL="https://download.civicrm.org/cv/cv.phar-2017-10-02-2c279c8e"
 HUB_VERSION="2.2.9"
 DRUSH8URL=http://files.drush.org/drush.phar
-PHPUNITURL=https://phar.phpunit.de/phpunit-4.8.21.phar
 WPCLIURL=https://github.com/wp-cli/wp-cli/releases/download/v1.3.0/wp-cli-1.3.0.phar
 GITSCANURL="https://download.civicrm.org/git-scan/git-scan.phar-2017-06-28-101620c7"
 AMPURL="https://download.civicrm.org/amp/amp.phar-2017-10-09-92650fb0"
@@ -550,7 +549,6 @@ pushd $PRJDIR >> /dev/null
   ## download_program_if_changed <url> <out-file> <flag-file>
   download_program_if_changed "$DRUSH8URL" "$PRJDIR/bin/drush8" "$PRJDIR/extern/drush8.txt"
   download_program_if_changed "$CVURL" "$PRJDIR/bin/cv" "$PRJDIR/extern/cv.txt"
-  download_program_if_changed "$PHPUNITURL" "$PRJDIR/bin/phpunit4" "$PRJDIR/extern/phpunit4.txt"
   download_program_if_changed "$WPCLIURL" "$PRJDIR/bin/wp" "$PRJDIR/extern/wp-cli.txt"
   download_program_if_changed "$GITSCANURL" "$PRJDIR/bin/git-scan" "$PRJDIR/extern/git-scan.txt"
   download_program_if_changed "$AMPURL" "$PRJDIR/bin/amp" "$PRJDIR/extern/amp.txt"

--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,8 @@
     "civicrm/upgrade-test": "dev-master#8747e21bfb0e4c57c539fb265070267b1e8662b4",
     "drupal/coder": "dev-8.x-2.x-civi#a801890a82d52e23a83c5d820270b6e228843d79",
     "brianium/paratest": "dev-batching as 0.7",
-    "phpunit/phpunit": "3.7.27",
-    "phpunit/dbunit": "1.3.x",
+    "phpunit/phpunit": "4.8.x",
+    "phpunit/dbunit": "1.4.x",
     "phpunit/phpunit-selenium": "1.2.x",
     "squizlabs/PHP_CodeSniffer": ">=2"
   },


### PR DESCRIPTION
As discussed with @totten on chat.civicrm.org.  Remote phpunit "just works" with phpstorm when phpunit4 is installed via composer.  But I've been unable to get it working at all with phpunit3 via composer.
There doesn't seem to be any good reason to have two versions available.
It's a testing tool, so worst case a unit test breaks, that won't immediately affect the end-user so I think we can cope with that.