### PR TITLE
PCHR-2548: Install ckeditor module for CiviHR

### DIFF
--- a/app/config/hr16/drush.make.tmpl
+++ b/app/config/hr16/drush.make.tmpl
@@ -181,9 +181,6 @@ projects[logintoboggan][version] = "1.5"
 projects[yoti][subdir] = civihr-contrib-required
 projects[yoti][version] = "1.4"
 
-projects[ckeditor][subdir] = civihr-contrib-required
-projects[ckeditor][version] = "1.18"
-
 ; Patch for pagination
 projects[views_merge_rows][patch][] = "https://www.drupal.org/files/issues/views_merge_rows-views_merge_rows_and_pagination-2188939-3_0.patch"
 projects[views_merge_rows][patch][] = "https://www.drupal.org/files/issues/views_merge_rows-views_merge_rows_pagination-2724691-2.patch"

--- a/app/config/hr16/drush.make.tmpl
+++ b/app/config/hr16/drush.make.tmpl
@@ -181,6 +181,9 @@ projects[logintoboggan][version] = "1.5"
 projects[yoti][subdir] = civihr-contrib-required
 projects[yoti][version] = "1.4"
 
+projects[ckeditor][subdir] = civihr-contrib-required
+projects[ckeditor][version] = "1.18"
+
 ; Patch for pagination
 projects[views_merge_rows][patch][] = "https://www.drupal.org/files/issues/views_merge_rows-views_merge_rows_and_pagination-2188939-3_0.patch"
 projects[views_merge_rows][patch][] = "https://www.drupal.org/files/issues/views_merge_rows-views_merge_rows_pagination-2724691-2.patch"

--- a/app/config/hr16/install.sh
+++ b/app/config/hr16/install.sh
@@ -122,6 +122,7 @@ pushd "${WEB_ROOT}/sites/${DRUPAL_SITE_DIR}" >> /dev/null
     yoti
 
   drush vset logintoboggan_login_with_email 1
+  drush vset --format=integer node_export_reset_path_webform 0
 
   ## Setup welcome page
   drush -y scr "$SITE_CONFIG_DIR/install-welcome.php"

--- a/app/config/hr16/install.sh
+++ b/app/config/hr16/install.sh
@@ -119,8 +119,7 @@ pushd "${WEB_ROOT}/sites/${DRUPAL_SITE_DIR}" >> /dev/null
     masquerade \
     smtp \
     logintoboggan \
-    yoti \
-    ckeditor
+    yoti
 
   drush vset logintoboggan_login_with_email 1
   drush vset --format=integer node_export_reset_path_webform 0

--- a/app/config/hr16/install.sh
+++ b/app/config/hr16/install.sh
@@ -119,7 +119,8 @@ pushd "${WEB_ROOT}/sites/${DRUPAL_SITE_DIR}" >> /dev/null
     masquerade \
     smtp \
     logintoboggan \
-    yoti
+    yoti \
+    ckeditor
 
   drush vset logintoboggan_login_with_email 1
   drush vset --format=integer node_export_reset_path_webform 0


### PR DESCRIPTION
## Overview

As part of the requirements for the CiviHR onboarding wizard the wizard configuration screen will use a WYSIWYG editor to edit the welcome text. The CKEditor is one of the most popular and its Drupal module will be added as part of this PR

Another small change is to change a setting for node import. By default webform aliases are not imported, but since a feature related to onboarding required a hardcoded URL for the webform they must be.

## Before

The hr16 build did not include the CKEditor. 

Webform node imports did not import the URL alias.

## After

The hr16 build installs the Drupal ckeditor module.

Webform node imports also import the URL alias.