### PR TITLE
civi-test-run - Accept a list of multiple suites

### DIFF
--- a/bin/civi-test-run
+++ b/bin/civi-test-run
@@ -93,28 +93,11 @@ function task_upgrade() {
 }
 
 #################################################
-## Parse inputs
-
-if [ -z $1 ]; then
-  echo "Missing argument: <build-name>"
-  echo
-  show_help
-  exit 2
-fi
-
-if [ -z $2 ]; then
-  echo "Missing argument: <junit-output-dir>"
-  echo
-  show_help
-  exit 2
-fi
-
-if [ -z $3 ]; then
-  echo "Missing argument: <test-type>"
-  echo
-  show_help
-  exit 2
-fi
+## Cleanup left-overs from previous test-runs
+function junit_cleanup() {
+  [ -d "$JUNITDIR" ] && $GUARD rm -rf "$JUNITDIR"
+  [ ! -d "$JUNITDIR" ] && $GUARD mkdir "$JUNITDIR"
+}
 
 ## Determine the absolute path of the directory with the file
 ## absdirname <file-path>
@@ -126,35 +109,62 @@ function absdirname() {
 
 BINDIR=$(absdirname "$0")
 PRJDIR=$(dirname "$BINDIR")
-BLDNAME="$1"
-BLDDIR="$PRJDIR/build/$BLDNAME"
-CIVI_CORE="$BLDDIR/sites/all/modules/civicrm"
-JUNITDIR="$2"
-TESTTYPE="$3"
 EXITCODES=
 GUARD=
 
 #################################################
-## Cleanup left-overs from previous test-runs
-[ -d "$JUNITDIR" ] && $GUARD rm -rf "$JUNITDIR"
-[ ! -d "$JUNITDIR" ] && $GUARD mkdir "$JUNITDIR"
+## Main
+function run_tests() {
+  ## Run Karma tests if requested Javascript
+  if [ $TESTTYPE = "karma" ] || [ $TESTTYPE = "all" ] ; then
+    task_karma
+  fi
+
+  ## Run Upgrade test if requested
+  if [ $TESTTYPE = "upgrade" ] || [ $TESTTYPE = "all" ] ; then
+    task_upgrade
+  fi
+
+  if [ $TESTTYPE != "upgrade" ] && [ $TESTTYPE != "karma" ] ; then
+    task_phpunit
+  fi
+}
+
 
 #################################################
-## Main
+## Parse inputs
+while [ -n "$1" ] ; do
+  if [ $1 = "-b" ] || [ $1 = "-j" ] ; then
+    OPTION="$1"
+    shift
 
-## Run Karma tests if requested Javascript
-if [ $TESTTYPE = "karma" ] || [ $TESTTYPE = "all" ] ; then
-  task_karma
-fi
+    case "$OPTION" in
+      #-h|--help|-?)
+      #  show_help
+      #  exit 2
+      #  ;;
 
-## Run Upgrade test if requested
-if [ $TESTTYPE = "upgrade" ] || [ $TESTTYPE = "all" ] ; then
-  task_upgrade
-fi
+      -b)
+        BLDNAME="$1"
+        BLDDIR="$PRJDIR/build/$BLDNAME"
+        CIVI_CORE="$BLDDIR/sites/all/modules/civicrm"
+        shift
+        ;;
 
-if [ $TESTTYPE != "upgrade" ] && [ $TESTTYPE != "karma" ] ; then
-  task_phpunit
-fi
+      -j)
+        JUNITDIR="$1"
+        junit_cleanup
+        shift
+        ;;
+
+    esac
+
+  else
+    TESTTYPE="$1"
+    run_tests
+    shift
+  fi
+done
 
 ## Check test results and set exit code
 echo "Check test results and set exit code"

--- a/bin/civi-test-run
+++ b/bin/civi-test-run
@@ -110,6 +110,7 @@ function absdirname() {
 BINDIR=$(absdirname "$0")
 PRJDIR=$(dirname "$BINDIR")
 EXITCODES=
+SUITES=
 GUARD=
 
 #################################################
@@ -159,10 +160,22 @@ while [ -n "$1" ] ; do
     exit 2
 
   else
-    TESTTYPE="$1"
-    run_tests
+    SUITES="$SUITES $1"
     shift
   fi
+done
+
+## Validate
+if [ -z "$SUITES" -o -z "$BLDNAME" -o -z "$JUNITDIR" ]; then
+  echo "Error: Missing required argument"
+  echo
+  show_help
+  exit 2
+fi
+
+## Main
+for TESTTYPE in $SUITES ; do
+  run_tests
 done
 
 ## Check test results and set exit code

--- a/bin/civi-test-run
+++ b/bin/civi-test-run
@@ -198,23 +198,25 @@ done
 echo "Check test results and set exit code"
 cat "$JUNITDIR"/*.xml | grep '<failure' -q && fatal "Found <failure> in XML"
 cat "$JUNITDIR"/*.xml | grep '<error' -q && fatal "Found <error> in XML"
-if  [ $TESTTYPE = "upgrade" ] || [ $TESTTYPE = "all" ] ; then
-  [ ! -f "$JUNITDIR/civicrm-upgrade-test.xml" ] && fatal "Missing XML: civicrm-upgrade-test.xml"
-fi
-if  [ $TESTTYPE = "phpunit-crm" ] || [ $TESTTYPE = "all" ] ; then
-  [ ! -f "$JUNITDIR/CRM_AllTests.xml" ] && fatal "Missing XML: CRM_AllTests.xml"
-fi 
-if  [ $TESTTYPE = "phpunit-api" ] || [ $TESTTYPE = "all" ] ; then
-  [ ! -f "$JUNITDIR/api_v3_AllTests.xml" ] && fatal "Missing XML: api_v3_AllTests.xml"
-fi
-if  [ $TESTTYPE = "phpunit-civi" ] || [ $TESTTYPE = "all" ] ; then
-  [ ! -f "$JUNITDIR/Civi\\AllTests.xml" ] && fatal "Missing XML: Civi\\AllTests.xml"
-fi
-if  [ $TESTTYPE = "phpunit-e2e" ] || [ $TESTTYPE = "all" ] ; then
-  [ ! -f "$JUNITDIR/E2E_AllTests.xml" ] && fatal "Missing XML: E2E_AllTests.xml"
-fi
-if  [ $TESTTYPE = "karma" ] || [ $TESTTYPE = "all" ] ; then
-  [ -d "$CIVI_CORE/tests/karma" -a ! -f "$JUNITDIR/karma.xml" ] && fatal "Missing XML: karma.xml"
+for TESTTYPE in $SUITES ; do
+  if  [ $TESTTYPE = "upgrade" ] || [ $TESTTYPE = "all" ] ; then
+    [ ! -f "$JUNITDIR/civicrm-upgrade-test.xml" ] && fatal "Missing XML: civicrm-upgrade-test.xml"
+  fi
+  if  [ $TESTTYPE = "phpunit-crm" ] || [ $TESTTYPE = "all" ] ; then
+    [ ! -f "$JUNITDIR/CRM_AllTests.xml" ] && fatal "Missing XML: CRM_AllTests.xml"
+  fi
+  if  [ $TESTTYPE = "phpunit-api" ] || [ $TESTTYPE = "all" ] ; then
+    [ ! -f "$JUNITDIR/api_v3_AllTests.xml" ] && fatal "Missing XML: api_v3_AllTests.xml"
+  fi
+  if  [ $TESTTYPE = "phpunit-civi" ] || [ $TESTTYPE = "all" ] ; then
+    [ ! -f "$JUNITDIR/Civi\\AllTests.xml" ] && fatal "Missing XML: Civi\\AllTests.xml"
+  fi
+  if  [ $TESTTYPE = "phpunit-e2e" ] || [ $TESTTYPE = "all" ] ; then
+    [ ! -f "$JUNITDIR/E2E_AllTests.xml" ] && fatal "Missing XML: E2E_AllTests.xml"
+  fi
+  if  [ $TESTTYPE = "karma" ] || [ $TESTTYPE = "all" ] ; then
+    [ -d "$CIVI_CORE/tests/karma" -a ! -f "$JUNITDIR/karma.xml" ] && fatal "Missing XML: karma.xml"
+  fi
 fi
 [ -n "$EXITCODES" ] && fatal "At least one command failed abnormally [$EXITCODES]"
 echo "Exit normally"

--- a/bin/civi-test-run
+++ b/bin/civi-test-run
@@ -23,8 +23,24 @@ function getCiviVer() {
 function show_help() {
   PROG=$(basename "$0")
   echo "about: Execute the CiviCRM test suites"
-  echo "usage: $PROG -b <build-name> -j <junit-output-dir> <test-types>"
-  echo "test-types is one or more of: all, karma, upgrade, phpunit-civi, phpunit-crm, phpunit-api, phpunit-e2e"
+  echo
+  echo "usage: $PROG [-h] -b <build-name> -j <junit-output-dir> <test-types>"
+  echo
+  echo "  -h                  Display help"
+  echo "  -b <build-name>     The name of a local site produced by civibuild"
+  echo "  -j <junit-dir>      The path to a folder for storing results in JUnit XML"
+  echo "  <test-types>        A list of one more of the following:"
+  echo "                        - all"
+  echo "                        - karma"
+  echo "                        - phpunit-api"
+  echo "                        - phpunit-civi"
+  echo "                        - phpunit-crm"
+  echo "                        - phpunit-e2e"
+  echo "                        - upgrade"
+  echo
+  echo "example: Run the KarmaJS and DB-upgrade tests on D7/Civi-Master build"
+  echo "  $PROG -b dmaster -j /tmp/junit-output karma upgrade"
+  echo
 }
 
 #################################################

--- a/bin/civi-test-run
+++ b/bin/civi-test-run
@@ -23,8 +23,8 @@ function getCiviVer() {
 function show_help() {
   PROG=$(basename "$0")
   echo "about: Execute the CiviCRM test suites"
-  echo "usage: $PROG <build-name> <junit-output-dir> <test-type>"
-  echo "test-type is one of all, karma, upgrade, phpunit-civi, phpunit-crm, phpunit-api, phpunit-e2e"
+  echo "usage: $PROG -b <build-name> -j <junit-output-dir> <test-types>"
+  echo "test-types is one or more of: all, karma, upgrade, phpunit-civi, phpunit-crm, phpunit-api, phpunit-e2e"
 }
 
 #################################################
@@ -139,11 +139,6 @@ while [ -n "$1" ] ; do
     shift
 
     case "$OPTION" in
-      #-h|--help|-?)
-      #  show_help
-      #  exit 2
-      #  ;;
-
       -b)
         BLDNAME="$1"
         BLDDIR="$PRJDIR/build/$BLDNAME"
@@ -158,6 +153,10 @@ while [ -n "$1" ] ; do
         ;;
 
     esac
+
+  elif [ $1 = "-h" ] || [ $1 = "--help" ] || [ $1 = "-?" ] ; then
+    show_help
+    exit 2
 
   else
     TESTTYPE="$1"


### PR DESCRIPTION
@totten local testing suggests this is doing sensible things. in that if i tell it to run something like 

```civi-test-run -b 47.demo -j /home/seamus/junit karma phpunit-e2e phpunit-civi``` it only runs karma phpunit-e2e phpunit-civi and it does appear to clean out the junit dir as well

Let me know if i need to do anything more but i think this will make it more suitable for Jenkins