### PR TITLE
package.json - Update phantomjs for compat with OSX Sierra

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "karma-jasmine": "~0.3.2",
     "karma-junit-reporter": "~0.2.2",
     "karma-ng-html2js-preprocessor": "~0.1.2",
-    "karma-phantomjs-launcher": "~0.1.4",
+    "karma-phantomjs-launcher": "~1.0.2",
     "protractor": "^4.0.10",
     "watch": "^1.0.1"
   }


### PR DESCRIPTION
Karma and PhantomJS are failing on OSX Sierra: https://github.com/karma-runner/karma-phantomjs-launcher/issues/138

Before merging this, we should (at minimum) test to see if this installs
correctly on `ubu1204`.  If we could try another variant of OSX, that would
also be ideal.