### PR TITLE
WMFF config: add extensions directory to civicrm.settings.php

### DIFF
--- a/app/config/wmff/install.sh
+++ b/app/config/wmff/install.sh
@@ -32,6 +32,8 @@ CIVI_TEMPLATEC="${CIVI_FILES}/templates_c"
 CIVI_UF="Drupal"
 
 civicrm_install
+echo "global \$civicrm_setting;" >> "${WEB_ROOT}/sites/default/civicrm.settings.php"
+echo "\$civicrm_setting['Directory Preferences']['extensionsDir'] = '${WEB_ROOT}/sites/default/civicrm/extensions';" >> "${WEB_ROOT}/sites/default/civicrm.settings.php"
 
 ###############################################################################
 ## Extra configuration


### PR DESCRIPTION
Pretty ugly, but it does the trick in our CI when other attempts fail.

There's got to be a better way to do this, right?