### PR TITLE
PCHR-2783: Disable Drupal user images

### DIFF
--- a/app/config/hr16/install.sh
+++ b/app/config/hr16/install.sh
@@ -122,6 +122,7 @@ pushd "${WEB_ROOT}/sites/${DRUPAL_SITE_DIR}" >> /dev/null
     yoti
 
   drush vset logintoboggan_login_with_email 1
+  drush vset --format=integer user_pictures 0
 
   ## Setup welcome page
   drush -y scr "$SITE_CONFIG_DIR/install-welcome.php"

--- a/app/config/hr17/install.sh
+++ b/app/config/hr17/install.sh
@@ -107,8 +107,22 @@ pushd "${WEB_ROOT}/sites/${DRUPAL_SITE_DIR}" >> /dev/null
 
   drush -y updatedb
   drush -y dis overlay shortcut color
-  drush -y en administerusersbyrole role_delegation subpermissions civicrm toolbar locale seven userprotect masquerade smtp logintoboggan
+  drush -y en \
+    administerusersbyrole \
+    role_delegation \
+    subpermissions \
+    civicrm \
+    toolbar \
+    locale \
+    seven \
+    userprotect \
+    masquerade \
+    smtp \
+    logintoboggan \
+    yoti
+
   drush vset logintoboggan_login_with_email 1
+  drush vset --format=integer user_pictures 0
 
   ## Setup welcome page
   drush -y scr "$SITE_CONFIG_DIR/install-welcome.php"


### PR DESCRIPTION
## Before

On installation Drupal user images were enabled and could be modified from the user edit page

## After

- Drupal images are disabled. 
- The hr17 script is up to date with changes from hr16