### PR TITLE
Sort drush.make "libraries[]"

### DIFF
--- a/app/config/doctrine/drush.make.tmpl
+++ b/app/config/doctrine/drush.make.tmpl
@@ -22,6 +22,13 @@ projects[] = drupal
 ; This will make it easier to submit pull-requests for patches.
 ; see: http://wiki.civicrm.org/confluence/display/CRMDOC/Github+for+CiviCRM
 
+libraries[civicrm][destination] = modules
+libraries[civicrm][directory_name] = civicrm
+libraries[civicrm][download][type] = git
+libraries[civicrm][download][url] = %%CACHE_DIR%%/civicrm/civicrm-core.git
+libraries[civicrm][download][branch] = doctrine
+libraries[civicrm][overwrite] = TRUE
+
 libraries[civicrmdrupal][destination] = modules
 libraries[civicrmdrupal][directory_name] = civicrm/drupal
 libraries[civicrmdrupal][download][type] = git
@@ -36,13 +43,6 @@ libraries[civicrmpackages][download][url] = %%CACHE_DIR%%/civicrm/civicrm-packag
 libraries[civicrmpackages][download][branch] = %%CIVI_VERSION%%
 libraries[civicrmpackages][overwrite] = TRUE
 
-; Download available l10n releases (may be outdated)
-; libraries[civicrm_l10n][destination] = modules
-; libraries[civicrm_l10n][directory_name] = civicrm/l10n/fr_CA/LC_MESSAGES/
-; libraries[civicrm_l10n][download][type] = get
-; libraries[civicrm_l10n][download][url] = "https://raw.github.com/civicrm/l10n/master/po/fr_CA/civicrm.mo"
-; libraries[civicrm_l10n][overwrite] = TRUE
-
 ; Overwrite .mo files with latest versions
 ; libraries[civicrm_l10n_latest][destination] = modules
 ; libraries[civicrm_l10n_latest][directory_name] = civicrm/l10n
@@ -50,12 +50,12 @@ libraries[civicrmpackages][overwrite] = TRUE
 ; libraries[civicrm_l10n_latest][download][url] = http://download.civicrm.org/civicrm-l10n-core/archives/civicrm-l10n-daily.tar.gz
 ; libraries[civicrm_l10n_latest][overwrite] = TRUE
 
-libraries[civicrm][destination] = modules
-libraries[civicrm][directory_name] = civicrm
-libraries[civicrm][download][type] = git
-libraries[civicrm][download][url] = %%CACHE_DIR%%/civicrm/civicrm-core.git
-libraries[civicrm][download][branch] = doctrine
-libraries[civicrm][overwrite] = TRUE
+; Download available l10n releases (may be outdated)
+; libraries[civicrm_l10n][destination] = modules
+; libraries[civicrm_l10n][directory_name] = civicrm/l10n/fr_CA/LC_MESSAGES/
+; libraries[civicrm_l10n][download][type] = get
+; libraries[civicrm_l10n][download][url] = "https://raw.github.com/civicrm/l10n/master/po/fr_CA/civicrm.mo"
+; libraries[civicrm_l10n][overwrite] = TRUE
 
 ; ****************************************
 ; Runtime Modules

--- a/app/config/drupal-case/drush.make.tmpl
+++ b/app/config/drupal-case/drush.make.tmpl
@@ -22,6 +22,13 @@ projects[] = drupal
 ; This will make it easier to submit pull-requests for patches.
 ; see: http://wiki.civicrm.org/confluence/display/CRMDOC/Github+for+CiviCRM
 
+libraries[civicrm][destination] = modules
+libraries[civicrm][directory_name] = civicrm
+libraries[civicrm][download][type] = git
+libraries[civicrm][download][url] = %%CACHE_DIR%%/civicrm/civicrm-core.git
+libraries[civicrm][download][branch] = %%CIVI_VERSION%%
+libraries[civicrm][overwrite] = TRUE
+
 libraries[civicrmdrupal][destination] = modules
 libraries[civicrmdrupal][directory_name] = civicrm/drupal
 libraries[civicrmdrupal][download][type] = git
@@ -36,13 +43,6 @@ libraries[civicrmpackages][download][url] = %%CACHE_DIR%%/civicrm/civicrm-packag
 libraries[civicrmpackages][download][branch] = %%CIVI_VERSION%%
 libraries[civicrmpackages][overwrite] = TRUE
 
-; Download available l10n releases (may be outdated)
-; libraries[civicrm_l10n][destination] = modules
-; libraries[civicrm_l10n][directory_name] = civicrm/l10n/fr_CA/LC_MESSAGES/
-; libraries[civicrm_l10n][download][type] = get
-; libraries[civicrm_l10n][download][url] = "https://raw.github.com/civicrm/l10n/master/po/fr_CA/civicrm.mo"
-; libraries[civicrm_l10n][overwrite] = TRUE
-
 ; Overwrite .mo files with latest versions
 libraries[civicrm_l10n_latest][destination] = modules
 libraries[civicrm_l10n_latest][directory_name] = civicrm/l10n
@@ -50,12 +50,12 @@ libraries[civicrm_l10n_latest][download][type] = get
 libraries[civicrm_l10n_latest][download][url] = http://download.civicrm.org/civicrm-l10n-core/archives/civicrm-l10n-daily.tar.gz
 libraries[civicrm_l10n_latest][overwrite] = TRUE
 
-libraries[civicrm][destination] = modules
-libraries[civicrm][directory_name] = civicrm
-libraries[civicrm][download][type] = git
-libraries[civicrm][download][url] = %%CACHE_DIR%%/civicrm/civicrm-core.git
-libraries[civicrm][download][branch] = %%CIVI_VERSION%%
-libraries[civicrm][overwrite] = TRUE
+; Download available l10n releases (may be outdated)
+; libraries[civicrm_l10n][destination] = modules
+; libraries[civicrm_l10n][directory_name] = civicrm/l10n/fr_CA/LC_MESSAGES/
+; libraries[civicrm_l10n][download][type] = get
+; libraries[civicrm_l10n][download][url] = "https://raw.github.com/civicrm/l10n/master/po/fr_CA/civicrm.mo"
+; libraries[civicrm_l10n][overwrite] = TRUE
 
 ; ****************************************
 ; Runtime Modules

--- a/app/config/drupal-clean/drush.make.tmpl
+++ b/app/config/drupal-clean/drush.make.tmpl
@@ -22,6 +22,13 @@ projects[] = drupal
 ; This will make it easier to submit pull-requests for patches.
 ; see: http://wiki.civicrm.org/confluence/display/CRMDOC/Github+for+CiviCRM
 
+libraries[civicrm][destination] = modules
+libraries[civicrm][directory_name] = civicrm
+libraries[civicrm][download][type] = git
+libraries[civicrm][download][url] = %%CACHE_DIR%%/civicrm/civicrm-core.git
+libraries[civicrm][download][branch] = %%CIVI_VERSION%%
+libraries[civicrm][overwrite] = TRUE
+
 libraries[civicrmdrupal][destination] = modules
 libraries[civicrmdrupal][directory_name] = civicrm/drupal
 libraries[civicrmdrupal][download][type] = git
@@ -49,13 +56,6 @@ libraries[civicrmpackages][overwrite] = TRUE
 ; libraries[civicrm_l10n_latest][download][type] = get
 ; libraries[civicrm_l10n_latest][download][url] = http://download.civicrm.org/civicrm-l10n-core/archives/civicrm-l10n-daily.tar.gz
 ; libraries[civicrm_l10n_latest][overwrite] = TRUE
-
-libraries[civicrm][destination] = modules
-libraries[civicrm][directory_name] = civicrm
-libraries[civicrm][download][type] = git
-libraries[civicrm][download][url] = %%CACHE_DIR%%/civicrm/civicrm-core.git
-libraries[civicrm][download][branch] = %%CIVI_VERSION%%
-libraries[civicrm][overwrite] = TRUE
 
 ; ****************************************
 ; Runtime Modules

--- a/app/config/drupal-clean/drush.make.tmpl
+++ b/app/config/drupal-clean/drush.make.tmpl
@@ -43,19 +43,19 @@ libraries[civicrmpackages][download][url] = %%CACHE_DIR%%/civicrm/civicrm-packag
 libraries[civicrmpackages][download][branch] = %%CIVI_VERSION%%
 libraries[civicrmpackages][overwrite] = TRUE
 
-; Download available l10n releases (may be outdated)
-; libraries[civicrm_l10n][destination] = modules
-; libraries[civicrm_l10n][directory_name] = civicrm/l10n/fr_CA/LC_MESSAGES/
-; libraries[civicrm_l10n][download][type] = get
-; libraries[civicrm_l10n][download][url] = "https://raw.github.com/civicrm/l10n/master/po/fr_CA/civicrm.mo"
-; libraries[civicrm_l10n][overwrite] = TRUE
-
 ; Overwrite .mo files with latest versions
 ; libraries[civicrm_l10n_latest][destination] = modules
 ; libraries[civicrm_l10n_latest][directory_name] = civicrm/l10n
 ; libraries[civicrm_l10n_latest][download][type] = get
 ; libraries[civicrm_l10n_latest][download][url] = http://download.civicrm.org/civicrm-l10n-core/archives/civicrm-l10n-daily.tar.gz
 ; libraries[civicrm_l10n_latest][overwrite] = TRUE
+
+; Download available l10n releases (may be outdated)
+; libraries[civicrm_l10n][destination] = modules
+; libraries[civicrm_l10n][directory_name] = civicrm/l10n/fr_CA/LC_MESSAGES/
+; libraries[civicrm_l10n][download][type] = get
+; libraries[civicrm_l10n][download][url] = "https://raw.github.com/civicrm/l10n/master/po/fr_CA/civicrm.mo"
+; libraries[civicrm_l10n][overwrite] = TRUE
 
 ; ****************************************
 ; Runtime Modules

--- a/app/config/drupal-clean42/drush.make.tmpl
+++ b/app/config/drupal-clean42/drush.make.tmpl
@@ -22,6 +22,13 @@ projects[] = drupal
 ; This will make it easier to submit pull-requests for patches.
 ; see: http://wiki.civicrm.org/confluence/display/CRMDOC/Github+for+CiviCRM
 
+libraries[civicrm][destination] = modules
+libraries[civicrm][directory_name] = civicrm
+libraries[civicrm][download][type] = git
+libraries[civicrm][download][url] = %%CACHE_DIR%%/CiviCRM42/civicrm42-core.git
+libraries[civicrm][download][branch] = %%CIVI_VERSION%%
+libraries[civicrm][overwrite] = TRUE
+
 libraries[civicrmdrupal][destination] = modules
 libraries[civicrmdrupal][directory_name] = civicrm/drupal
 libraries[civicrmdrupal][download][type] = git
@@ -36,13 +43,6 @@ libraries[civicrmpackages][download][url] = %%CACHE_DIR%%/CiviCRM42/civicrm42-pa
 libraries[civicrmpackages][download][branch] = %%CIVI_VERSION%%
 libraries[civicrmpackages][overwrite] = TRUE
 
-; Download available l10n releases (may be outdated)
-; libraries[civicrm_l10n][destination] = modules
-; libraries[civicrm_l10n][directory_name] = civicrm/l10n/fr_CA/LC_MESSAGES/
-; libraries[civicrm_l10n][download][type] = get
-; libraries[civicrm_l10n][download][url] = "https://raw.github.com/civicrm/l10n/master/po/fr_CA/civicrm.mo"
-; libraries[civicrm_l10n][overwrite] = TRUE
-
 ; Overwrite .mo files with latest version from SVN
 ; libraries[civicrm_l10n_latest][destination] = modules
 ; libraries[civicrm_l10n_latest][directory_name] = civicrm/l10n
@@ -50,12 +50,12 @@ libraries[civicrmpackages][overwrite] = TRUE
 ; libraries[civicrm_l10n_latest][download][url] = http://svn.civicrm.org/l10n/trunk/
 ; libraries[civicrm_l10n_latest][overwrite] = TRUE
 
-libraries[civicrm][destination] = modules
-libraries[civicrm][directory_name] = civicrm
-libraries[civicrm][download][type] = git
-libraries[civicrm][download][url] = %%CACHE_DIR%%/CiviCRM42/civicrm42-core.git
-libraries[civicrm][download][branch] = %%CIVI_VERSION%%
-libraries[civicrm][overwrite] = TRUE
+; Download available l10n releases (may be outdated)
+; libraries[civicrm_l10n][destination] = modules
+; libraries[civicrm_l10n][directory_name] = civicrm/l10n/fr_CA/LC_MESSAGES/
+; libraries[civicrm_l10n][download][type] = get
+; libraries[civicrm_l10n][download][url] = "https://raw.github.com/civicrm/l10n/master/po/fr_CA/civicrm.mo"
+; libraries[civicrm_l10n][overwrite] = TRUE
 
 ; ****************************************
 ; Runtime Modules

--- a/app/config/drupal-demo/drush.make.tmpl
+++ b/app/config/drupal-demo/drush.make.tmpl
@@ -43,13 +43,6 @@ libraries[civicrmpackages][download][url] = %%CACHE_DIR%%/civicrm/civicrm-packag
 libraries[civicrmpackages][download][branch] = %%CIVI_VERSION%%
 libraries[civicrmpackages][overwrite] = TRUE
 
-; Download available l10n releases (may be outdated)
-; libraries[civicrm_l10n][destination] = modules
-; libraries[civicrm_l10n][directory_name] = civicrm/l10n/fr_CA/LC_MESSAGES/
-; libraries[civicrm_l10n][download][type] = get
-; libraries[civicrm_l10n][download][url] = "https://raw.github.com/civicrm/l10n/master/po/fr_CA/civicrm.mo"
-; libraries[civicrm_l10n][overwrite] = TRUE
-
 ; Overwrite .mo files with latest versions
 libraries[civicrm_l10n_latest][destination] = modules
 libraries[civicrm_l10n_latest][directory_name] = civicrm/l10n
@@ -57,6 +50,12 @@ libraries[civicrm_l10n_latest][download][type] = get
 libraries[civicrm_l10n_latest][download][url] = http://download.civicrm.org/civicrm-l10n-core/archives/civicrm-l10n-daily.tar.gz
 libraries[civicrm_l10n_latest][overwrite] = TRUE
 
+; Download available l10n releases (may be outdated)
+; libraries[civicrm_l10n][destination] = modules
+; libraries[civicrm_l10n][directory_name] = civicrm/l10n/fr_CA/LC_MESSAGES/
+; libraries[civicrm_l10n][download][type] = get
+; libraries[civicrm_l10n][download][url] = "https://raw.github.com/civicrm/l10n/master/po/fr_CA/civicrm.mo"
+; libraries[civicrm_l10n][overwrite] = TRUE
 
 ; ****************************************
 ; Runtime Modules

--- a/app/config/drupal-demo/drush.make.tmpl
+++ b/app/config/drupal-demo/drush.make.tmpl
@@ -22,6 +22,13 @@ projects[] = drupal
 ; This will make it easier to submit pull-requests for patches.
 ; see: http://wiki.civicrm.org/confluence/display/CRMDOC/Github+for+CiviCRM
 
+libraries[civicrm][destination] = modules
+libraries[civicrm][directory_name] = civicrm
+libraries[civicrm][download][type] = git
+libraries[civicrm][download][url] = %%CACHE_DIR%%/civicrm/civicrm-core.git
+libraries[civicrm][download][branch] = %%CIVI_VERSION%%
+libraries[civicrm][overwrite] = TRUE
+
 libraries[civicrmdrupal][destination] = modules
 libraries[civicrmdrupal][directory_name] = civicrm/drupal
 libraries[civicrmdrupal][download][type] = git
@@ -50,12 +57,6 @@ libraries[civicrm_l10n_latest][download][type] = get
 libraries[civicrm_l10n_latest][download][url] = http://download.civicrm.org/civicrm-l10n-core/archives/civicrm-l10n-daily.tar.gz
 libraries[civicrm_l10n_latest][overwrite] = TRUE
 
-libraries[civicrm][destination] = modules
-libraries[civicrm][directory_name] = civicrm
-libraries[civicrm][download][type] = git
-libraries[civicrm][download][url] = %%CACHE_DIR%%/civicrm/civicrm-core.git
-libraries[civicrm][download][branch] = %%CIVI_VERSION%%
-libraries[civicrm][overwrite] = TRUE
 
 ; ****************************************
 ; Runtime Modules

--- a/app/config/hr15/drush.make.tmpl
+++ b/app/config/hr15/drush.make.tmpl
@@ -22,6 +22,13 @@ projects[] = drupal
 ; This will make it easier to submit pull-requests for patches.
 ; see: http://wiki.civicrm.org/confluence/display/CRMDOC/Github+for+CiviCRM
 
+libraries[civicrm][destination] = modules
+libraries[civicrm][directory_name] = civicrm
+libraries[civicrm][download][type] = git
+libraries[civicrm][download][url] = %%CACHE_DIR%%/civicrm/civicrm-core.git
+libraries[civicrm][download][branch] = %%CIVI_VERSION%%
+libraries[civicrm][overwrite] = TRUE
+
 libraries[civicrmdrupal][destination] = modules
 libraries[civicrmdrupal][directory_name] = civicrm/drupal
 libraries[civicrmdrupal][download][type] = git
@@ -46,13 +53,6 @@ libraries[civihr][download][url] = %%CACHE_DIR%%/civicrm/civihr.git
 libraries[civihr][download][branch] = %%HR_VERSION%%
 libraries[civihr][overwrite] = TRUE
 
-; Download available l10n releases (may be outdated)
-; libraries[civicrm_l10n][destination] = modules
-; libraries[civicrm_l10n][directory_name] = civicrm/l10n/fr_CA/LC_MESSAGES/
-; libraries[civicrm_l10n][download][type] = get
-; libraries[civicrm_l10n][download][url] = "https://raw.github.com/civicrm/l10n/master/po/fr_CA/civicrm.mo"
-; libraries[civicrm_l10n][overwrite] = TRUE
-
 ; Overwrite .mo files with latest version from SVN
 ; libraries[civicrm_l10n_latest][destination] = modules
 ; libraries[civicrm_l10n_latest][directory_name] = civicrm/l10n
@@ -60,12 +60,12 @@ libraries[civihr][overwrite] = TRUE
 ; libraries[civicrm_l10n_latest][download][url] = http://svn.civicrm.org/l10n/trunk/
 ; libraries[civicrm_l10n_latest][overwrite] = TRUE
 
-libraries[civicrm][destination] = modules
-libraries[civicrm][directory_name] = civicrm
-libraries[civicrm][download][type] = git
-libraries[civicrm][download][url] = %%CACHE_DIR%%/civicrm/civicrm-core.git
-libraries[civicrm][download][branch] = %%CIVI_VERSION%%
-libraries[civicrm][overwrite] = TRUE
+; Download available l10n releases (may be outdated)
+; libraries[civicrm_l10n][destination] = modules
+; libraries[civicrm_l10n][directory_name] = civicrm/l10n/fr_CA/LC_MESSAGES/
+; libraries[civicrm_l10n][download][type] = get
+; libraries[civicrm_l10n][download][url] = "https://raw.github.com/civicrm/l10n/master/po/fr_CA/civicrm.mo"
+; libraries[civicrm_l10n][overwrite] = TRUE
 
 ; ****************************************
 ; Runtime Modules
@@ -224,7 +224,7 @@ projects[views_json_query][patch][] = "https://raw.githubusercontent.com/compuco
 projects[views_data_export][subdir] = civihr-contrib-required
 projects[views_data_export][version] = 3.0-beta8
 
-projects[views_bulk_operations][subdir] = civihr-contrib-required 
+projects[views_bulk_operations][subdir] = civihr-contrib-required
 projects[views_bulk_operations][version] = 3.3
 
 projects[browserclass][subdir] = civihr-contrib-required

--- a/app/config/hr16/drush.make.tmpl
+++ b/app/config/hr16/drush.make.tmpl
@@ -18,6 +18,13 @@ projects[] = drupal
 ; CiviCRM core
 ; ****************************************
 
+libraries[civicrm][destination] = modules
+libraries[civicrm][directory_name] = civicrm
+libraries[civicrm][download][type] = git
+libraries[civicrm][download][url] = %%CACHE_DIR%%/civicrm/civicrm-core.git
+libraries[civicrm][download][tag] = %%CIVI_VERSION%%
+libraries[civicrm][overwrite] = TRUE
+
 libraries[civicrmdrupal][destination] = modules
 libraries[civicrmdrupal][directory_name] = civicrm/drupal
 libraries[civicrmdrupal][download][type] = git
@@ -38,13 +45,6 @@ libraries[civihr][download][type] = git
 libraries[civihr][download][url] = %%CACHE_DIR%%/civicrm/civihr.git
 libraries[civihr][download][branch] = %%HR_VERSION%%
 libraries[civihr][overwrite] = TRUE
-
-libraries[civicrm][destination] = modules
-libraries[civicrm][directory_name] = civicrm
-libraries[civicrm][download][type] = git
-libraries[civicrm][download][url] = %%CACHE_DIR%%/civicrm/civicrm-core.git
-libraries[civicrm][download][tag] = %%CIVI_VERSION%%
-libraries[civicrm][overwrite] = TRUE
 
 ; ****************************************
 ; Runtime Modules

--- a/app/config/hr17/drush.make.tmpl
+++ b/app/config/hr17/drush.make.tmpl
@@ -18,6 +18,13 @@ projects[] = drupal
 ; CiviCRM core
 ; ****************************************
 
+libraries[civicrm][destination] = modules
+libraries[civicrm][directory_name] = civicrm
+libraries[civicrm][download][type] = git
+libraries[civicrm][download][url] = %%CACHE_DIR%%/civicrm/civicrm-core.git
+libraries[civicrm][download][tag] = %%CIVI_VERSION%%
+libraries[civicrm][overwrite] = TRUE
+
 libraries[civicrmdrupal][destination] = modules
 libraries[civicrmdrupal][directory_name] = civicrm/drupal
 libraries[civicrmdrupal][download][type] = git
@@ -38,13 +45,6 @@ libraries[civihr][download][type] = git
 libraries[civihr][download][url] = %%CACHE_DIR%%/civicrm/civihr.git
 libraries[civihr][download][branch] = %%HR_VERSION%%
 libraries[civihr][overwrite] = TRUE
-
-libraries[civicrm][destination] = modules
-libraries[civicrm][directory_name] = civicrm
-libraries[civicrm][download][type] = git
-libraries[civicrm][download][url] = %%CACHE_DIR%%/civicrm/civicrm-core.git
-libraries[civicrm][download][tag] = %%CIVI_VERSION%%
-libraries[civicrm][overwrite] = TRUE
 
 ; ****************************************
 ; Runtime Modules

--- a/app/config/hrdemo/drush.make.tmpl
+++ b/app/config/hrdemo/drush.make.tmpl
@@ -22,6 +22,13 @@ projects[] = drupal
 ; This will make it easier to submit pull-requests for patches.
 ; see: http://wiki.civicrm.org/confluence/display/CRMDOC/Github+for+CiviCRM
 
+libraries[civicrm][destination] = modules
+libraries[civicrm][directory_name] = civicrm
+libraries[civicrm][download][type] = git
+libraries[civicrm][download][url] = %%CACHE_DIR%%/civicrm/civicrm-core.git
+libraries[civicrm][download][branch] = %%CIVI_VERSION%%
+libraries[civicrm][overwrite] = TRUE
+
 libraries[civicrmdrupal][destination] = modules
 libraries[civicrmdrupal][directory_name] = civicrm/drupal
 libraries[civicrmdrupal][download][type] = git
@@ -43,13 +50,6 @@ libraries[civihr][download][url] = %%CACHE_DIR%%/civicrm/civihr.git
 libraries[civihr][download][branch] = %%HR_VERSION%%
 libraries[civihr][overwrite] = TRUE
 
-; Download available l10n releases (may be outdated)
-; libraries[civicrm_l10n][destination] = modules
-; libraries[civicrm_l10n][directory_name] = civicrm/l10n/fr_CA/LC_MESSAGES/
-; libraries[civicrm_l10n][download][type] = get
-; libraries[civicrm_l10n][download][url] = "https://raw.github.com/civicrm/l10n/master/po/fr_CA/civicrm.mo"
-; libraries[civicrm_l10n][overwrite] = TRUE
-
 ; Overwrite .mo files with latest versions
 ; libraries[civicrm_l10n_latest][destination] = modules
 ; libraries[civicrm_l10n_latest][directory_name] = civicrm/l10n
@@ -57,12 +57,12 @@ libraries[civihr][overwrite] = TRUE
 ; libraries[civicrm_l10n_latest][download][url] = http://download.civicrm.org/civicrm-l10n-core/archives/civicrm-l10n-daily.tar.gz
 ; libraries[civicrm_l10n_latest][overwrite] = TRUE
 
-libraries[civicrm][destination] = modules
-libraries[civicrm][directory_name] = civicrm
-libraries[civicrm][download][type] = git
-libraries[civicrm][download][url] = %%CACHE_DIR%%/civicrm/civicrm-core.git
-libraries[civicrm][download][branch] = %%CIVI_VERSION%%
-libraries[civicrm][overwrite] = TRUE
+; Download available l10n releases (may be outdated)
+; libraries[civicrm_l10n][destination] = modules
+; libraries[civicrm_l10n][directory_name] = civicrm/l10n/fr_CA/LC_MESSAGES/
+; libraries[civicrm_l10n][download][type] = get
+; libraries[civicrm_l10n][download][url] = "https://raw.github.com/civicrm/l10n/master/po/fr_CA/civicrm.mo"
+; libraries[civicrm_l10n][overwrite] = TRUE
 
 ; ****************************************
 ; Runtime Modules

--- a/app/config/symfony/drush.make.tmpl
+++ b/app/config/symfony/drush.make.tmpl
@@ -22,6 +22,13 @@ projects[] = drupal
 ; This will make it easier to submit pull-requests for patches.
 ; see: http://wiki.civicrm.org/confluence/display/CRMDOC/Github+for+CiviCRM
 
+libraries[civicrm][destination] = modules
+libraries[civicrm][directory_name] = civicrm
+libraries[civicrm][download][type] = git
+libraries[civicrm][download][url] = %%CACHE_DIR%%/civicrm/civicrm-core.git
+libraries[civicrm][download][branch] = %%CIVI_VERSION%%
+libraries[civicrm][overwrite] = TRUE
+
 libraries[civicrmdrupal][destination] = modules
 libraries[civicrmdrupal][directory_name] = civicrm/drupal
 libraries[civicrmdrupal][download][type] = git
@@ -36,13 +43,6 @@ libraries[civicrmpackages][download][url] = %%CACHE_DIR%%/civicrm/civicrm-packag
 libraries[civicrmpackages][download][branch] = %%CIVI_VERSION%%
 libraries[civicrmpackages][overwrite] = TRUE
 
-; Download available l10n releases (may be outdated)
-; libraries[civicrm_l10n][destination] = modules
-; libraries[civicrm_l10n][directory_name] = civicrm/l10n/fr_CA/LC_MESSAGES/
-; libraries[civicrm_l10n][download][type] = get
-; libraries[civicrm_l10n][download][url] = "https://raw.github.com/civicrm/l10n/master/po/fr_CA/civicrm.mo"
-; libraries[civicrm_l10n][overwrite] = TRUE
-
 ; Overwrite .mo files with latest versions
 ; libraries[civicrm_l10n_latest][destination] = modules
 ; libraries[civicrm_l10n_latest][directory_name] = civicrm/l10n
@@ -50,12 +50,12 @@ libraries[civicrmpackages][overwrite] = TRUE
 ; libraries[civicrm_l10n_latest][download][url] = http://download.civicrm.org/civicrm-l10n-core/archives/civicrm-l10n-daily.tar.gz
 ; libraries[civicrm_l10n_latest][overwrite] = TRUE
 
-libraries[civicrm][destination] = modules
-libraries[civicrm][directory_name] = civicrm
-libraries[civicrm][download][type] = git
-libraries[civicrm][download][url] = %%CACHE_DIR%%/civicrm/civicrm-core.git
-libraries[civicrm][download][branch] = %%CIVI_VERSION%%
-libraries[civicrm][overwrite] = TRUE
+; Download available l10n releases (may be outdated)
+; libraries[civicrm_l10n][destination] = modules
+; libraries[civicrm_l10n][directory_name] = civicrm/l10n/fr_CA/LC_MESSAGES/
+; libraries[civicrm_l10n][download][type] = get
+; libraries[civicrm_l10n][download][url] = "https://raw.github.com/civicrm/l10n/master/po/fr_CA/civicrm.mo"
+; libraries[civicrm_l10n][overwrite] = TRUE
 
 ; ****************************************
 ; Runtime Modules


### PR DESCRIPTION
I have re-ordered the 'libraries' in the makefiles as outlined in https://github.com/civicrm/civicrm-buildkit/issues/369 with the exception of D8 since I am not familiar with these and there seemed to be some inconsistencies in the make files.

Compare

https://github.com/civicrm/civicrm-buildkit/blob/4632601652874ea4c8b5111aaf188301e82fe505/app/config/drupal8-clean/drush.make.tmpl#L27

with 

https://github.com/civicrm/civicrm-buildkit/blob/4632601652874ea4c8b5111aaf188301e82fe505/app/config/drupal8-demo/drush.make.tmpl#L27

I wasn't sure which of these was correct. Maybe both? maybe neither! I will do a little bit more testing...