### PR TITLE
add some comments/suggestions for PATH in app/civibuild.conf.tmpl

### DIFF
--- a/app/civibuild.conf.tmpl
+++ b/app/civibuild.conf.tmpl
@@ -48,6 +48,7 @@
 ## Example: Update civibuild's $PATH
 
 # PATH="$HOME/src/amp/bin:$PATH"
+# export PATH
 
 ## The above example forces civibuild to use the amp executable found
 ## in $HOME/src/amp/bin rather than the default from buildkit's bin

--- a/app/civibuild.conf.tmpl
+++ b/app/civibuild.conf.tmpl
@@ -47,8 +47,8 @@
 #############################################################################
 ## Example: Update civibuild's $PATH
 
-# PATH="$HOME/bin:$PATH"
+# PATH="$HOME/src/amp/bin:$PATH"
 
-## This is useful if you want to point civibuild to specific versions
-## of tools like drush or amp instead of the versions that it would
-## use by default (i.e. those found in buildkit's bin directory).
+## The above example forces civibuild to use the amp executable found
+## in $HOME/src/amp/bin rather than the default from buildkit's bin
+## directory.

--- a/app/civibuild.conf.tmpl
+++ b/app/civibuild.conf.tmpl
@@ -43,3 +43,12 @@
 ## want to destroy and recreate them.  Moving them may be tricky
 ## because you would need to find and update absolute-paths in
 ## several places.
+
+#############################################################################
+## Example: Update civibuild's $PATH
+
+# PATH="$HOME/bin:$PATH"
+
+## This is useful if you want to point civibuild to specific versions
+## of tools like drush or amp instead of the versions that it would
+## use by default (i.e. those found in buildkit's bin directory).


### PR DESCRIPTION
@totten, following on from #368 I added a comment suggestion to the civibuild.conf.tmpl.

In `bin/civibuild` the path is exported.

In my experiments I found that an export is not necessary in the config file: when I added `drush --version` to `civicrm-buildkit/app/config/drupal8-demo/download.sh`, and checked the output with the `PATH="$HOME/bin:$PATH"` commented/uncomments, the output reported the expected drush version.

I only bring that up here in case I am missing something and we should suggest that people export the path in the config.


