### PR TITLE
PCHR-2632: Add menu_attributes module

### DIFF
--- a/app/config/hr17/drush.make.tmpl
+++ b/app/config/hr17/drush.make.tmpl
@@ -221,6 +221,9 @@ projects[smtp][version] = 1.6
 projects[menu_attributes][subdir] = civihr-contrib-required
 projects[menu_attributes][version] = 1.0
 
+projects[menu_per_role][subdir] = civihr-contrib-required
+projects[menu_per_role][version] = 1.0-alpha1
+
 ; ****************************************
 ; Compucorp custom drupal modules
 ; ****************************************

--- a/app/config/hr17/drush.make.tmpl
+++ b/app/config/hr17/drush.make.tmpl
@@ -218,6 +218,9 @@ projects[conditional_styles][version] = 2.2
 projects[smtp][subdir] = civihr-contrib-required
 projects[smtp][version] = 1.6
 
+projects[menu_attributes][subdir] = civihr-contrib-required
+projects[menu_attributes][version] = 1.0
+
 ; ****************************************
 ; Compucorp custom drupal modules
 ; ****************************************
@@ -244,7 +247,7 @@ libraries[civihr_employee_portal_theme][download][branch] = %%HR_VERSION%%
 libraries[civihr_employee_portal_theme][overwrite] = TRUE
 
 ; ****************************************
-; Boostrap theme
+; Bootstrap theme
 ; ****************************************
 
 ; Download Radix base theme


### PR DESCRIPTION
This PR adds two modules to CivIHR:

* [menu_attributes](https://www.drupal.org/project/menu_attributes) module to CiviHR so we can assign an icon to each of the main menu items
* [menu_per_role](https://www.drupal.org/project/menu_per_role) module to CiviHR, so  we can assign access criteria also to menu items that are pointing to external URLs


cc @davialexandre 