### PR TITLE
add civicrm-admin-utilities to wp-demo

### DIFF
--- a/app/config/wp-demo/install.sh
+++ b/app/config/wp-demo/install.sh
@@ -53,6 +53,7 @@ wp eval '$home = get_page_by_title("Welcome to CiviCRM with WordPress"); update_
 
 wp plugin activate civicrm
 wp plugin activate civicrm-demo-wp
+wp plugin install civicrm-admin-utilities && wp plugin activate civicrm-admin-utilities
 
 civicrm_apply_demo_defaults
 


### PR DESCRIPTION
Add Plugin for WP to demo-wp install type.   https://github.com/christianwach/civicrm-admin-utilities  WP repo at https://wordpress.org/plugins/civicrm-admin-utilities/   Add direct from wp repo via wp-cli to get the stable branch.

From the README:

- Modifies the styling of the CiviCRM menu to fix a number of issues
- Fixes the appearance of the WordPress Access Control form
- Adds a handy CiviCRM Shortcuts menu to the WordPress Admin Bar
- Allows you to choose which Post Types the CiviCRM shortcode button appears on
- In WordPress multisite, allows you to hide CiviCRM on sub-sites

This is a great addition to buildkit when using as both a demo site and for development.   