### PR TITLE
Fix Yoti Version

### DIFF
--- a/app/config/hr17/drush.make.tmpl
+++ b/app/config/hr17/drush.make.tmpl
@@ -178,6 +178,9 @@ projects[masquerade][version] = "1.0-rc7"
 projects[logintoboggan][subdir] = civihr-contrib-required
 projects[logintoboggan][version] = "1.5"
 
+projects[yoti][subdir] = civihr-contrib-required
+projects[yoti][version] = "1.4"
+
 ; Patch for pagination
 projects[views_merge_rows][patch][] = "https://www.drupal.org/files/issues/views_merge_rows-views_merge_rows_and_pagination-2188939-3_0.patch"
 projects[views_merge_rows][patch][] = "https://www.drupal.org/files/issues/views_merge_rows-views_merge_rows_pagination-2724691-2.patch"


### PR DESCRIPTION
The default Yoti version (if unspecified) now relies on PHP 5.6 so we need to lock the version to 1.4, which supports PHP 5.5

This was already done in the hr16 build, but I forgot to add it to hr17, which this PR does.