### PR TITLE
Remove point numbers from module versions

### DIFF
--- a/app/config/drupal-demo/drush.make.tmpl
+++ b/app/config/drupal-demo/drush.make.tmpl
@@ -62,39 +62,38 @@ libraries[civicrm_l10n_latest][overwrite] = TRUE
 ; ****************************************
 
 projects[civicrm_error][subdir] = contrib
-projects[civicrm_error][version] = 2.0-rc3
-
+projects[civicrm_error][version] = 2
 
 projects[libraries][subdir] = contrib
-projects[libraries][version] = 1.0
+projects[libraries][version] = 1
 
 projects[redirect][subdir] = contrib
-projects[redirect][version] = 1.0-rc1
+projects[redirect][version] = 1
 
 projects[webform][subdir] = contrib
-projects[webform][version] = 4.12
+projects[webform][version] = 4
 
 projects[options_element][subdir] = contrib
-projects[options_element][version] = 1.12
+projects[options_element][version] = 1
 
 projects[webform_civicrm][subdir] = contrib
-projects[webform_civicrm][version] = 4.16
+projects[webform_civicrm][version] = 4
 
 projects[views][subdir] = contrib
-projects[views][version] = 3.8
+projects[views][version] = 3
 
 projects[login_destination][subdir] = contrib
-projects[login_destination][version] = "1.1"
+projects[login_destination][version] = 1
 
 projects[userprotect][subdir] = contrib
-projects[userprotect][version] = "1.0"
+projects[userprotect][version] = 1
 
 ; ****************************************
 ; Developer modules
 ; ****************************************
 
 projects[devel][subdir] = contrib
-projects[devel][version] = 1.3
+projects[devel][version] = 1
 
 libraries[civicrmdeveloper][destination] = modules
 libraries[civicrmdeveloper][directory_name] = contrib/civicrm_developer


### PR DESCRIPTION
Overview
------
The version of Views in buildkit was so old that `civicrm_views_dashlets` couldn't function. This change ensures we always have the latest version of modules installed.

Notes
-------
I can't think of any downsides to this change offhand, but maybe @totten can think of some cases where always using the latest version of modules is not desirable.

If accepted I can expand this PR to update other builds as well.