### PR TITLE
app/config - Sync users during installation

### DIFF
--- a/app/config/drupal-case/install.sh
+++ b/app/config/drupal-case/install.sh
@@ -40,6 +40,7 @@ pushd "${WEB_ROOT}/sites/${DRUPAL_SITE_DIR}" >> /dev/null
     | drush cvapi setting.create --in=json
   ## Note: CiviGrant disabled by default. If you enable, update the permissions as well.
   civicrm_apply_demo_defaults
+  cv ev 'return CRM_Utils_System::synchronizeUsers();'
 
   ## Setup theme
   #above# drush -y en seven

--- a/app/config/drupal-clean/install.sh
+++ b/app/config/drupal-clean/install.sh
@@ -41,6 +41,8 @@ pushd "${WEB_ROOT}/sites/${DRUPAL_SITE_DIR}" >> /dev/null
   ## disable annoying/unneeded modules
   drush -y dis overlay
 
+  cv ev 'return CRM_Utils_System::synchronizeUsers();'
+
   ## Setup theme
   #above# drush -y en garland
   export SITE_CONFIG_DIR

--- a/app/config/drupal-demo/install.sh
+++ b/app/config/drupal-demo/install.sh
@@ -47,6 +47,7 @@ pushd "${WEB_ROOT}/sites/${DRUPAL_SITE_DIR}" >> /dev/null
     | drush cvapi setting.create --in=json
   ## Note: CiviGrant disabled by default. If you enable, update the permissions as well.
   civicrm_apply_demo_defaults
+  cv ev 'return CRM_Utils_System::synchronizeUsers();'
 
   ## Setup theme
   #above# drush -y en garland

--- a/app/config/drupal8-clean/install.sh
+++ b/app/config/drupal8-clean/install.sh
@@ -50,6 +50,7 @@ pushd "${WEB_ROOT}/sites/${DRUPAL_SITE_DIR}" >> /dev/null
   #echo '{"enable_components":["CiviEvent","CiviContribute","CiviMember","CiviMail","CiviReport","CiviPledge","CiviCase","CiviCampaign"]}' \
   #  | drush8 cvapi setting.create --in=json
   #civicrm_apply_demo_defaults
+  #cv ev 'return CRM_Utils_System::synchronizeUsers();'
 
   ## Setup theme
   #above# drush8 -y en garland

--- a/app/config/drupal8-demo/install.sh
+++ b/app/config/drupal8-demo/install.sh
@@ -50,6 +50,7 @@ pushd "${WEB_ROOT}/sites/${DRUPAL_SITE_DIR}" >> /dev/null
   echo '{"enable_components":["CiviEvent","CiviContribute","CiviMember","CiviMail","CiviReport","CiviPledge","CiviCase","CiviCampaign"]}' \
     | drush8 cvapi setting.create --in=json
   civicrm_apply_demo_defaults
+  # TODO: cv ev 'return CRM_Utils_System::synchronizeUsers();'
 
   ## Setup theme
   #above# drush8 -y en garland

--- a/app/config/wp-case/install.sh
+++ b/app/config/wp-case/install.sh
@@ -46,6 +46,7 @@ wp plugin activate civicrm-demo-wp
 
 echo '{"enable_components":["CiviMail","CiviReport","CiviCase"]}' | cv api setting.create --in=json
 civicrm_apply_demo_defaults
+cv ev 'return CRM_Utils_System::synchronizeUsers();'
 
 ## Install Shoreditch and CiviCase
 cv en shoreditch styleguide civicase

--- a/app/config/wp-demo/install.sh
+++ b/app/config/wp-demo/install.sh
@@ -56,6 +56,7 @@ wp plugin activate civicrm-demo-wp
 wp plugin install civicrm-admin-utilities && wp plugin activate civicrm-admin-utilities
 
 civicrm_apply_demo_defaults
+cv ev 'return CRM_Utils_System::synchronizeUsers();'
 
 wp role create civicrm_admin 'CiviCRM Administrator'
 wp cap add civicrm_admin \


### PR DESCRIPTION
Background
----------
When setting up the test bot for Mosaico's E2E tests, some tests failed
because they needed to lookup the admin user.

You can inspect the user/contact mappings by running a SQL query,
`select * from civicrm_uf_match;`

Before
------
In a new build, the admin and demo users exist. The demo user
has a corresponding `Contact` record, but the admin user doesn't.

After
-----
Both users have `Contact` records.

Comment
-------
So far, I've applied this on `test-ubu1204-1` and run the
Mosaico tests on top of the `drupal-clean` configuration. The
changes fixed that test.

However, I'm going to locally run several other build scripts to
ensure they don't regress.