### PR TITLE
PCHR-2959: Enable on install menu_attributes and menu_per_role

### DIFF
--- a/app/config/hr17/install.sh
+++ b/app/config/hr17/install.sh
@@ -119,7 +119,9 @@ pushd "${WEB_ROOT}/sites/${DRUPAL_SITE_DIR}" >> /dev/null
     masquerade \
     smtp \
     logintoboggan \
-    yoti
+    yoti \
+    menu_attributes \
+    menu_per_role
 
   drush vset logintoboggan_login_with_email 1
   drush vset --format=integer user_pictures 0


### PR DESCRIPTION
_(nevermind the name of the branch with the wrong ticket number, the correct ticket was created after the PR)_

In #372 we added the [menu_attributes](https://www.drupal.org/project/menu_attributes) and [menu_per_role](https://www.drupal.org/project/menu_per_role) modules to CiviHR, but forgot to enable them on install