### PR TITLE
PCHR-2961: User roles_for_menu instead of menus_per_role module

### DIFF
--- a/app/config/hr17/drush.make.tmpl
+++ b/app/config/hr17/drush.make.tmpl
@@ -224,8 +224,8 @@ projects[smtp][version] = 1.6
 projects[menu_attributes][subdir] = civihr-contrib-required
 projects[menu_attributes][version] = 1.0
 
-projects[menu_per_role][subdir] = civihr-contrib-required
-projects[menu_per_role][version] = 1.0-alpha1
+projects[roles_for_menu][subdir] = civihr-contrib-required
+projects[roles_for_menu][version] = 1.1
 
 ; ****************************************
 ; Compucorp custom drupal modules

--- a/app/config/hr17/install.sh
+++ b/app/config/hr17/install.sh
@@ -121,7 +121,7 @@ pushd "${WEB_ROOT}/sites/${DRUPAL_SITE_DIR}" >> /dev/null
     logintoboggan \
     yoti \
     menu_attributes \
-    menu_per_role
+    roles_for_menu
 
   drush vset logintoboggan_login_with_email 1
   drush vset --format=integer user_pictures 0


### PR DESCRIPTION
The [menu_per_role](https://www.drupal.org/project/menu_per_role) module doesn't allow settings to be exported in features, while [roles_for_menu](https://www.drupal.org/project/roles_for_menu) does. Hence the switch