### PR TITLE
(drupal,wp)-case - Use path var for Shoreditch CSS

### DIFF
--- a/app/config/drupal-case/install.sh
+++ b/app/config/drupal-case/install.sh
@@ -50,7 +50,7 @@ pushd "${WEB_ROOT}/sites/${DRUPAL_SITE_DIR}" >> /dev/null
 
   ## Install Shoreditch and CiviCase
   cv en shoreditch styleguide civicase
-  cv api setting.create customCSSURL=$(cv url -x shoreditch/css/custom-civicrm.css --out=list)
+  cv api setting.create customCSSURL='[civicrm.root]/ext/shoreditch/css/custom-civicrm.css'
   cv scr --user="$ADMIN_USER" "$PRJDIR/src/create-civicase-examples.php"
 
   ## Based on the block info, CRM_Core_Block::CREATE_NEW and CRM_Core_Block::ADD should be enabled by default, but they aren't.

--- a/app/config/wp-case/install.sh
+++ b/app/config/wp-case/install.sh
@@ -50,7 +50,7 @@ cv ev 'if(is_callable(array("CRM_Core_BAO_CMSUser","synchronize"))){CRM_Core_BAO
 
 ## Install Shoreditch and CiviCase
 cv en shoreditch styleguide civicase
-cv api setting.create customCSSURL=$(cv url -x shoreditch/css/custom-civicrm.css --out=list)
+cv api setting.create customCSSURL='[civicrm.root]/ext/shoreditch/css/custom-civicrm.css'
 cv scr --user="$ADMIN_USER" "$PRJDIR/src/create-civicase-examples.php"
 
 ## Setup permissions


### PR DESCRIPTION
When building a CiviCase/Shoreditch demo site, the old snippet sets the
`customCSSUURL` to an absolute URL.  However, that raises a soft warning in
the system status.  The new snippet uses a relative to resolve the warning.