### PR TITLE
Don't exclude DAO files from linting

### DIFF
--- a/bin/civilint
+++ b/bin/civilint
@@ -51,7 +51,7 @@ function split_files() {
     if [ ! -e "$file" ]; then
       echo "$file" >> "$skipfiles"
 
-    elif [[ "$file" =~ (/?DAO/|/?examples/|/?tools/) ]]; then
+    elif [[ "$file" =~ (/?examples/|/?tools/) ]]; then
       echo "$file" >> "$skipfiles"
 
     elif [[ "$file" =~ Trait\.php$ ]]; then


### PR DESCRIPTION
Once https://github.com/civicrm/civicrm-core/pull/11418 is merged we should merge this as well to lock in the testing of these files.