### PR TITLE
upgrade-test - Make version checks more adaptable

### DIFF
--- a/bin/civi-test-run
+++ b/bin/civi-test-run
@@ -81,16 +81,7 @@ function task_karma() {
 function task_upgrade() {
   ## Run the tests -- DB upgrade tests
   CIVIVER=$(getCiviVer)
-  case "$CIVIVER" in
-    4.3*)    UTVERS="4.2.9-multilingual_af_bg_en.mysql.bz2 4.3.0*" ;;
-    4.4*)    UTVERS="4.2.9-multilingual_af_bg_en.mysql.bz2 4.3.0* 4.4.0*" ;;
-    4.5*)    UTVERS="4.2.9-multilingual_af_bg_en.mysql.bz2 4.3.0* 4.4.0* 4.5.0*" ;;
-    4.6*)    UTVERS="4.2.9-multilingual_af_bg_en.mysql.bz2 4.3.0* 4.4.0* 4.5.0* 4.6.0*" ;;
-    4.7*)    UTVERS="4.2.9-multilingual_af_bg_en.mysql.bz2 4.4.0* 4.5.0* 4.6.0* 4.7.0*" ;;
-    master*) UTVERS="4.2.9-multilingual_af_bg_en.mysql.bz2 4.4.0* 4.5.0* 4.6.0* 4.7.0*" ;;
-    *)      echo "UpgradeTest failed: Unrecognized version ($CIVIVER)" ; exit 1; ;;
-  esac
-  if  ! $GUARD civibuild upgrade-test $BLDNAME $UTVERS ; then
+  if  ! $GUARD civibuild upgrade-test $BLDNAME 4.2.9-multilingual_af_bg_en* "@4.2..$CIVIVER:10" ; then
     EXITCODES="$EXITCODES upgrade-test"
   fi
   $GUARD cp "$PRJDIR/app/debug/$BLDNAME/civicrm-upgrade-test.xml" "$JUNITDIR/"

--- a/bin/civi-test-run
+++ b/bin/civi-test-run
@@ -38,6 +38,7 @@ function show_help() {
   echo "                        - phpunit-crm"
   echo "                        - phpunit-e2e"
   echo "                        - upgrade"
+  echo "                        - upgrade@4.7.30:10"
   echo
   echo "example: Run the KarmaJS and DB-upgrade tests on D7/Civi-Master build"
   echo "  $PROG -b dmaster -j /tmp/junit-output karma upgrade"
@@ -78,10 +79,11 @@ function task_karma() {
   $GUARD popd
 }
 
+## Execute the upgrade test suite
+## ex: task_upgrade @4.3..4.6.30
 function task_upgrade() {
   ## Run the tests -- DB upgrade tests
-  CIVIVER=$(getCiviVer)
-  if  ! $GUARD civibuild upgrade-test $BLDNAME 4.2.9-multilingual_af_bg_en* "@4.2..$CIVIVER:10" ; then
+  if  ! $GUARD civibuild upgrade-test $BLDNAME $@ ; then
     EXITCODES="$EXITCODES upgrade-test"
   fi
   $GUARD cp "$PRJDIR/app/debug/$BLDNAME/civicrm-upgrade-test.xml" "$JUNITDIR/"
@@ -175,7 +177,8 @@ fi
 for TESTTYPE in $SUITES ; do
   case "$TESTTYPE" in
     karma)  task_karma ;;
-    upgrade)  task_upgrade ;;
+    upgrade)  CIVIVER=$(getCiviVer) ; task_upgrade 4.2.9-multilingual_af_bg_en* "@4.2..$CIVIVER:10" ;;
+    upgrade@*)  task_upgrade $(echo $TESTTYPE | sed s'/^upgrade//' ) ;;
     phpunit-e2e)  task_phpunit E2E_AllTests ;;
     phpunit-crm)  task_phpunit CRM_AllTests ;;
     phpunit-api)  task_phpunit api_v3_AllTests ;;

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "php": ">=5.3.3",
     "drush/drush": "dev-master#d1d13676f5beacaa9f8619088fe3ae45ea28a6cf",
     "totten/php-symbol-diff": "dev-master#54f869ca68a3cd75f3386f8490870369733d2c23",
-    "civicrm/upgrade-test": "dev-master#8747e21bfb0e4c57c539fb265070267b1e8662b4",
+    "civicrm/upgrade-test": "dev-master#0bec3b99755597f64afe3c08d9aa20dca776ce77",
     "drupal/coder": "dev-8.x-2.x-civi#a801890a82d52e23a83c5d820270b6e228843d79",
     "brianium/paratest": "dev-batching as 0.7",
     "phpunit/phpunit": "3.7.27",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "php": ">=5.3.3",
     "drush/drush": "dev-master#d1d13676f5beacaa9f8619088fe3ae45ea28a6cf",
     "totten/php-symbol-diff": "dev-master#54f869ca68a3cd75f3386f8490870369733d2c23",
-    "civicrm/upgrade-test": "dev-master#0bec3b99755597f64afe3c08d9aa20dca776ce77",
+    "civicrm/upgrade-test": "dev-master#df3a5b97a980bd35083824ae382c97de6539bc4d",
     "drupal/coder": "dev-8.x-2.x-civi#a801890a82d52e23a83c5d820270b6e228843d79",
     "brianium/paratest": "dev-batching as 0.7",
     "phpunit/phpunit": "3.7.27",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "296359385684c950b7029db0f1f5b6fa",
+    "content-hash": "8749f8eeb625480c49b265a130922f33",
     "packages": [
         {
             "name": "brianium/habitat",
@@ -106,12 +106,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/civicrm/civicrm-upgrade-test.git",
-                "reference": "0bec3b99755597f64afe3c08d9aa20dca776ce77"
+                "reference": "df3a5b97a980bd35083824ae382c97de6539bc4d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/civicrm/civicrm-upgrade-test/zipball/0bec3b99755597f64afe3c08d9aa20dca776ce77",
-                "reference": "0bec3b99755597f64afe3c08d9aa20dca776ce77",
+                "url": "https://api.github.com/repos/civicrm/civicrm-upgrade-test/zipball/df3a5b97a980bd35083824ae382c97de6539bc4d",
+                "reference": "df3a5b97a980bd35083824ae382c97de6539bc4d",
                 "shasum": ""
             },
             "bin": [
@@ -130,7 +130,7 @@
             ],
             "description": "Collection of scripts and data-files for testing CiviCRM upgrades",
             "homepage": "https://github.com/civicrm/civicrm-upgrade-test",
-            "time": "2018-02-05T08:31:21+00:00"
+            "time": "2018-03-16T22:07:49+00:00"
         },
         {
             "name": "composer/semver",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "242eb00b77ac03ff784f88a5e40441c2",
-    "content-hash": "e4480ae254a47660c1ff3a792f56576a",
+    "content-hash": "296359385684c950b7029db0f1f5b6fa",
     "packages": [
         {
             "name": "brianium/habitat",
@@ -46,7 +45,7 @@
                 }
             ],
             "description": "A dependable php environment",
-            "time": "2013-06-08 04:42:29"
+            "time": "2013-06-08T04:42:29+00:00"
         },
         {
             "name": "brianium/paratest",
@@ -99,7 +98,7 @@
                 "parallel",
                 "testing"
             ],
-            "time": "2014-09-21 04:45:25"
+            "time": "2014-09-21T04:45:25+00:00"
         },
         {
             "name": "civicrm/upgrade-test",
@@ -107,12 +106,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/civicrm/civicrm-upgrade-test.git",
-                "reference": "8747e21bfb0e4c57c539fb265070267b1e8662b4"
+                "reference": "0bec3b99755597f64afe3c08d9aa20dca776ce77"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/civicrm/civicrm-upgrade-test/zipball/8747e21bfb0e4c57c539fb265070267b1e8662b4",
-                "reference": "8747e21bfb0e4c57c539fb265070267b1e8662b4",
+                "url": "https://api.github.com/repos/civicrm/civicrm-upgrade-test/zipball/0bec3b99755597f64afe3c08d9aa20dca776ce77",
+                "reference": "0bec3b99755597f64afe3c08d9aa20dca776ce77",
                 "shasum": ""
             },
             "bin": [
@@ -131,7 +130,7 @@
             ],
             "description": "Collection of scripts and data-files for testing CiviCRM upgrades",
             "homepage": "https://github.com/civicrm/civicrm-upgrade-test",
-            "time": "2017-07-06 01:27:26"
+            "time": "2018-02-05T08:31:21+00:00"
         },
         {
             "name": "composer/semver",
@@ -192,7 +191,7 @@
                 "validation",
                 "versioning"
             ],
-            "time": "2015-09-21 09:42:36"
+            "time": "2015-09-21T09:42:36+00:00"
         },
         {
             "name": "d11wtq/boris",
@@ -226,7 +225,7 @@
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
-            "time": "2014-01-17 12:21:18"
+            "time": "2014-01-17T12:21:18+00:00"
         },
         {
             "name": "drupal/coder",
@@ -258,7 +257,7 @@
                 "issues": "https://drupal.org/project/issues/coder",
                 "source": "https://drupal.org/project/coder"
             },
-            "time": "2015-01-20 05:38:56"
+            "time": "2015-01-20T05:38:56+00:00"
         },
         {
             "name": "drush/drush",
@@ -332,7 +331,7 @@
             ],
             "description": "Drush is a command line shell and scripting interface for Drupal, a veritable Swiss Army knife designed to make life easier for those of us who spend some of our working hours hacking away at the command prompt.",
             "homepage": "http://www.drush.org",
-            "time": "2013-10-26 07:40:45"
+            "time": "2013-10-26T07:40:45+00:00"
         },
         {
             "name": "mustache/mustache",
@@ -377,7 +376,7 @@
                 "mustache",
                 "templating"
             ],
-            "time": "2014-08-26 19:50:10"
+            "time": "2014-08-26T19:50:10+00:00"
         },
         {
             "name": "nb/oxymel",
@@ -418,7 +417,7 @@
             "keywords": [
                 "xml"
             ],
-            "time": "2013-02-24 15:01:54"
+            "time": "2013-02-24T15:01:54+00:00"
         },
         {
             "name": "nikic/php-parser",
@@ -463,7 +462,7 @@
                 "parser",
                 "php"
             ],
-            "time": "2015-07-14 17:31:05"
+            "time": "2015-07-14T17:31:05+00:00"
         },
         {
             "name": "pear/console_table",
@@ -518,7 +517,7 @@
             "keywords": [
                 "console"
             ],
-            "time": "2012-12-07 14:43:01"
+            "time": "2012-12-07T14:43:01+00:00"
         },
         {
             "name": "phpunit/dbunit",
@@ -577,7 +576,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2014-03-26 11:25:06"
+            "time": "2014-03-26T11:25:06+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -638,7 +637,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2014-09-02 10:13:14"
+            "time": "2014-09-02T10:13:14+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -683,7 +682,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2013-10-10 15:34:57"
+            "time": "2013-10-10T15:34:57+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -727,7 +726,7 @@
             "keywords": [
                 "template"
             ],
-            "time": "2014-01-30 17:20:04"
+            "time": "2014-01-30T17:20:04+00:00"
         },
         {
             "name": "phpunit/php-timer",
@@ -771,7 +770,7 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2013-08-02 07:42:54"
+            "time": "2013-08-02T07:42:54+00:00"
         },
         {
             "name": "phpunit/php-token-stream",
@@ -821,7 +820,7 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2014-03-03 05:10:30"
+            "time": "2014-03-03T05:10:30+00:00"
         },
         {
             "name": "phpunit/phpunit",
@@ -895,7 +894,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2013-09-16 03:09:52"
+            "time": "2013-09-16T03:09:52+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
@@ -944,7 +943,7 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2013-01-13 10:24:48"
+            "time": "2013-01-13T10:24:48+00:00"
         },
         {
             "name": "phpunit/phpunit-selenium",
@@ -993,7 +992,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2013-02-02 16:03:01"
+            "time": "2013-02-02T16:03:01+00:00"
         },
         {
             "name": "ramsey/array_column",
@@ -1038,7 +1037,7 @@
                 "array_column",
                 "column"
             ],
-            "time": "2015-03-20 22:07:39"
+            "time": "2015-03-20T22:07:39+00:00"
         },
         {
             "name": "rmccue/requests",
@@ -1087,7 +1086,7 @@
                 "iri",
                 "sockets"
             ],
-            "time": "2014-05-18 04:59:02"
+            "time": "2014-05-18T04:59:02+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
@@ -1160,7 +1159,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2014-12-18 02:37:51"
+            "time": "2014-12-18T02:37:51+00:00"
         },
         {
             "name": "symfony/config",
@@ -1208,7 +1207,7 @@
             ],
             "description": "Symfony Config Component",
             "homepage": "http://symfony.com",
-            "time": "2014-12-02 20:19:20"
+            "time": "2014-12-02T20:19:20+00:00"
         },
         {
             "name": "symfony/console",
@@ -1268,7 +1267,7 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2016-06-29 07:02:14"
+            "time": "2016-06-29T07:02:14+00:00"
         },
         {
             "name": "symfony/dependency-injection",
@@ -1325,7 +1324,7 @@
             ],
             "description": "Symfony DependencyInjection Component",
             "homepage": "http://symfony.com",
-            "time": "2014-12-03 09:22:11"
+            "time": "2014-12-03T09:22:11+00:00"
         },
         {
             "name": "symfony/filesystem",
@@ -1372,7 +1371,7 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "http://symfony.com",
-            "time": "2014-12-02 20:19:20"
+            "time": "2014-12-02T20:19:20+00:00"
         },
         {
             "name": "symfony/finder",
@@ -1419,7 +1418,7 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "http://symfony.com",
-            "time": "2014-12-02 20:19:20"
+            "time": "2014-12-02T20:19:20+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
@@ -1478,7 +1477,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2016-05-18 14:26:46"
+            "time": "2016-05-18T14:26:46+00:00"
         },
         {
             "name": "symfony/process",
@@ -1525,7 +1524,7 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "http://symfony.com",
-            "time": "2014-12-02 20:19:20"
+            "time": "2014-12-02T20:19:20+00:00"
         },
         {
             "name": "symfony/templating",
@@ -1578,7 +1577,7 @@
             ],
             "description": "Symfony Templating Component",
             "homepage": "http://symfony.com",
-            "time": "2014-12-02 20:19:20"
+            "time": "2014-12-02T20:19:20+00:00"
         },
         {
             "name": "symfony/yaml",
@@ -1625,7 +1624,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "http://symfony.com",
-            "time": "2014-12-02 20:19:20"
+            "time": "2014-12-02T20:19:20+00:00"
         },
         {
             "name": "totten/php-symbol-diff",
@@ -1668,7 +1667,7 @@
                 }
             ],
             "description": "Identify changes in PHP code by symbol (class/method)",
-            "time": "2015-08-06 08:23:13"
+            "time": "2015-08-06T08:23:13+00:00"
         },
         {
             "name": "wp-cli/php-cli-tools",
@@ -1718,7 +1717,7 @@
                 "cli",
                 "console"
             ],
-            "time": "2015-08-10 12:46:19"
+            "time": "2015-08-10T12:46:19+00:00"
         }
     ],
     "packages-dev": [],

--- a/src/command/upgrade-test.run.sh
+++ b/src/command/upgrade-test.run.sh
@@ -4,7 +4,7 @@ if grep -q drupal "$WEB_ROOT/index.php" ; then
   cvutil_mkdir "$UPGRADE_LOG_DIR"
   pushd "$PRJDIR/vendor/civicrm/upgrade-test/databases" > /dev/null
     ## Note $ARGS is list of non-option parameters. The first two were action+buildname.
-    civicrm-upgrade-test --db "$CIVI_DB_NAME" --db-args "$CIVI_DB_ARGS" --web "$WEB_ROOT" --out "$UPGRADE_LOG_DIR" --junit-xml "$UPGRADE_LOG_DIR/civicrm-upgrade-test.xml" "${ARGS[@]:2}"
+    ../civicrm-upgrade-test --db "$CIVI_DB_NAME" --db-args "$CIVI_DB_ARGS" --web "$WEB_ROOT" --out "$UPGRADE_LOG_DIR" --junit-xml "$UPGRADE_LOG_DIR/civicrm-upgrade-test.xml" "${ARGS[@]:2}"
   popd > /dev/null
 else
   echo "Skipped. civicrm-upgrade-test currently requires Drupal 7 and Drush."


### PR DESCRIPTION
https://lab.civicrm.org/development-team/Release-Management/issues/1 will realign the version numbering from the third digit (`4.7.{$z}`) to the second digit (`5.{$y}.0`).

However, some parts of the upgrade-testing assumed that the second digit doesn't change very often -- they are hardcoded to the given value of the second digit.

With this revision, the upgrade-testing should provide similar behavior without requiring the hard-coded values.