### PR TITLE
civi-test-run - Multiple updates

### DIFF
--- a/bin/civi-test-run
+++ b/bin/civi-test-run
@@ -117,9 +117,12 @@ function absdirname() {
 
 BINDIR=$(absdirname "$0")
 PRJDIR=$(dirname "$BINDIR")
+BLDDIR="$PRJDIR/build"
 EXITCODES=
 SUITES=
 GUARD=
+
+[ -f "$PRJDIR/app/civibuild.conf" ] && source "$PRJDIR/app/civibuild.conf"
 
 #################################################
 ## Parse inputs
@@ -131,8 +134,7 @@ while [ -n "$1" ] ; do
     case "$OPTION" in
       -b)
         BLDNAME="$1"
-        BLDDIR="$PRJDIR/build/$BLDNAME"
-        pushd "$BLDDIR"
+        pushd "$BLDDIR/$BLDNAME"
           CIVI_CORE=$(cv ev 'echo $GLOBALS["civicrm_root"];')
           ## or: cv path -d '[civicrm.root]'
         popd

--- a/bin/civi-test-run
+++ b/bin/civi-test-run
@@ -58,6 +58,7 @@ function task_phpunit() {
   if ! $GUARD phpunit-each $EXCLUDE_GROUP "$CIVI_CORE" "$JUNITDIR" $SUITE ; then
     EXITCODES="$EXITCODES phpunit"
   fi
+  echo "Found EXITCODES=\"$EXITCODES\""
 
   if [ $SUITE = 'E2E_AllTests' ]; then
       $GUARD civibuild restore "$BLDNAME"
@@ -75,6 +76,7 @@ function task_karma() {
       if ! $GUARD karma start --browsers PhantomJS --single-run --reporters dots,junit ; then
         EXITCODES="$EXITCODES karma"
       fi
+      echo "Found EXITCODES=\"$EXITCODES\""
       $GUARD cp tests/output/karma.xml "$JUNITDIR/"
     fi
   $GUARD popd
@@ -87,6 +89,7 @@ function task_upgrade() {
   if  ! $GUARD civibuild upgrade-test $BLDNAME $@ ; then
     EXITCODES="$EXITCODES upgrade-test"
   fi
+  echo "Found EXITCODES=\"$EXITCODES\""
   $GUARD cp "$PRJDIR/app/debug/$BLDNAME/civicrm-upgrade-test.xml" "$JUNITDIR/"
   $GUARD civibuild restore "$BLDNAME"
 }
@@ -103,6 +106,7 @@ function task_phpunit_drupal() {
   if ! $GUARD phpunit4 --tap --log-junit "$JUNITDIR/phpunit_drupal.xml" $EXCLUDE_GROUP ; then
     EXITCODES="$EXITCODES phpunit-drupal"
   fi
+  echo "Found EXITCODES=\"$EXITCODES\""
 
   phpunit-xml-cleanup "$JUNITDIR"/*.xml
   $GUARD popd
@@ -172,7 +176,7 @@ if [ -z "$SUITES" -o -z "$BLDNAME" -o -z "$JUNITDIR" ]; then
   exit 2
 fi
 
-if [ $SUITES = "all" ]; then
+if [ "$SUITES" = "all" ]; then
   if [ -f "$CIVI_CORE/tests/phpunit/E2E/AllTests.php" ]; then
     SUITES="karma upgrade phpunit-e2e phpunit-crm phpunit-api phpunit-civi"
   else

--- a/bin/civi-test-run
+++ b/bin/civi-test-run
@@ -30,6 +30,7 @@ function show_help() {
   echo "  -h                  Display help"
   echo "  -b <build-name>     The name of a local site produced by civibuild (required)"
   echo "  -j <junit-dir>      The path to a folder for storing results in JUnit XML (required)"
+  echo "  --exclude-group <g> Exclude tests with a particular @group"
   echo "  <suites>            A list of one more of the following:"
   echo "                        - all"
   echo "                        - karma"
@@ -54,7 +55,7 @@ function show_help() {
 function task_phpunit() {
   SUITE="$1"
 
-  if ! $GUARD phpunit-each --exclude-group ornery "$CIVI_CORE" "$JUNITDIR" $SUITE ; then
+  if ! $GUARD phpunit-each $EXCLUDE_GROUP "$CIVI_CORE" "$JUNITDIR" $SUITE ; then
     EXITCODES="$EXITCODES phpunit"
   fi
 
@@ -99,7 +100,7 @@ function junit_cleanup() {
 
 function task_phpunit_drupal() {
   $GUARD pushd "$CIVI_CORE/drupal"
-  if ! $GUARD phpunit4 --tap --log-junit "$JUNITDIR/phpunit_drupal.xml" '--exclude-group' 'ornery' ; then
+  if ! $GUARD phpunit4 --tap --log-junit "$JUNITDIR/phpunit_drupal.xml" $EXCLUDE_GROUP ; then
     EXITCODES="$EXITCODES phpunit-drupal"
   fi
 
@@ -120,6 +121,7 @@ PRJDIR=$(dirname "$BINDIR")
 BLDDIR="$PRJDIR/build"
 EXITCODES=
 SUITES=
+EXCLUDE_GROUP=
 GUARD=
 
 [ -f "$PRJDIR/app/civibuild.conf" ] && source "$PRJDIR/app/civibuild.conf"
@@ -127,36 +129,39 @@ GUARD=
 #################################################
 ## Parse inputs
 while [ -n "$1" ] ; do
-  if [ $1 = "-b" ] || [ $1 = "-j" ] ; then
-    OPTION="$1"
-    shift
+  OPTION="$1"
+  shift
 
-    case "$OPTION" in
-      -b)
-        BLDNAME="$1"
-        pushd "$BLDDIR/$BLDNAME"
-          CIVI_CORE=$(cv ev 'echo $GLOBALS["civicrm_root"];')
-          ## or: cv path -d '[civicrm.root]'
-        popd
-        shift
-        ;;
+  case "$OPTION" in
+    -b)
+      BLDNAME="$1"
+      pushd "$BLDDIR/$BLDNAME"
+        CIVI_CORE=$(cv ev 'echo $GLOBALS["civicrm_root"];')
+        ## or: cv path -d '[civicrm.root]'
+      popd
+      shift
+      ;;
 
-      -j)
-        JUNITDIR="$1"
-        junit_cleanup
-        shift
-        ;;
+    -j)
+      JUNITDIR="$1"
+      junit_cleanup
+      shift
+      ;;
 
-    esac
+    --exclude-group)
+      EXCLUDE_GROUP="--exclude-group $1"
+      shift
+      ;;
 
-  elif [ $1 = "-h" ] || [ $1 = "--help" ] || [ $1 = "-?" ] ; then
-    show_help
-    exit 2
+    -h|--help|-?)
+      show_help
+      exit 2
+      ;;
 
-  else
-    SUITES="$SUITES $1"
-    shift
-  fi
+    *)
+      SUITES="$SUITES $OPTION"
+      ;;
+  esac
 done
 
 ## Validate


### PR DESCRIPTION
There's more description in the commits, but generally:

1. When running `civi-test-run` on a system with a custom path for `BLDDIR`, we should use that custom path.

2. For PHPUnit tests, the `--exclude-group ornery` should be optional. 
