### PR TITLE
PCHR-3495: Remove webform_civicrm patch, update version

### DIFF
--- a/app/config/hr17/drush.make.tmpl
+++ b/app/config/hr17/drush.make.tmpl
@@ -63,8 +63,7 @@ projects[webform][subdir] = contrib
 projects[webform][version] = 4.12
 
 projects[webform_civicrm][subdir] = contrib
-projects[webform_civicrm][version] = "4.19"
-projects[webform_civicrm][patch][] = "https://patch-diff.githubusercontent.com/raw/colemanw/webform_civicrm/pull/93.patch"
+projects[webform_civicrm][version] = "4.20"
 
 projects[views][subdir] = contrib
 projects[views][version] = 3.14


### PR DESCRIPTION
## Before 

`webform_civicrm` versions on new sites was 4.19 and included a patch to enable "Create Only" mode

## After

`webform_civicrm` versions on new sites is 4.20 and includes the changes from the patch (which was merged)