### PR TITLE
civi-test-run - Fix handling of "all" target

### DIFF
--- a/bin/civi-test-run
+++ b/bin/civi-test-run
@@ -163,7 +163,8 @@ while [ -n "$1" ] ; do
       ;;
 
     *)
-      SUITES="$SUITES $OPTION"
+      SUITES=$(echo "$SUITES" "$OPTION" | xargs)
+      # note: xargs strips leading/trailing spaces
       ;;
   esac
 done
@@ -182,6 +183,9 @@ if [ "$SUITES" = "all" ]; then
   else
     SUITES="karma upgrade phpunit-crm phpunit-api phpunit-civi"
   fi
+elif [[ " $SUITES " =~ \ all\  ]]; then
+  echo "The \"all\" target should not be mixed with other targets."
+  exit 3
 fi
 
 ## Main


### PR DESCRIPTION
This addresses a regression where running "civi-test-run all" would lead to an error

```
unrecognized suite: all
```

The problem arose because `$SUITES` had a leading space which was hard to
test for.