### PR TITLE
PCHR-3523: Run the apply fork patch script as part of buildkit

### DIFF
--- a/app/config/hr17/install.sh
+++ b/app/config/hr17/install.sh
@@ -6,7 +6,7 @@
 # Runs the scripts that patches the compucorp's civicrm-core fork on
 # the original core files
 function apply_core_fork_patch() {
-  bash ${CIVI_CORE}/tools/extensions/civihr/bin/apply-core-fork-patch.sh
+  (cd ${CIVI_CORE}/tools/extensions/civihr && bash bin/apply-core-fork-patch.sh)
 }
 
 ##

--- a/app/config/hr17/install.sh
+++ b/app/config/hr17/install.sh
@@ -3,6 +3,13 @@
 ## install.sh -- Create config files and databases; fill the databases
 
 ##
+# Runs the scripts that patches the compucorp's civicrm-core fork on
+# the original core files
+function apply_core_fork_patch() {
+  bash ${CIVI_CORE}/tools/extensions/civihr/bin/apply-core-fork-patch.sh
+}
+
+##
 # Creates the default CiviHR users
 function create_default_users() {
   drush -y user-create --password="civihr_staff" --mail="civihr_staff@compucorp.co.uk" "civihr_staff"
@@ -137,6 +144,7 @@ pushd "${WEB_ROOT}/sites/${DRUPAL_SITE_DIR}" >> /dev/null
   ## Setup welcome page
   drush -y scr "$SITE_CONFIG_DIR/install-welcome.php"
 
+  apply_core_fork_patch
   install_civihr
 
   drush -y en civicrmtheme \


### PR DESCRIPTION
Running the script added in https://github.com/civicrm/civihr/pull/2571 as part of the civibuild install script, before installing CiviHR