### PR TITLE
app/config/site-list - Add an optional web-based list of available builds

### DIFF
--- a/app/config/site-list/download.sh
+++ b/app/config/site-list/download.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+mkdir "$WEB_ROOT"
+
+cat >"$WEB_ROOT/index.php" <<EOF
+<?php
+require_once __DIR__ . '/site-list.settings.php';
+require_once \$GLOBALS['civibuild']['SITE_CONFIG_DIR'] . '/src/site-list.php';
+sitelist_main(\$GLOBALS['sitelist'], \$GLOBALS['civibuild']);
+EOF

--- a/app/config/site-list/install.sh
+++ b/app/config/site-list/install.sh
@@ -14,6 +14,9 @@ global \$sitelist;
 //\$sitelist['display'] =  ['ALL'];
 //\$sitelist['display'] =  ['ADMIN_USER', 'DEMO_USER', 'WEB_ROOT', 'CIVI_CORE', 'CMS_DB', 'CIVI_DB', 'TEST_DB', 'SITE_TYPE', 'BUILD_TIME'];
 \$sitelist['display'] = ['ADMIN_USER', 'DEMO_USER', 'SITE_TYPE', 'BUILD_TIME'];
+
+//\$sitelist['about'] = 'These test sites are produced by the continuous-integration system.';
+//\$sitelist['about'] = 'These are local development sites.';
 EOF
 
 cvutil_inject_settings "$WEB_ROOT/site-list.settings.php" "site-list.settings.d"

--- a/app/config/site-list/install.sh
+++ b/app/config/site-list/install.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+amp_install
+
+#echo "<?php" > "$WEB_ROOT/site-list.settings.php"
+#echo "\$civibuild['BLDDIR'] = '$BLDDIR';" >> "$WEB_ROOT/site-list.settings.php"
+
+cat > "$WEB_ROOT/site-list.settings.php" << EOF
+<?php
+\$civibuild['BLDDIR'] = '$BLDDIR';
+
+// Choose what details to display. A few examples:
+global \$sitelist;
+//\$sitelist['display'] =  ['ALL'];
+//\$sitelist['display'] =  ['ADMIN_USER', 'DEMO_USER', 'WEB_ROOT', 'CIVI_CORE', 'CMS_DB', 'CIVI_DB', 'TEST_DB', 'SITE_TYPE', 'BUILD_TIME'];
+\$sitelist['display'] = ['ADMIN_USER', 'DEMO_USER', 'SITE_TYPE', 'BUILD_TIME'];
+EOF
+
+cvutil_inject_settings "$WEB_ROOT/site-list.settings.php" "site-list.settings.d"

--- a/app/config/site-list/install.sh
+++ b/app/config/site-list/install.sh
@@ -15,6 +15,8 @@ global \$sitelist;
 //\$sitelist['display'] =  ['ADMIN_USER', 'DEMO_USER', 'WEB_ROOT', 'CIVI_CORE', 'CMS_DB', 'CIVI_DB', 'TEST_DB', 'SITE_TYPE', 'BUILD_TIME'];
 \$sitelist['display'] = ['ADMIN_USER', 'DEMO_USER', 'SITE_TYPE', 'BUILD_TIME'];
 
+//\$sitelist['title'] = 'My local sites';
+
 //\$sitelist['about'] = 'These test sites are produced by the continuous-integration system.';
 //\$sitelist['about'] = 'These are local development sites.';
 EOF

--- a/app/config/site-list/src/list-page.tpl.php
+++ b/app/config/site-list/src/list-page.tpl.php
@@ -8,6 +8,8 @@
  *   Site-list UI configuration.
  * @param array $sites
  *   List of site definitions (from the *.sh files)
+ * @param string $filter
+ *   The current filter value.
  */ ?>
 <html>
 
@@ -25,6 +27,11 @@
 <?php if (!empty($config['about'])): ?>
   <p class="about"><?php echo $config['about'];?></p>
 <?php endif; ?>
+
+<?php echo sitelist_render('search-form.tpl.php', [
+  'config' => $config,
+  'filter' => $filter,
+]); ?>
 
 <?php if (empty($sites)): ?>
   <p>No sites found.</p>

--- a/app/config/site-list/src/list-page.tpl.php
+++ b/app/config/site-list/src/list-page.tpl.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * @file
+ *
+ * Render a full listing page.
+ *
+ * @param array $config
+ *   Site-list UI configuration.
+ * @param array $sites
+ *   List of site definitions (from the *.sh files)
+ */ ?>
+<html>
+
+<head>
+  <title><?php echo htmlentities($title); ?></title>
+  <style type="text/css">
+    <?php echo sitelist_render('style.css.php'); ?>
+  </style>
+</head>
+
+<body>
+
+<h1><?php echo htmlentities($title); ?></h1>
+
+<?php if (empty($sites)): ?>
+  <p>No sites found.</p>
+<?php endif; ?>
+
+<ul class="site-list">
+  <?php foreach ($sites as $name => $site): ?>
+    <li>
+      <h2 class="site-list-title">
+        <a href="<?php echo htmlentities($site['CMS_URL']); ?>">
+          <?php echo htmlentities($name); ?>
+        </a>
+      </h2>
+      <div class="site-list-details">
+        <?php echo sitelist_render('site-details.tpl.php', [
+          'config' => $config,
+          'site' => $site
+        ]); ?>
+      </div>
+    </li>
+  <?php endforeach; ?>
+</ul>
+</body>
+</html>

--- a/app/config/site-list/src/list-page.tpl.php
+++ b/app/config/site-list/src/list-page.tpl.php
@@ -22,6 +22,10 @@
 
 <h1><?php echo htmlentities($title); ?></h1>
 
+<?php if (!empty($config['about'])): ?>
+  <p class="about"><?php echo $config['about'];?></p>
+<?php endif; ?>
+
 <?php if (empty($sites)): ?>
   <p>No sites found.</p>
 <?php endif; ?>

--- a/app/config/site-list/src/list-page.tpl.php
+++ b/app/config/site-list/src/list-page.tpl.php
@@ -12,7 +12,7 @@
 <html>
 
 <head>
-  <title><?php echo htmlentities($title); ?></title>
+  <title><?php echo htmlentities($config['title']); ?></title>
   <style type="text/css">
     <?php echo sitelist_render('style.css.php'); ?>
   </style>
@@ -20,7 +20,7 @@
 
 <body>
 
-<h1><?php echo htmlentities($title); ?></h1>
+<h1><?php echo htmlentities($config['title']); ?></h1>
 
 <?php if (!empty($config['about'])): ?>
   <p class="about"><?php echo $config['about'];?></p>

--- a/app/config/site-list/src/search-form.tpl.php
+++ b/app/config/site-list/src/search-form.tpl.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * @file
+ *
+ * Render a search from.
+ *
+ * @param array $config
+ *   Site-list UI configuration.
+ * @param string $filter
+ *   The current filter value.
+ */ ?>
+
+<form method="get">
+  <label>Filter
+    <input type="text" name="filter" value="<?php echo htmlentities($filter); ?>"/>
+  </label>
+  <input type="submit" value="Apply"/>
+</form>

--- a/app/config/site-list/src/site-details.tpl.php
+++ b/app/config/site-list/src/site-details.tpl.php
@@ -85,7 +85,7 @@
   <?php if ($displayOption === 'BUILD_TIME'): ?>
     <div class="site-list-detail">
       <strong>Build Time</strong>:
-      <?php echo date('Y-m-d H:i:s T', $site['BUILD_TIME']); ?>
+      <?php echo date('Y-m-d H:i T', $site['BUILD_TIME']); ?>
     </div>
   <?php endif; ?>
 

--- a/app/config/site-list/src/site-details.tpl.php
+++ b/app/config/site-list/src/site-details.tpl.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * @file
+ *
+ * Render the chosen list of fields (for a given site).
+ *
+ * @param array $config
+ *   Site-list UI configuration.
+ * @param array $site
+ *   Site definition (from the *.sh file)
+ */ ?>
+
+<?php foreach ($config['display'] as $displayOption): ?>
+
+  <?php if ($displayOption === 'ALL'): ?>
+    <div class="site-list-detail">
+      <strong>All site metadata</strong>:
+      <pre>
+          <?php var_export($site); ?>
+        </pre>
+    </div>
+  <?php endif; ?>
+
+  <?php if ($displayOption === 'ADMIN_USER'): ?>
+    <div class="site-list-detail">
+      <strong>Admin User</strong>:
+      <code><?php echo htmlentities($site['ADMIN_USER']); ?></code>
+      /
+      <code><?php echo htmlentities($site['ADMIN_PASS']); ?></code>
+    </div>
+  <?php endif; ?>
+
+  <?php if ($displayOption === 'DEMO_USER'): ?>
+    <div class="site-list-detail">
+      <strong>Demo User</strong>:
+      <code><?php echo htmlentities($site['DEMO_USER']); ?></code>
+      /
+      <code><?php echo htmlentities($site['DEMO_USER']); ?></code>
+    </div>
+  <?php endif; ?>
+
+  <?php if ($displayOption === 'CMS_DB'): ?>
+    <div class="site-list-detail">
+      <strong>CMS DB</strong>:
+      <code><?php echo htmlentities($site['CMS_DB_DSN']); ?></code>
+    </div>
+  <?php endif; ?>
+
+  <?php if ($displayOption === 'CIVI_DB'): ?>
+    <div class="site-list-detail">
+      <strong>Civi DB</strong>:
+      <code><?php echo htmlentities($site['CIVI_DB_DSN']); ?></code>
+    </div>
+  <?php endif; ?>
+
+  <?php if ($displayOption === 'TEST_DB'): ?>
+    <div class="site-list-detail">
+      <strong>Test DB</strong>:
+      <code><?php echo htmlentities($site['TEST_DB_DSN']); ?></code>
+    </div>
+  <?php endif; ?>
+
+  <?php if ($displayOption === 'SITE_TYPE'): ?>
+    <div class="site-list-detail">
+      <strong>Site Build Type</strong>:
+      <code><?php echo htmlentities($site['SITE_TYPE']); ?></code>
+    </div>
+  <?php endif; ?>
+
+
+  <?php if ($displayOption === 'WEB_ROOT'): ?>
+    <div class="site-list-detail">
+      <strong>Web Root Path</strong>:
+      <code><?php echo htmlentities($site['WEB_ROOT']); ?></code>
+    </div>
+  <?php endif; ?>
+
+  <?php if ($displayOption === 'CIVI_CORE'): ?>
+    <div class="site-list-detail">
+      <strong>Civi Core Path</strong>:
+      <code><?php echo htmlentities($site['CIVI_CORE']); ?></code>
+    </div>
+  <?php endif; ?>
+
+  <?php if ($displayOption === 'BUILD_TIME'): ?>
+    <div class="site-list-detail">
+      <strong>Build Time</strong>:
+      <?php echo date('Y-m-d H:i:s T', $site['BUILD_TIME']); ?>
+    </div>
+  <?php endif; ?>
+
+<?php endforeach; ?>

--- a/app/config/site-list/src/site-list.php
+++ b/app/config/site-list/src/site-list.php
@@ -12,7 +12,6 @@ function sitelist_main($config, $civibuild) {
 
   if (empty($_GET['filter'])) {
     echo sitelist_render('list-page.tpl.php', [
-      'title' => 'Local Builds',
       'config' => $config,
       'sites' => $sites,
     ]);
@@ -20,7 +19,7 @@ function sitelist_main($config, $civibuild) {
   else {
     $regex = sitelist_create_filter($_GET['filter']);
     echo sitelist_render('list-page.tpl.php', [
-      'title' => 'Local Builds (filter="' . $_GET['filter'] . '")',
+      'filter' => $_GET['filter'],
       'config' => $config,
       'sites' => array_filter($sites, function($key) use ($regex) {
         return (bool) preg_match($regex, $key);
@@ -88,6 +87,7 @@ function sitelist_render($_tpl_file, $_tpl_data = array()) {
  */
 function sitelist_config($values = array()) {
   $defaults = array(
+    'title' => sprintf('Site list (%s)', gethostname()),
     'display' => ['ADMIN_USER', 'DEMO_USER', 'SITE_TYPE', 'BUILD_TIME'],
   );
   global $sitelist;

--- a/app/config/site-list/src/site-list.php
+++ b/app/config/site-list/src/site-list.php
@@ -73,7 +73,8 @@ function sitelist_render($_tpl_file, $_tpl_data = array()) {
  *
  * @return array
  *   A list of config options, such as:
- *   'display': array with an ordered list of options; any of the following
+ *   'about': string, displayable message about this server
+ *   'display': array, with an ordered list of options; any of the following
  *     'ADMIN_USER'
  *     'ALL'
  *     'BUILD_TIME'

--- a/app/config/site-list/src/site-list.php
+++ b/app/config/site-list/src/site-list.php
@@ -134,6 +134,12 @@ function sitelist_read_all($bldDir) {
   $files = (array) glob($bldDir . DIRECTORY_SEPARATOR . '*.sh');
   foreach ($files as $file) {
     $name = preg_replace(';\.sh$;', '', basename($file));
+
+    // Does the site appear to truly exist?
+    if (!file_exists($bldDir . DIRECTORY_SEPARATOR . $name)) {
+      continue;
+    }
+
     $sites[$name] = sitelist_read_sh($file);
   }
   return $sites;

--- a/app/config/site-list/src/site-list.php
+++ b/app/config/site-list/src/site-list.php
@@ -1,0 +1,139 @@
+<?php
+
+/**
+ * Render the main page.
+ *
+ * @param array|NULL $config
+ * @param array $civibuild
+ */
+function sitelist_main($config, $civibuild) {
+  $config = sitelist_config((array) $config);
+  $sites = sitelist_read_all($civibuild['BLDDIR']);
+
+  if (empty($_GET['filter'])) {
+    echo sitelist_render('list-page.tpl.php', [
+      'title' => 'Local Builds',
+      'config' => $config,
+      'sites' => $sites,
+    ]);
+  }
+  else {
+    $regex = sitelist_create_filter($_GET['filter']);
+    echo sitelist_render('list-page.tpl.php', [
+      'title' => 'Local Builds (filter="' . $_GET['filter'] . '")',
+      'config' => $config,
+      'sites' => array_filter($sites, function($key) use ($regex) {
+        return (bool) preg_match($regex, $key);
+      }, ARRAY_FILTER_USE_KEY),
+    ]);
+  }
+}
+
+/**
+ * Convert a filter expression to regex.
+ *
+ * @param string $filter
+ *   Ex: 'dmaster'
+ *   Ex: 'core-*-*'
+ *   Ex: 'd*'
+ * @return string
+ *   Ex: '/^dmaster$/'
+ *   Ex: '/^core-.*-.*$/'
+ *   Ex: '/^d.*$/'
+ */
+function sitelist_create_filter($filter) {
+  $regex = '/^' . preg_quote($filter, '/') . '$/';
+  $regex = str_replace(
+    preg_quote('*', '/'),
+    '.*',
+    $regex
+  );
+  return $regex;
+}
+
+/**
+ * Render a template.
+ *
+ * @param string $_tpl_file
+ *   Ex: 'my-view.tpl.php';
+ * @param array $_tpl_data
+ *   List of variables to import to the scope of the view.
+ * @return string
+ */
+function sitelist_render($_tpl_file, $_tpl_data = array()) {
+  $_tpl_file = __DIR__ . DIRECTORY_SEPARATOR . $_tpl_file;
+  ob_start();
+  extract($_tpl_data);
+  include $_tpl_file;
+  return ob_get_clean();
+}
+
+/**
+ * Generate the overall configuration, including $values and any defaults.
+ *
+ * @return array
+ *   A list of config options, such as:
+ *   'display': array with an ordered list of options; any of the following
+ *     'ADMIN_USER'
+ *     'ALL'
+ *     'BUILD_TIME'
+ *     'DEMO_USER'
+ *     'CIVI_CORE'
+ *     'CIVI_DB'
+ *     'CMS_DB'
+ *     'SITE_TYPE'
+ *     'TEST_DB'
+ *     'WEB_ROOT'
+ */
+function sitelist_config($values = array()) {
+  $defaults = array(
+    'display' => ['ADMIN_USER', 'DEMO_USER', 'SITE_TYPE', 'BUILD_TIME'],
+  );
+  global $sitelist;
+  return array_merge($defaults, (array) $sitelist);
+}
+
+/**
+ * Read a civibuild config file.
+ *
+ * @param string $shFile
+ *   Ex: '/srv/buildkit/build/foobar.sh'
+ * @return array
+ *   List of stored config values.
+ *   Ex: ['ADMIN_USER'=>'foo', 'ADMIN_PASS'=>'bar', ...].
+ */
+function sitelist_read_sh($shFile) {
+  $lines = explode("\n", file_get_contents($shFile));
+  $result = array();
+  foreach ($lines as $line) {
+    if (empty($line) || $line{0} == '#') {
+      continue;
+    }
+    if (preg_match('/^([A-Z0-9_]+)=\"(.*)\"$/', $line, $matches)) {
+      $result[$matches[1]] = stripcslashes($matches[2]);
+    }
+    else {
+      throw new \RuntimeException("Malformed line [$line]");
+    }
+  }
+
+  $result['BUILD_TIME'] = filemtime($shFile);
+  return $result;
+}
+
+/**
+ * Read metadata for all available sites.
+ *
+ * @param string $bldDir
+ * @return array
+ *   Ex: ['dmaster' => ['SITE_TYPE' => 'drupal-demo', ...]].
+ */
+function sitelist_read_all($bldDir) {
+  $sites = array();
+  $files = (array) glob($bldDir . DIRECTORY_SEPARATOR . '*.sh');
+  foreach ($files as $file) {
+    $name = preg_replace(';\.sh$;', '', basename($file));
+    $sites[$name] = sitelist_read_sh($file);
+  }
+  return $sites;
+}

--- a/app/config/site-list/src/style.css.php
+++ b/app/config/site-list/src/style.css.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * @file
+ *
+ * Render any CSS rules
+ */ ?>
+
+table, tr, td, th {
+  border: 0;
+}
+
+th {
+  font-weight: bold;
+  text-decoration: underline;
+}
+
+td, th {
+  text-align: left;
+  vertical-align: text-top;
+  padding: 1em;
+}

--- a/app/config/site-list/src/style.css.php
+++ b/app/config/site-list/src/style.css.php
@@ -5,6 +5,10 @@
  * Render any CSS rules
  */ ?>
 
+.about {
+  font-style: italic;
+}
+
 table, tr, td, th {
   border: 0;
 }

--- a/app/config/site-list/uninstall.sh
+++ b/app/config/site-list/uninstall.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+amp_uninstall


### PR DESCRIPTION
Add an optional, web-based list of available builds. This is intended to support CI/demo/test workflows.

Before
-------
* If you want to browse a list of sites created with `civibuild`, you can use `civibuild` subcommands on the CLI. 
* You cannot browse builds in a web browser.

After
-----
* If you want to browse a list of sites created with `civibuild`, you can use `civibuild` subcommands on the CLI. (Same as before.)
* You can run `civibuild create site-list ...` and visit the resulting web-page. It will show a live list of sites.
* To tweak the available info, edit `build/site-list/site-list.settings.php`.