### PR TITLE
PCHR-3784: Don't install yoti by defautl

### DIFF
--- a/app/config/hr17/install.sh
+++ b/app/config/hr17/install.sh
@@ -126,7 +126,6 @@ pushd "${WEB_ROOT}/sites/${DRUPAL_SITE_DIR}" >> /dev/null
     masquerade \
     smtp \
     logintoboggan \
-    yoti \
     menu_attributes \
     roles_for_menu
 


### PR DESCRIPTION
Installing yoti requires some additional configuration in Drupal. Since most people don't use yoti anyway and the installation script doesn't take care of this additional configuration, the yoti module should not be installed by default. It will still be downloaded, but people willing to use it will have to enable the module manually.