### PR TITLE
Load civirules from lab.civicrm.org

### DIFF
--- a/app/config/caches.sh
+++ b/app/config/caches.sh
@@ -28,7 +28,7 @@ git_cache_setup "https://github.com/eileenmcnaughton/civicrm_developer.git"  "$C
 git_cache_setup "https://github.com/civicrm/civivolunteer.git" "$CACHE_DIR/civicrm/civivolunteer.git"
 git_cache_setup "https://github.com/ginkgostreet/org.civicrm.angularprofiles.git" "$CACHE_DIR/ginkgostreet/org.civicrm.angularprofiles.git"
 
-git_cache_setup "https://github.com/civicoop/org.civicoop.civirules.git" "$CACHE_DIR/civicrm/org.civicoop.civirules.git"
+git_cache_setup "https://lab.civicrm.org/extensions/civirules.git" "$CACHE_DIR/civicrm/org.civicoop.civirules.git"
 git_cache_setup "https://github.com/TechToThePeople/civisualize.git" "$CACHE_DIR/TechToThePeople/civisualize.git"
 git_cache_setup "https://github.com/dlobo/org.civicrm.module.cividiscount.git" "$CACHE_DIR/dlobo/org.civicrm.module.cividiscount.git"
 


### PR DESCRIPTION
We have moved CiviRules from github to lab.civicrm.org
Buildkit should fetch civirules from this new location.