### PR TITLE
PCHR-3811: Update CiviHR repo URL

### DIFF
--- a/app/config/hr17/download.sh
+++ b/app/config/hr17/download.sh
@@ -4,7 +4,7 @@
 
 ###############################################################################
 
-git_cache_setup "https://github.com/civicrm/civihr.git" "$CACHE_DIR/civicrm/civihr.git"
+git_cache_setup "https://github.com/compucorp/civihr.git" "$CACHE_DIR/compucorp/civihr.git"
 
 [ -z "$CMS_VERSION" ] && CMS_VERSION=7.x
 [ -z "$CIVI_VERSION" ] && CIVI_VERSION=4.4

--- a/app/config/hr17/drush.make.tmpl
+++ b/app/config/hr17/drush.make.tmpl
@@ -42,7 +42,7 @@ libraries[civicrmpackages][overwrite] = TRUE
 libraries[civihr][destination] = modules
 libraries[civihr][directory_name] = civicrm/tools/extensions/civihr
 libraries[civihr][download][type] = git
-libraries[civihr][download][url] = %%CACHE_DIR%%/civicrm/civihr.git
+libraries[civihr][download][url] = %%CACHE_DIR%%/compucorp/civihr.git
 libraries[civihr][download][branch] = %%HR_VERSION%%
 libraries[civihr][overwrite] = TRUE
 


### PR DESCRIPTION
## Overview

The ownership of the civihr repository has been transferred from the CiviCRM organization to Compucorp. This PR updates references to the repo URL to reflect the new ownership.

## Before

URLs to the repository would reference `civicrm` as the owner.

## After

URLs to the repository now reference `compucorp` as the owner.