### PR TITLE
For build types which install CiviVolunteer…

### DIFF
--- a/app/config/drupal-demo/download.sh
+++ b/app/config/drupal-demo/download.sh
@@ -5,9 +5,8 @@
 ###############################################################################
 
 [ -z "$CMS_VERSION" ] && CMS_VERSION=7.x
-#[ -z "$VOL_VERSION" ] && VOL_VERSION='4.4-1.x'
 [ -z "$VOL_VERSION" ] && VOL_VERSION='master'
-[ -z "$NG_PRFL_VERSION" ] && NG_PRFL_VERSION='v4.6-1.0.2'
+[ -z "$NG_PRFL_VERSION" ] && NG_PRFL_VERSION='master'
 [ -z "$RULES_VERSION" ] && RULES_VERSION='master'
 [ -z "$DISC_VERSION" ] && DISC_VERSION='master'
 

--- a/app/config/drupal8-demo/download.sh
+++ b/app/config/drupal8-demo/download.sh
@@ -5,8 +5,8 @@
 ###############################################################################
 
 [ -z "$CMS_VERSION" ] && CMS_VERSION=8.x
-[ -z "$VOL_VERSION" ] && VOL_VERSION='4.4-1.x'
-[ -z "$NG_PRFL_VERSION" ] && NG_PRFL_VERSION='v4.6-1.0.1'
+[ -z "$VOL_VERSION" ] && VOL_VERSION='master'
+[ -z "$NG_PRFL_VERSION" ] && NG_PRFL_VERSION='master'
 [ -z "$DISC_VERSION" ] && DISC_VERSION=master
 
 MAKEFILE="${TMPDIR}/${SITE_TYPE}/${SITE_NAME}/${SITE_ID}.make"

--- a/app/config/wp-demo/download.sh
+++ b/app/config/wp-demo/download.sh
@@ -3,7 +3,8 @@
 ## download.sh -- Download WordPress and CiviCRM
 
 ###############################################################################
-[ -z "$VOL_VERSION" ] && VOL_VERSION='4.4-1.x'
+[ -z "$VOL_VERSION" ] && VOL_VERSION='master'
+[ -z "$NG_PRFL_VERSION" ] && NG_PRFL_VERSION='master'
 
 [ -z "$CMS_VERSION" ] && CMS_VERSION=4.8
 
@@ -25,7 +26,7 @@ pushd $WEB_ROOT/wp-content/plugins >> /dev/null
   git clone ${CACHE_DIR}/civicrm/civicrm-packages.git                 -b "$CIVI_VERSION" civicrm/civicrm/packages
   git clone ${CACHE_DIR}/civicrm/civicrm-demo-wp.git                  -b master          civicrm-demo-wp
   git clone ${CACHE_DIR}/civicrm/civivolunteer.git                    -b "$VOL_VERSION"  civicrm/civicrm/tools/extensions/civivolunteer
-  git clone ${CACHE_DIR}/ginkgostreet/org.civicrm.angularprofiles.git -b master          civicrm/civicrm/tools/extensions/org.civicrm.angularprofiles
+  git clone ${CACHE_DIR}/ginkgostreet/org.civicrm.angularprofiles.git -b "$NG_PRFL_VERSION" civicrm/civicrm/tools/extensions/org.civicrm.angularprofiles
 
   git_set_hooks civicrm-wordpress   civicrm                    "../civicrm/tools/scripts/git"
   git_set_hooks civicrm-core        civicrm/civicrm            "../tools/scripts/git"

--- a/app/config/wp-empty/download.sh
+++ b/app/config/wp-empty/download.sh
@@ -3,8 +3,6 @@
 ## download.sh -- Download WordPress
 
 ###############################################################################
-[ -z "$VOL_VERSION" ] && VOL_VERSION='4.4-1.x'
-
 [ -z "$CMS_VERSION" ] && CMS_VERSION=4.8
 
 echo "[[Download WordPress]]"


### PR DESCRIPTION
…set the default branch for the org.civicrm.volunteer and org.civicrm.angularprofiles repos to master.

Removed reference to CiviVolunteer from wp-empty, which doesn't install CiviCRM at all.