### PR TITLE
PCHR-3933: patch for civicrm_webform 7.x-4.20

### DIFF
--- a/app/config/hr17/drush.make.tmpl
+++ b/app/config/hr17/drush.make.tmpl
@@ -64,7 +64,7 @@ projects[webform][version] = 4.12
 
 projects[webform_civicrm][subdir] = contrib
 projects[webform_civicrm][version] = "4.20"
-projects[webform_civicrm][patch] = "https://github.com/compucorp/webform_civicrm-1/compare/7.x-4.20...PCHR-3933-fixes-for-7.x-4.20.patch"
+projects[webform_civicrm][patch][] = "https://github.com/compucorp/webform_civicrm-1/compare/7.x-4.20...PCHR-3933-fixes-for-7.x-4.20.patch"
 
 projects[views][subdir] = contrib
 projects[views][version] = 3.14

--- a/app/config/hr17/drush.make.tmpl
+++ b/app/config/hr17/drush.make.tmpl
@@ -64,6 +64,7 @@ projects[webform][version] = 4.12
 
 projects[webform_civicrm][subdir] = contrib
 projects[webform_civicrm][version] = "4.20"
+projects[webform_civicrm][patch] = "https://github.com/compucorp/webform_civicrm-1/compare/7.x-4.20...PCHR-3933-fixes-for-7.x-4.20.patch"
 
 projects[views][subdir] = contrib
 projects[views][version] = 3.14


### PR DESCRIPTION
Overview
------------------------------------
This patch is intended to fix 2 bugs present in `webform_civicrm` 7.x-4.20.

1. **When webform is configured with multiple emails of the same location** (for example: personal) it overwrites on save the first value with the last value, producing unexpected results on save. See https://github.com/colemanw/webform_civicrm/pull/145 and https://github.com/colemanw/webform_civicrm/pull/148

2. **When webform is configured to have an address and the user is allowed to select the type**, the existing phone data is not automatically filled in the form, producing unexpected results on load and on save. See https://github.com/colemanw/webform_civicrm/pull/146

Before
---------------------------------
`webform_civicrm`  on version 4.20 without patches.

After
----------------------------
`webform_civicrm`  on version 4.20 with a patch to fix issues described in this ticket:
https://compucorp.atlassian.net/browse/PCHR-3933

Technical Details
--------------------------
2 PRs were created against the current master version of webform_civicrm

https://github.com/colemanw/webform_civicrm/pull/145 - merged
https://github.com/colemanw/webform_civicrm/pull/146 - currently open
