### PR TITLE
PCHR-4029: CiviHR 1.7.9 updates

### DIFF
--- a/app/config/hr17/download.sh
+++ b/app/config/hr17/download.sh
@@ -7,8 +7,8 @@
 git_cache_setup "https://github.com/compucorp/civihr.git" "$CACHE_DIR/compucorp/civihr.git"
 
 [ -z "$CMS_VERSION" ] && CMS_VERSION=7.x
-[ -z "$CIVI_VERSION" ] && CIVI_VERSION=4.4
-[ -z "$HR_VERSION" ] && HR_VERSION=master
+[ -z "$CIVI_VERSION" ] && CIVI_VERSION=5.3.1
+[ -z "$HR_VERSION" ] && HR_VERSION=staging
 
 MAKEFILE="${TMPDIR}/${SITE_TYPE}/${SITE_NAME}/${SITE_ID}.make"
 cvutil_makeparent "$MAKEFILE"

--- a/app/config/hr17/drush.make.tmpl
+++ b/app/config/hr17/drush.make.tmpl
@@ -136,7 +136,7 @@ projects[radix_layouts][subdir] = civihr-contrib-required
 projects[radix_layouts][version] = "3.3"
 
 projects[uuid][subdir] = civihr-contrib-required
-projects[uuid][version] = "1.0-alpha6"
+projects[uuid][version] = "1.2"
 
 projects[node_export][subdir] = civihr-contrib-required
 projects[node_export][version] = "3.0"

--- a/src/civibuild.aliases.sh
+++ b/src/civibuild.aliases.sh
@@ -78,7 +78,7 @@ function civibuild_alias_resolve() {
     hr14)        SITE_TYPE=hrdemo           ; CIVI_VERSION=4.5       ; CMS_TITLE="CiviHR 1.4 Demo"                   ; HR_VERSION=1.4        ;;
     hr15)        SITE_TYPE=hr15             ; CIVI_VERSION=4.5       ; CMS_TITLE="CiviHR 1.5 Demo"                   ; HR_VERSION=1.5        ;;
     hr16)        SITE_TYPE=hr16             ; CIVI_VERSION=4.7.9     ; CMS_TITLE="CiviHR 1.6 Demo"                   ; HR_VERSION=master     ; NO_SAMPLE_DATA=1       ;;
-    hr17)        SITE_TYPE=hr17             ; CIVI_VERSION=4.7.18    ; CMS_TITLE="CiviHR 1.7 Demo"                   ; HR_VERSION=master     ; NO_SAMPLE_DATA=1       ;;
+    hr17)        SITE_TYPE=hr17             ; CIVI_VERSION=5.3.1     ; CMS_TITLE="CiviHR 1.7 Demo"                   ; HR_VERSION=staging    ; NO_SAMPLE_DATA=1       ;;
     hrmaster)    SITE_TYPE=hr15             ; CIVI_VERSION=master    ; CMS_TITLE="CiviHR Sandbox"                    ; HR_VERSION=master     ;;
 
     bempty)      SITE_TYPE=backdrop-empty   ; CIVI_VERSION=none      ; CMS_TITLE="Backdrop Sandbox"                  ;;


### PR DESCRIPTION
This PR:

- Sets the minimum required version for CiviHR as 5.3.1
- Sets the default values for `hr-version` and `civi-version` in the `hr17` alias to `staging` and `5.3.1` respectively
- Sets the new default value for the `hr-ver` to `staging`, as this is the version we use most of the time
- Updates the `uuid` module version to 1.2, which is a security update