### PR TITLE
Fix error install CiviCRM demo instances with CiviCRM 5.x

### DIFF
--- a/src/civibuild.lib.sh
+++ b/src/civibuild.lib.sh
@@ -523,7 +523,7 @@ EOSQL
 ###############################################################################
 ## Appy more default values
 function civicrm_apply_demo_defaults() {
-  if cv ev 'exit(version_compare(CRM_Utils_System::version(), "4.7.0", "<") ?0:1);' ; then
+  if cv ev 'exit(version_compare(CRM_Utils_System::version(), "4.7", "<") ?0:1);' ; then
     cv api setting.create versionCheck=0 debug=1
   fi
   cv api MailSettings.create id=1 is_default=1 domain=example.org debug=1


### PR DESCRIPTION
The version check for 4.7.0 gives a false positive for 5.x and civicrm_apply_demo_defaults fails.  This fixes the issue.