### PR TITLE
don't require mcrypt

### DIFF
--- a/bin/civi-download-tools
+++ b/bin/civi-download-tools
@@ -570,7 +570,6 @@ check_php_ext curl required
 check_php_ext date required
 check_php_ext json required
 check_php_ext libxml required
-check_php_ext mcrypt required
 check_php_ext pcre required
 check_php_ext pdo_mysql required
 check_php_ext xml required


### PR DESCRIPTION
I feel that https://github.com/civicrm/civicrm-core/pull/12733 implies that mcrypt should no longer be a requirement for civi-download-tools - especially since this breaks on Ubuntu Bionic.  

My only question is if we should go a step or two further:
* Should we disable installing mcrypt on 7.2 via PECL?
* Should we disable installing mcrypt on all systems?

I can add to this PR or file follow-ups, but I'd like to poll the crowd first.