### PR TITLE
Use civicrm-drupal-8 for Drupal 8 builds instead of civicrm-drupal

### DIFF
--- a/app/config/caches.sh
+++ b/app/config/caches.sh
@@ -19,6 +19,7 @@
 git_cache_setup "https://github.com/civicrm/civicrm-backdrop.git"            "$CACHE_DIR/civicrm/civicrm-backdrop.git"
 git_cache_setup "https://github.com/civicrm/civicrm-core.git"                "$CACHE_DIR/civicrm/civicrm-core.git"
 git_cache_setup "https://github.com/civicrm/civicrm-drupal.git"              "$CACHE_DIR/civicrm/civicrm-drupal.git"
+git_cache_setup "https://github.com/civicrm/civicrm-drupal-8.git"            "$CACHE_DIR/civicrm/civicrm-drupal-8.git"
 git_cache_setup "https://github.com/civicrm/civicrm-packages.git"            "$CACHE_DIR/civicrm/civicrm-packages.git"
 git_cache_setup "https://github.com/civicrm/civicrm-joomla.git"              "$CACHE_DIR/civicrm/civicrm-joomla.git"
 git_cache_setup "https://github.com/civicrm/civicrm-wordpress.git"           "$CACHE_DIR/civicrm/civicrm-wordpress.git"

--- a/app/config/drupal8-clean/drush.make.tmpl
+++ b/app/config/drupal8-clean/drush.make.tmpl
@@ -26,8 +26,8 @@ projects[] = libraries
 libraries[civicrmdrupal][destination] = modules
 libraries[civicrmdrupal][directory_name] = civicrm
 libraries[civicrmdrupal][download][type] = git
-libraries[civicrmdrupal][download][url] = %%CACHE_DIR%%/civicrm/civicrm-drupal.git
-libraries[civicrmdrupal][download][branch] = 8.x-%%CIVI_VERSION%%
+libraries[civicrmdrupal][download][url] = %%CACHE_DIR%%/civicrm/civicrm-drupal-8.git
+libraries[civicrmdrupal][download][branch] = %%CIVI_VERSION%%
 libraries[civicrmdrupal][overwrite] = TRUE
 
 libraries[civicrm][destination] = libraries

--- a/app/config/drupal8-demo/drush.make.tmpl
+++ b/app/config/drupal8-demo/drush.make.tmpl
@@ -26,8 +26,8 @@ projects[] = libraries
 libraries[civicrmdrupal][destination] = modules
 libraries[civicrmdrupal][directory_name] = civicrm-drupal
 libraries[civicrmdrupal][download][type] = git
-libraries[civicrmdrupal][download][url] = %%CACHE_DIR%%/civicrm/civicrm-drupal.git
-libraries[civicrmdrupal][download][branch] = 8.x-%%CIVI_VERSION%%
+libraries[civicrmdrupal][download][url] = %%CACHE_DIR%%/civicrm/civicrm-drupal-8.git
+libraries[civicrmdrupal][download][branch] = %%CIVI_VERSION%%
 libraries[civicrmdrupal][overwrite] = TRUE
 
 libraries[civicrm][destination] = libraries


### PR DESCRIPTION
Buildkit used to use the civicrm-drupal repo for creating Drupal 8 sites. However the latest development is in the civicrm-drupal-8 repo. This PR

1) addes the civicrm-drupal-8 to the git cache warming
2) points the drupal8-demo to the new repo
3) points the drupal8-clean to the new repo.