### PR TITLE
drush - Fix random PHAR exceptions. Use dedicated cache dir.

### DIFF
--- a/bin/civi-download-tools
+++ b/bin/civi-download-tools
@@ -663,7 +663,7 @@ pushd $PRJDIR >> /dev/null
   [ -d "$PRJDIR/extern/civix" ] && rm -rf "$PRJDIR/extern/civix"
 
   ## download_program_if_changed <url> <out-file> <flag-file>
-  download_program_if_changed "$DRUSH8URL" "$PRJDIR/bin/drush8" "$PRJDIR/extern/drush8.txt"
+  download_program_if_changed "$DRUSH8URL" "$PRJDIR/extern/drush8.phar" "$PRJDIR/extern/drush8.txt"
   download_program_if_changed "$CVURL" "$PRJDIR/bin/cv" "$PRJDIR/extern/cv.txt"
   download_program_if_changed "$PHPUNITURL" "$PRJDIR/extern/phpunit4/phpunit4.phar" "$PRJDIR/extern/_phpunit4.txt"
   download_program_if_changed "$PHPUNIT5URL" "$PRJDIR/extern/phpunit5/phpunit5.phar" "$PRJDIR/extern/_phpunit5.txt"
@@ -685,6 +685,12 @@ pushd $PRJDIR >> /dev/null
       rm -f "$OLDFILE"
     fi
   done
+
+  if [ -z "$IS_QUIET" -o ! -f "$PRJDIR/bin/drush8" ]; then
+    ## drush8 was previously downloaded directly. This "cp" ensures we overwrite without git conflicts.
+    echo "[[drush8 ($PRJDIR/bin/drush8): Generate wrapper]]"
+    cp "$PRJDIR/src/drush/drush8.tmpl" "$PRJDIR/bin/drush8"
+  fi
 
   ## Setup phpunit aliases for CLI usage
   make_link "$PRJDIR/bin" "drush8" "drush"

--- a/src/drush/drush8.tmpl
+++ b/src/drush/drush8.tmpl
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+BINDIR=$(dirname $0)
+PRJDIR=$(dirname "$BINDIR")
+
+export CACHE_PREFIX=$PRJDIR/app/tmp/drush
+[ ! -d "$CACHE_PREFIX" ] && mkdir -p "$CACHE_PREFIX"
+if [ "$PWD" == "$BINDIR" ]; then
+  echo "Error: Cannot run drush from the bin dir. Please navigate to a site dir." >&2
+  exit 1
+fi
+exec "$PRJDIR/extern/drush8.phar" "$@"


### PR DESCRIPTION
After deploying the drush8 PHAR, we started getting random failures during builds.
This appears to happen because different copies of `drush8.phar`
(eg `bknix-min/bin/drush8` and `bknix-max/bin/drush8`) were writing data to the
same cache folder (`~/.drush`) ... but with conflicting metadata.

The specific symptom involved an error from the PharInterceptor, which I believe worked
like this:

* `bknix-min/bin/drush8` would write metadata about available commandfiles to `~/.drush`
* `bknix-max/bin/drush8` would read the metadata from`~/.drush`; but tha would point to
  commandfiles nested under `bknix-min/bin/drush8`
* `bknix-max/bin/drush8` would try to load the commandfiles from `bknix-min/bin/drush8`
* This would require opening the PHAR, but the PHAR had a non-PHAR extension.
* This would provoke an exception from D7's customized `phar://` stream wrapper.

This was very hard to diagnose because the symptoms did not appear
consistently -- if you had a dozen test jobs using a mix of environments,
then the happenstance of job-ordering and cache-timeouts would mean that
you'd only provoke a problematic crossover half the time.

This patch forces buildkit's copy of `drush` to use a separate cache folder
under `app/tmp/drush`.