### PR TITLE
Remove recommendation to install mcrypt

### DIFF
--- a/bin/civi-download-tools
+++ b/bin/civi-download-tools
@@ -750,7 +750,7 @@ check_php_ext hash recommended
 check_php_ext imap recommended
 check_php_ext intl recommended
 check_php_ext mbstring recommended
-check_php_ext mcrypt recommended "WARNING: Failed to locate the PHP \"mcrypt\" extension. Please install this manually to avoid issues with SMTP passwords or older versions of CiviCRM."
+
 if php -r 'exit(version_compare(PHP_VERSION, 7.0, "<") ? 0 : 1);' ; then
   check_php_ext mysql recommended  ## In case you try to install older Civi versions (<= 4.7.11)
 fi


### PR DESCRIPTION
We are no longer recommending this in core since it's as likely to create problems as solve them - ie
adding mcrypt to a functional php7.2 site will result in problems with passwords.

We don't have a great fix for encryption but we should stop making this recommendation as we
are making a recommendation that we are not confident will be helpful and may cause harm. Better to make no recommendation than a bad one