### PR TITLE
civibuild - Optionally use CIVIBUILD_HOME to redirect all mutable files

### DIFF
--- a/bin/civi-download-tools
+++ b/bin/civi-download-tools
@@ -15,7 +15,7 @@ function absdirname() {
 
 BINDIR=$(absdirname "$0")
 PRJDIR=$(dirname "$BINDIR")
-TMPDIR="$PRJDIR/app/tmp"
+[ -z "$CIVIBUILD_HOME" ] && TMPDIR="$PRJDIR/app/tmp" || TMPDIR="$CIVIBUILD_HOME/.civibuild/tmp"
 LOCKFILE="$TMPDIR/civi-download-tools.lock"
 LOCKTIMEOUT=90
 CIVIXURL="https://download.civicrm.org/civix/civix.phar-2019-06-19-ed25c04b"
@@ -68,7 +68,7 @@ while [ -n "$1" ] ; do
           PRJDIR=$(pwd)
         popd >> /dev/null
         BINDIR="$PRJDIR/bin"
-        TMPDIR="$PRJDIR/app/tmp"
+        [ -z "$CIVIBUILD_HOME" ] && TMPDIR="$PRJDIR/app/tmp" || TMPDIR="$CIVIBUILD_HOME/.civibuild/tmp"
         LOCKFILE="$TMPDIR/civi-download-tools.lock"
       set +e
       shift
@@ -739,7 +739,7 @@ pushd $PRJDIR >> /dev/null
     fi
   done
 
-  if [ -z "$IS_QUIET" -o ! -f "$PRJDIR/bin/drush8" ]; then
+  if [ ! -f "$PRJDIR/bin/drush8" -o "$PRJDIR/src/drush/drush8.tmpl" -nt  "$PRJDIR/bin/drush8" ]; then
     ## drush8 was previously downloaded directly. This "cp" ensures we overwrite without git conflicts.
     echo "[[drush8 ($PRJDIR/bin/drush8): Generate wrapper]]"
     cp "$PRJDIR/src/drush/drush8.tmpl" "$PRJDIR/bin/drush8"

--- a/bin/civi-test-run
+++ b/bin/civi-test-run
@@ -135,7 +135,8 @@ function absdirname() {
 
 BINDIR=$(absdirname "$0")
 PRJDIR=$(dirname "$BINDIR")
-BLDDIR="$PRJDIR/build"
+[ -z "$CIVIBUILD_HOME" ] && TMPDIR="$PRJDIR/app/tmp" || TMPDIR="$CIVIBUILD_HOME/.civibuild/tmp"
+[ -z "$CIVIBUILD_HOME" ] && BLDDIR="$PRJDIR/build" || BLDDIR="$CIVIBUILD_HOME"
 EXITCODES=
 SUITES=
 EXCLUDE_GROUP=

--- a/bin/civibuild
+++ b/bin/civibuild
@@ -14,8 +14,8 @@ function absdirname() {
 
 BINDIR=$(absdirname "$0")
 PRJDIR=$(dirname "$BINDIR")
-TMPDIR="$PRJDIR/app/tmp"
-BLDDIR="$PRJDIR/build"
+[ -z "$CIVIBUILD_HOME" ] && TMPDIR="$PRJDIR/app/tmp" || TMPDIR="$CIVIBUILD_HOME/.civibuild/tmp"
+[ -z "$CIVIBUILD_HOME" ] && BLDDIR="$PRJDIR/build" || BLDDIR="$CIVIBUILD_HOME"
 
 ## Make sure bundled utilities are available, regardless of local config
 export PATH="$BINDIR:$PATH"

--- a/bin/civihydra
+++ b/bin/civihydra
@@ -14,8 +14,8 @@ function absdirname() {
 
 BINDIR=$(absdirname "$0")
 PRJDIR=$(dirname "$BINDIR")
-TMPDIR="$PRJDIR/app/tmp"
-BLDDIR="$PRJDIR/build"
+[ -z "$CIVIBUILD_HOME" ] && TMPDIR="$PRJDIR/app/tmp" || TMPDIR="$CIVIBUILD_HOME/.civibuild/tmp"
+[ -z "$CIVIBUILD_HOME" ] && BLDDIR="$PRJDIR/build" || BLDDIR="$CIVIBUILD_HOME"
 
 ## Make sure bundled utilities are available, regardless of local config
 export PATH="$BINDIR:$PATH"

--- a/bin/gitify
+++ b/bin/gitify
@@ -15,8 +15,8 @@ function absdirname() {
 
 BINDIR=$(absdirname "$0")
 PRJDIR=$(dirname "$BINDIR")
-TMPDIR="$PRJDIR/app/tmp"
-BLDDIR="$PRJDIR/build"
+[ -z "$CIVIBUILD_HOME" ] && TMPDIR="$PRJDIR/app/tmp" || TMPDIR="$CIVIBUILD_HOME/.civibuild/tmp"
+[ -z "$CIVIBUILD_HOME" ] && BLDDIR="$PRJDIR/build" || BLDDIR="$CIVIBUILD_HOME"
 
 source "$PRJDIR/src/civibuild.lib.sh"
 source "$PRJDIR/src/civibuild.aliases.sh"
@@ -223,7 +223,8 @@ set -e
 
 source "$PRJDIR/src/civibuild.defaults.sh"
 [ -f "$PRJDIR/app/civibuild.conf" ] && source "$PRJDIR/app/civibuild.conf"
-cvutil_mkdir "$TMPDIR" "$BLDDIR" "$PRJDIR/app/private"
+cvutil_mkdir "$TMPDIR" "$BLDDIR"
+[ -z "$CIVIBUILD_HOME" ] && cvutil_mkdir "$PRJDIR/app/private"
 
 source "$PRJDIR/src/civibuild.compute-defaults.sh"
 

--- a/bin/releaser
+++ b/bin/releaser
@@ -20,8 +20,8 @@ function absdirname() {
 
 BINDIR=$(absdirname "$0")
 PRJDIR=$(dirname "$BINDIR")
-TMPDIR="$PRJDIR/app/tmp"
-BLDDIR="$PRJDIR/build"
+[ -z "$CIVIBUILD_HOME" ] && TMPDIR="$PRJDIR/app/tmp" || TMPDIR="$CIVIBUILD_HOME/.civibuild/tmp"
+[ -z "$CIVIBUILD_HOME" ] && BLDDIR="$PRJDIR/build" || BLDDIR="$CIVIBUILD_HOME"
 export RELEASE_TMPDIR="$TMPDIR/releaser"
 
 source "$PRJDIR/src/civibuild.lib.sh"

--- a/src/civibuild.compute-defaults.sh
+++ b/src/civibuild.compute-defaults.sh
@@ -1,18 +1,23 @@
 #!/bin/bash
 
-[ -z "$CACHE_DIR" ]          && CACHE_DIR="$TMPDIR/git-cache"
-[ -z "$WEB_ROOT" ]           && WEB_ROOT="$BLDDIR/$SITE_NAME"
-[ -z "$CMS_ROOT" ]           && CMS_ROOT="$WEB_ROOT"
-[ -z "$PRIVATE_ROOT" ]       && PRIVATE_ROOT="$PRJDIR/app/private/$SITE_NAME"
-[ -z "$CLONE_ROOT" ]         && CLONE_ROOT="$PRJDIR/app/clone/$SITE_NAME/$SITE_ID"
-[ -z "$CLONE_DIR" ]          && CLONE_DIR="$CLONE_ROOT/$CLONE_ID"
-[ -z "$UPGRADE_LOG_DIR" ]    && UPGRADE_LOG_DIR="$PRJDIR/app/debug/$SITE_NAME"
+###############################################################################
+## Common/standard defaults
+
+[ -z "$SITE_TOKEN" ]         && SITE_TOKEN=$(cvutil_makepasswd 16)
 [ -z "$CIVI_SITE_KEY" ]      && CIVI_SITE_KEY=$(cvutil_makepasswd 16)
 [ -z "$ADMIN_PASS" ]         && ADMIN_PASS=$(cvutil_makepasswd 12)
 [ -z "$DEMO_PASS" ]          && DEMO_PASS=$(cvutil_makepasswd 12)
 [ -z "$SITE_TYPE" ]          && SITE_TYPE="$SITE_NAME"
 [ -z "$CMS_TITLE" ]          && CMS_TITLE="$SITE_NAME"
 [ -z "$SNAPSHOT_NAME" ]      && SNAPSHOT_NAME="$SITE_NAME"
+
+## Note: "WEB_ROOT" is actually the root of the build's code, and "CMS_ROOT" is the HTTP document root.
+## Now-a-days, most builds set "CMS_ROOT=$WEB_ROOT/web"
+[ -z "$WEB_ROOT" ]           && WEB_ROOT="$BLDDIR/$SITE_NAME"
+[ -z "$CMS_ROOT" ]           && CMS_ROOT="$WEB_ROOT"
+
+[ -z "$SITE_CONFIG_DIR" ]    && SITE_CONFIG_DIR="$PRJDIR/app/config/$SITE_TYPE"
+
 if [ -z "$CMS_URL" ]; then
   if [ "%AUTO%" == "$URL_TEMPLATE" ]; then
     if [ -n "$IS_ALIAS" ]; then
@@ -23,9 +28,53 @@ if [ -z "$CMS_URL" ]; then
     CMS_URL=$( echo "$URL_TEMPLATE" | sed "s;%SITE_NAME%;$SITE_NAME;g" )
   fi
 fi
-#[ -z "$CMS_HOSTNAME" ]       && CMS_HOSTNAME=$(php -r '$p = parse_url($argv[1]); echo $p["host"];' "$CMS_URL")
-#[ -z "$CMS_PORT" ]           && CMS_PORT=$(php -r '$p = parse_url($argv[1]); echo $p["port"];' "$CMS_URL")
-[ -z "$SNAPSHOT_DIR" ]       && SNAPSHOT_DIR="$PRJDIR/app/snapshot"
+
+###############################################################################
+## Defaults for traditional file-structure, in which user clones repo and
+## data is written to "./app" and "./build"
+if [ -z "$CIVIBUILD_HOME" ]; then
+
+  [ -z "$CACHE_DIR" ]          && CACHE_DIR="$TMPDIR/git-cache"
+  [ -z "$SNAPSHOT_DIR" ]       && SNAPSHOT_DIR="$PRJDIR/app/snapshot"
+
+  ## Note: Originally, all common build-types lacked a 'web/' folder, so
+  ## auxiliary data needed to go elsewhere.
+
+  [ -z "$PRIVATE_ROOT" ]       && PRIVATE_ROOT="$PRJDIR/app/private/$SITE_NAME"
+  [ -z "$CLONE_ROOT" ]         && CLONE_ROOT="$PRJDIR/app/clone/$SITE_NAME/$SITE_ID"
+  [ -z "$CLONE_DIR" ]          && CLONE_DIR="$CLONE_ROOT/$CLONE_ID"
+  [ -z "$UPGRADE_LOG_DIR" ]    && UPGRADE_LOG_DIR="$PRJDIR/app/debug/$SITE_NAME"
+
+  [ -z "$CIVICRM_GENCODE_DIGEST" ] && CIVICRM_GENCODE_DIGEST="$TMPDIR/$SITE_NAME-gencode.md5"
+  [ -z "$SHOW_LAST_SCAN" ]     && SHOW_LAST_SCAN="$TMPDIR/git-scan-${SITE_NAME}-last.json"
+  [ -z "$SHOW_NEW_SCAN" ]      && SHOW_NEW_SCAN="$TMPDIR/git-scan-${SITE_NAME}-new.json"
+
+###############################################################################
+## Defaults for system-wide installs, in which scripts are placed in a shared folder
+## and data is written to some configureable "HOME"
+
+elif [ -n "$CIVIBUILD_HOME" ]; then
+
+  [ -z "$CACHE_DIR" ]          && CACHE_DIR="$CIVIBUILD_HOME/.civibuild/cache"
+  [ -z "$SNAPSHOT_DIR" ]       && SNAPSHOT_DIR="$CIVIBUILD_HOME/.civibuild/snapshot"
+
+  ## Note: Now-a-days, all common build-types point HTTTPD to 'WEB_ROOT/web/' folder, so we can
+  ## put auxiliary data adjacent to that.
+
+  [ -z "$PRIVATE_ROOT" ]       && PRIVATE_ROOT="$WEB_ROOT/.civibuild/private"
+  [ -z "$CLONE_ROOT" ]         && CLONE_ROOT="$WEB_ROOT/.civibuild/clone/$SITE_ID"
+  [ -z "$CLONE_DIR" ]          && CLONE_DIR="$CLONE_ROOT/$CLONE_ID"
+  [ -z "$UPGRADE_LOG_DIR" ]    && UPGRADE_LOG_DIR="$WEB_ROOT/.civibuild/debug"
+
+  [ -z "$CIVICRM_GENCODE_DIGEST" ] && CIVICRM_GENCODE_DIGEST="$WEB_ROOT/.civibuild/gencode.md5"
+  [ -z "$SHOW_LAST_SCAN" ]     && SHOW_LAST_SCAN="$WEB_ROOT/.civibuild/git-scan-last.json"
+  [ -z "$SHOW_NEW_SCAN" ]      && SHOW_NEW_SCAN="$WEB_ROOT/.civibuild/git-scan-new.json"
+
+fi
+
+###############################################################################
+## Wrap-up - common defaults which are derived from some other default
+
 if [ "default" == "$SITE_ID" ]; then
   [ -z "$CIVI_SQL"  ]        && CIVI_SQL="$SNAPSHOT_DIR/$SNAPSHOT_NAME/civi.sql.gz"
   [ -z "$CMS_SQL" ]          && CMS_SQL="$SNAPSHOT_DIR/$SNAPSHOT_NAME/cms.sql.gz"
@@ -33,10 +82,5 @@ else
   [ -z "$CIVI_SQL"  ]        && CIVI_SQL="$SNAPSHOT_DIR/$SNAPSHOT_NAME--$SITE_ID/civi.sql.gz"
   [ -z "$CMS_SQL" ]          && CMS_SQL="$SNAPSHOT_DIR/$SNAPSHOT_NAME--$SITE_ID/cms.sql.gz"
 fi
-[ -z "$SITE_CONFIG_DIR" ]    && SITE_CONFIG_DIR="$PRJDIR/app/config/$SITE_TYPE"
-[ -z "$CIVICRM_GENCODE_DIGEST" ] && CIVICRM_GENCODE_DIGEST="$TMPDIR/$SITE_NAME-gencode.md5"
-[ -z "$SHOW_LAST_SCAN" ]     && SHOW_LAST_SCAN="$TMPDIR/git-scan-${SITE_NAME}-last.json"
-[ -z "$SHOW_NEW_SCAN" ]      && SHOW_NEW_SCAN="$TMPDIR/git-scan-${SITE_NAME}-new.json"
-[ -z "$SITE_TOKEN" ]         && SITE_TOKEN=$(cvutil_makepasswd 16)
 
 export CIVICRM_GENCODE_DIGEST

--- a/src/civibuild.defaults.sh
+++ b/src/civibuild.defaults.sh
@@ -9,10 +9,14 @@
 ## The location of the civicrm-buildkit binaries
 # BINDIR=
 
-## A place to store temp files (PRJDIR/app/tmp)
+## A place to store temp files
+## (default-git: PRJDIR/app/tmp)
+## (default-sys: CIVIBUILD_HOME/.civibuild/tmp
 # TMPDIR=
 
-## A place to put sites that we build (PRJDIR/build)
+## A place to put sites that we build
+## (default-git: PRJDIR/build)
+## (default-sys: CIVIBUILD_HOME)
 # BLDDIR=
 
 ###############################################################################
@@ -47,11 +51,13 @@ SITE_TOKEN=
 WEB_ROOT=
 
 ## Root directory where the site can put private (unpublished) data files
-## (default: app/private/SITE_NAME)
+## (default-git: app/private/SITE_NAME )
+## (default-sys: WEB_ROOT/.civibuild/private)
 PRIVATE_ROOT=
 
 ## Root directory where we store cached copies of git repositories
-## (default: TMPDIR/git-cache)
+## (default-git: TMPDIR/git-cache)
+## (default-sys: CIVIBUILD_HOME/.civibuild/cache)
 CACHE_DIR=
 
 ## Time to wait before allowing updates to git/svn caches (seconds)
@@ -196,7 +202,9 @@ TEST_DB_PERM=super
 ## snapshot-related variables
 ## (also used for cloning)
 
-## Path to the directory which stores snapshots (default: PRJDIR/app/snapshot) [non-persistent]
+## Path to the directory which stores snapshots
+## (default-git: PRJDIR/app/snapshot) [non-persistent]
+## (default-sys: CIVIBUILD_HOME/.civibuild/snapshot) [non-persistent]
 SNAPSHOT_DIR=
 
 ## Name of the subdirectory containing the snapshot (default: SITE_NAME) [non-persistent]
@@ -224,7 +232,8 @@ TEST_SQL_SKIP=
 CLONE_ID=
 
 ## Base directory in whch we store clones metadata
-## [default: app/clone/$SITE_NAME/$SITE_ID ]
+## (default-git: app/clone/$SITE_NAME/$SITE_ID)
+## (default-sys: WEB_ROOT/.civibuild/clone/$SITE_ID)
 CLONE_ROOT=
 
 ## Directory storing the activty clone's metadata
@@ -251,11 +260,13 @@ UPGRADE_LOG_DIR=
 SHOW_HTML=
 
 ## Path to the last git summary file (from "git scan export")
-## (Default: TMPDIR/git-scan-$SITE_NAME-last.json)
+## (default-git: TMPDIR/git-scan-$SITE_NAME-last.json)
+## (default-sys: WEB_ROOT/.civibuild/git-scan-last.json)
 SHOW_LAST_SCAN=
 
 ## Path to which we will write a new git summary file (using "git scan export")
-## (Default: TMPDIR/git-scan-$SITE_NAME-new.json)
+## (default-git: TMPDIR/git-scan-$SITE_NAME-new.json)
+## (default-sys: WEB_ROOT/.civibuild/git-scan-new.json)
 SHOW_NEW_SCAN=
 
 ###############################################################################

--- a/src/civibuild.parse.sh
+++ b/src/civibuild.parse.sh
@@ -116,7 +116,8 @@ declare -a ARGS=()
 function civibuild_parse() {
   source "$PRJDIR/src/civibuild.defaults.sh"
   [ -f "$PRJDIR/app/civibuild.conf" ] && source "$PRJDIR/app/civibuild.conf"
-  cvutil_mkdir "$TMPDIR" "$BLDDIR" "$PRJDIR/app/private"
+  cvutil_mkdir "$TMPDIR" "$BLDDIR"
+  [ -z "$CIVIBUILD_HOME" ] && cvutil_mkdir "$PRJDIR/app/private"
 
   civibuild_parse_unnamed_params $@
 

--- a/src/drush/drush8.tmpl
+++ b/src/drush/drush8.tmpl
@@ -2,8 +2,9 @@
 
 BINDIR=$(dirname $0)
 PRJDIR=$(dirname "$BINDIR")
+[ -z "$CIVIBUILD_HOME" ] && CACHE_PREFIX="$PRJDIR/app/tmp/drush" || CACHE_PREFIX="$CIVIBUILD_HOME/.civibuild/drush"
 
-export CACHE_PREFIX=$PRJDIR/app/tmp/drush
+export CACHE_PREFIX
 [ ! -d "$CACHE_PREFIX" ] && mkdir -p "$CACHE_PREFIX"
 if [ "$PWD" == "$BINDIR" ]; then
   echo "Error: Cannot run drush from the bin dir. Please navigate to a site dir." >&2

--- a/src/releaser.orig
+++ b/src/releaser.orig
@@ -20,12 +20,13 @@ function absdirname() {
 
 BINDIR=$(absdirname "$0")
 PRJDIR=$(dirname "$BINDIR")
-TMPDIR="$PRJDIR/app/tmp"
-BLDDIR="$PRJDIR/build"
+[ -z "$CIVIBUILD_HOME" ] && TMPDIR="$PRJDIR/app/tmp" || TMPDIR="$CIVIBUILD_HOME/.civibuild/tmp"
+[ -z "$CIVIBUILD_HOME" ] && BLDDIR="$PRJDIR/build" || BLDDIR="$CIVIBUILD_HOME"
 
 source "$PRJDIR/src/civibuild.lib.sh"
 source "$PRJDIR/src/civibuild.aliases.sh"
-cvutil_mkdir "$TMPDIR" "$PRJDIR/app/private"
+cvutil_mkdir "$TMPDIR"
+[ -z "$CIVIBUILD_HOME" ] && cvutil_mkdir "$PRJDIR/app/private"
 
 ## Make sure bundled utilities are available, regardless of local config
 export PATH="$BINDIR:$PATH"


### PR DESCRIPTION
This implements a completely different file structure for all mutable files.

* If you don't set `CIVIBUILD_HOME`, then you get the same directory structure as traditionally (with data going to `./app` and `./build`)
* If you set `CIVIBUILD_HOME`, then builds will be put in that folder (`CIVIBUILD_HOME/dmaster`). All auxiliary files (caches, snapshots, temp data, etc) will be stored in-situ with a dot folder (`.civibuild`).

The general aim is to progress toward supporting `civibuild` as a shared/read-only/system resource, in which case any download/tmp/build files need to go outside the main source tree.