### PR TITLE
civi-download-tools - Add drush-backdrop plugin

### DIFF
--- a/app/config/backdrop-clean/install.sh
+++ b/app/config/backdrop-clean/install.sh
@@ -33,4 +33,11 @@ civicrm_install
 
 pushd "$CMS_ROOT" >> /dev/null
   php "$SITE_CONFIG_DIR/module-enable.php" civicrm
+
+  ## Setup demo user
+  # drush -y en civicrm_webtest
+  drush -y user-create --password="$DEMO_PASS" --mail="$DEMO_EMAIL" "$DEMO_USER"
+  ##FIXME drush -y user-add-role civicrm_webtest_user "$DEMO_USER"
+  #echo 'INSERT IGNORE INTO users_roles (uid,role) SELECT uid, "civicrm_webtest_user" FROM users WHERE name = @ENV[DEMO_USER];' \
+  #  | env DEMO_USER="$DEMO_USER" amp sql -Ncms -e
 popd >> /dev/null

--- a/app/config/backdrop-demo/install.sh
+++ b/app/config/backdrop-demo/install.sh
@@ -34,4 +34,11 @@ civicrm_install
 pushd "$CMS_ROOT" >> /dev/null
   php "$SITE_CONFIG_DIR/module-enable.php" civicrm
   civicrm_apply_demo_defaults
+
+  ## Setup demo user
+  #drush -y en civicrm_webtest
+  drush -y user-create --password="$DEMO_PASS" --mail="$DEMO_EMAIL" "$DEMO_USER"
+  ##FIXME: drush -y user-add-role civicrm_webtest_user "$DEMO_USER"
+  #echo 'INSERT IGNORE INTO users_roles (uid,role) SELECT uid, "civicrm_webtest_user" FROM users WHERE name = @ENV[DEMO_USER];' \
+  #  | env DEMO_USER="$DEMO_USER" amp sql -Ncms -e
 popd >> /dev/null

--- a/app/config/backdrop-empty/install.sh
+++ b/app/config/backdrop-empty/install.sh
@@ -19,3 +19,6 @@ backdrop_install
 ###############################################################################
 ## Extra configuration
 
+pushd "$CMS_ROOT" >> /dev/null
+  drush -y user-create --password="$DEMO_PASS" --mail="$DEMO_EMAIL" "$DEMO_USER"
+popd >> /dev/null

--- a/bin/civi-download-tools
+++ b/bin/civi-download-tools
@@ -34,6 +34,7 @@ CIVISTRINGSURL="https://download.civicrm.org/civistrings/civistrings.phar-2018-0
 JOOMLAURL="https://download.civicrm.org/joomlatools-console/joomla.phar-2017-06-19-62ff6a9df"
 CODECEPTION_PHP5_URL="http://codeception.com/releases/2.3.6/php54/codecept.phar"
 CODECEPTION_PHP7_URL="http://codeception.com/releases/2.3.6/codecept.phar"
+DRUSH_BD_URL="https://github.com/backdrop-contrib/drush/archive/1.0.0.zip"
 IS_QUIET=
 IS_FORCE=
 IS_FULL=
@@ -750,6 +751,21 @@ pushd $PRJDIR >> /dev/null
   make_link "$PRJDIR/bin" "../extern/phpunit4/phpunit4.phar" "phpunit4"
   make_link "$PRJDIR/bin" "../extern/phpunit5/phpunit5.phar" "phpunit5"
   make_link "$PRJDIR/bin" "../extern/phpunit6/phpunit6.phar" "phpunit6"
+
+  ## Download "drush" addons
+  if [ -z "$IS_FORCE" -a -e "$PRJDIR/extern/drush-lib/backdrop" -a "$(cat $PRJDIR/extern/drush-lib-backdrop.txt)" == "$DRUSH_BD_URL" ]; then
+    echo_comment "[[drush-backdrop ($PRJDIR/extern/drush-lib/backdrop) already exists. Skipping.]]"
+  else
+    download_url "$DRUSH_BD_URL" "$TMPDIR/drush-backdrop.zip"
+    [ -d "$PRJDIR/extern/drush-lib/backdrop" ] && rm -rf "$PRJDIR/extern/drush-lib/backdrop"
+    mkdir -p "$PRJDIR/extern/drush-lib/backdrop"
+    pushd "$PRJDIR/extern/drush-lib/backdrop" >> /dev/null
+    #  touch created-by-me
+      unzip "$TMPDIR/drush-backdrop.zip"
+    popd >> /dev/null
+    rm -f  "$TMPDIR/drush-backdrop.zip"
+    echo "$DRUSH_BD_URL" > "$PRJDIR/extern/drush-lib-backdrop.txt"
+  fi
 
   ## Download "hub"
   touch "$PRJDIR/extern/hub.txt"

--- a/src/drush/drush8.tmpl
+++ b/src/drush/drush8.tmpl
@@ -10,4 +10,4 @@ if [ "$PWD" == "$BINDIR" ]; then
   echo "Error: Cannot run drush from the bin dir. Please navigate to a site dir." >&2
   exit 1
 fi
-exec "$PRJDIR/extern/drush8.phar" "$@"
+exec "$PRJDIR/extern/drush8.phar" --include="$PRJDIR/extern/drush-lib" "$@"


### PR DESCRIPTION
Before
------

On Backdrop builds, `drush` cannot be used - because the drush-backdrop plugin is missing.

After
-----

On Backdrop builds, `drush` can be used - because the plugin is present.

Comments
--------

This has come up a few ways - e.g.

* Test/demo sites don't have a test/demo user - https://lab.civicrm.org/infra/ops/issues/906
* When QA'ing patches for civicrm-backdrop's copy of `civicrm.drush.inc` - e.g. https://github.com/civicrm/civicrm-backdrop/pull/98