### PR TITLE
Migrate PHAR downloads from bash to composer-downloads-plugin

### DIFF
--- a/bin/civi-download-tools
+++ b/bin/civi-download-tools
@@ -18,23 +18,7 @@ PRJDIR=$(dirname "$BINDIR")
 [ -z "$CIVIBUILD_HOME" ] && TMPDIR="$PRJDIR/app/tmp" || TMPDIR="$CIVIBUILD_HOME/.civibuild/tmp"
 LOCKFILE="$TMPDIR/civi-download-tools.lock"
 LOCKTIMEOUT=90
-CIVIXURL="https://download.civicrm.org/civix/civix.phar-2019-08-21-cf6cefcd"
-CIVICIURL="https://download.civicrm.org/civici/civici-0.1.3.phar"
-CVURL="https://download.civicrm.org/cv/cv.phar-2019-08-20-14fe9da8"
 HUB_VERSION="2.2.9"
-DRUSH8URL=https://github.com/drush-ops/drush/releases/download/8.1.18/drush.phar
-PHPUNITURL=https://phar.phpunit.de/phpunit-4.8.21.phar
-PHPUNIT5URL=https://phar.phpunit.de/phpunit-5.phar
-PHPUNIT6URL=https://phar.phpunit.de/phpunit-6.phar
-WPCLIURL=https://github.com/wp-cli/wp-cli/releases/download/v2.0.1/wp-cli-2.0.1.phar
-GITSCANURL="https://download.civicrm.org/git-scan/git-scan.phar-2019-04-08-24bd3fa1"
-AMPURL="https://download.civicrm.org/amp/amp.phar-2019-06-25-dc96b3da"
-BOXURL="https://github.com/box-project/box2/releases/download/2.7.5/box-2.7.5.phar"
-CIVISTRINGSURL="https://download.civicrm.org/civistrings/civistrings.phar-2018-04-11-93987d92"
-JOOMLAURL="https://download.civicrm.org/joomlatools-console/joomla.phar-2017-06-19-62ff6a9df"
-CODECEPTION_PHP5_URL="http://codeception.com/releases/2.3.6/php54/codecept.phar"
-CODECEPTION_PHP7_URL="http://codeception.com/releases/2.3.6/codecept.phar"
-DRUSH_BD_URL="https://github.com/backdrop-contrib/drush/archive/1.0.0.zip"
 IS_QUIET=
 IS_FORCE=
 IS_FULL=
@@ -95,28 +79,6 @@ function download_url() {
   fi
 }
 
-###############################################################################
-## usage: download_program_if_changed <url> <out-file> <flag-file>
-function download_program_if_changed() {
-  local url="$1"
-  local binfile="$2"
-  local flagfile="$3"
-  local progname=$(basename $binfile)
-
-  mkdir -p $(dirname "$flagfile")
-  touch "$flagfile"
-  if [ -z "$IS_FORCE" -a -e "$binfile" -a "$(cat $flagfile)" == "$url" ]; then
-    echo_comment "[[$progname binary ($binfile) already exists. Skipping.]]"
-  else
-    echo "[[Install $progname]]"
-    if [ -L "$binfile" ]; then
-      rm -f "$binfile"
-    fi
-    download_url "$url" "$binfile"
-    chmod +x "$binfile"
-    echo "$url" > "$flagfile"
-  fi
-}
 
 ###############################################################################
 ## usage: echo_comment <message>
@@ -143,6 +105,12 @@ function make_link() {
   local from="$2"
   local to="$3"
   pushd "$workdir" >> /dev/null
+    if [ -L "$to" ]; then
+      local oldLink=$(readlink "$to")
+      if [ -n "$oldLink" -a "$oldLink" != "$from" ]; then
+        rm -f "$to"
+      fi
+    fi
     if [ ! -e "$to" ]; then
       echo_comment "[[Create symlink $to in $workdir]]"
       ln -s "$from" "$to"
@@ -667,6 +635,28 @@ pushd $PRJDIR >> /dev/null
     [ -z "$AMPHOME" -a -d "$HOME/.amp/apache.d" ] && check_datafile_ownership "$HOME/.amp/apache.d"
   fi
 
+  ## Cleanup previous PHAR downloads before composer-downloads-plugin takes a crack at it.
+  [ -f "$PRJDIR/extern/_phpunit4.txt" ] && rm -f "$PRJDIR/extern/phpunit4/phpunit4.phar" "$PRJDIR/extern/_phpunit4.txt"
+  [ -f "$PRJDIR/extern/_phpunit5.txt" ] && rm -f "$PRJDIR/extern/phpunit5/phpunit5.phar" "$PRJDIR/extern/_phpunit5.txt"
+  [ -f "$PRJDIR/extern/_phpunit6.txt" ] && rm -f "$PRJDIR/extern/phpunit6/phpunit6.phar" "$PRJDIR/extern/_phpunit6.txt"
+  [ -f "$PRJDIR/extern/amp.txt" ] && rm -f "$PRJDIR/bin/amp" "$PRJDIR/extern/amp.txt"
+  [ -f "$PRJDIR/extern/box.txt" ] && rm -f "$PRJDIR/bin/box" "$PRJDIR/extern/box.txt"
+  [ -f "$PRJDIR/extern/civistrings.txt" ] && rm -f "$PRJDIR/bin/civistrings" "$PRJDIR/extern/civistrings.txt"
+  [ -f "$PRJDIR/extern/civix.txt" ] && rm -f "$PRJDIR/bin/civix" "$PRJDIR/extern/civix.txt"
+  [ -f "$PRJDIR/extern/cv.txt" ] && rm -f "$PRJDIR/bin/cv" "$PRJDIR/extern/cv.txt"
+  [ -f "$PRJDIR/extern/drush8.txt" ] && rm -f "$PRJDIR/extern/drush8.phar" "$PRJDIR/extern/drush8.txt"
+  [ -f "$PRJDIR/extern/git-scan.txt" ] && rm -f "$PRJDIR/bin/git-scan" "$PRJDIR/extern/git-scan.txt"
+  [ -f "$PRJDIR/extern/wp-cli.txt" ] && rm -f "$PRJDIR/bin/wp" "$PRJDIR/extern/wp-cli.txt"
+  [ -f "$PRJDIR/extern/civici.txt" ] && rm -f  "$PRJDIR/bin/civici" "$PRJDIR/extern/civici.txt"
+  [ -f "$PRJDIR/extern/joomla.txt" ] && rm -f "$PRJDIR/bin/joomla" "$PRJDIR/extern/joomla.txt"
+  [ -f "$PRJDIR/extern/codecept-php5.txt" ] && rm -f "$PRJDIR/bin/_codecept-php5.phar" "$PRJDIR/extern/codecept-php5.txt"
+  [ -f "$PRJDIR/extern/codecept-php7.txt" ] && rm -f "$PRJDIR/bin/_codecept-php7.phar" "$PRJDIR/extern/codecept-php7.txt"
+  [ -f "$PRJDIR/extern/drush-lib-backdrop.txt" ] && rm -rf "$PRJDIR/extern/drush-lib/backdrop" "$PRJDIR/extern/drush-lib-backdrop.txt"
+
+  ## Cleanup misnamed files from past
+  [ -f "$PRJDIR/extern/phpunit4/phpunit6.phar" ] && rm -f "$PRJDIR/extern/phpunit4/phpunit6.phar" "$PRJDIR/extern/phpunit4/phpunit6.phar"
+  [ -f "$PRJDIR/extern/phpunit5/phpunit6.phar" ] && rm -f "$PRJDIR/extern/phpunit5/phpunit6.phar" "$PRJDIR/extern/phpunit5/phpunit6.phar"
+
   ## Download "composer"
   if [ -z "$IS_FORCE" -a -f "$PRJDIR/bin/composer" ]; then
     echo_comment "[[Composer binary ($PRJDIR/bin/composer) already exists. Skipping.]]"
@@ -708,29 +698,9 @@ pushd $PRJDIR >> /dev/null
   fi
 
   [ ! -d "$PRJDIR/extern" ] && mkdir "$PRJDIR/extern"
-  [ ! -d "$PRJDIR/extern/phpunit4" ] && mkdir "$PRJDIR/extern/phpunit4"
-  [ ! -d "$PRJDIR/extern/phpunit5" ] && mkdir "$PRJDIR/extern/phpunit5"
-  [ ! -d "$PRJDIR/extern/phpunit6" ] && mkdir "$PRJDIR/extern/phpunit6"
 
   ## Cleanup old civix tarballs
   [ -d "$PRJDIR/extern/civix" ] && rm -rf "$PRJDIR/extern/civix"
-
-  ## download_program_if_changed <url> <out-file> <flag-file>
-  download_program_if_changed "$DRUSH8URL" "$PRJDIR/extern/drush8.phar" "$PRJDIR/extern/drush8.txt"
-  download_program_if_changed "$CVURL" "$PRJDIR/bin/cv" "$PRJDIR/extern/cv.txt"
-  download_program_if_changed "$PHPUNITURL" "$PRJDIR/extern/phpunit4/phpunit4.phar" "$PRJDIR/extern/_phpunit4.txt"
-  download_program_if_changed "$PHPUNIT5URL" "$PRJDIR/extern/phpunit5/phpunit5.phar" "$PRJDIR/extern/_phpunit5.txt"
-  download_program_if_changed "$PHPUNIT6URL" "$PRJDIR/extern/phpunit6/phpunit6.phar" "$PRJDIR/extern/_phpunit6.txt"
-  download_program_if_changed "$WPCLIURL" "$PRJDIR/bin/wp" "$PRJDIR/extern/wp-cli.txt"
-  download_program_if_changed "$GITSCANURL" "$PRJDIR/bin/git-scan" "$PRJDIR/extern/git-scan.txt"
-  download_program_if_changed "$AMPURL" "$PRJDIR/bin/amp" "$PRJDIR/extern/amp.txt"
-  download_program_if_changed "$BOXURL" "$PRJDIR/bin/box" "$PRJDIR/extern/box.txt"
-  download_program_if_changed "$CIVIXURL" "$PRJDIR/bin/civix" "$PRJDIR/extern/civix.txt"
-  download_program_if_changed "$CIVICIURL" "$PRJDIR/bin/civici" "$PRJDIR/extern/civici.txt"
-  download_program_if_changed "$CIVISTRINGSURL" "$PRJDIR/bin/civistrings" "$PRJDIR/extern/civistrings.txt"
-  download_program_if_changed "$JOOMLAURL" "$PRJDIR/bin/joomla" "$PRJDIR/extern/joomla.txt"
-  download_program_if_changed "$CODECEPTION_PHP5_URL" "$PRJDIR/bin/_codecept-php5.phar" "$PRJDIR/extern/codecept-php5.txt"
-  download_program_if_changed "$CODECEPTION_PHP7_URL" "$PRJDIR/bin/_codecept-php7.phar" "$PRJDIR/extern/codecept-php7.txt"
 
   ## Cleanup old phpunit files
   for OLDFILE in "$PRJDIR/bin/phpunit4" "$PRJDIR/bin/phpunit5" "$PRJDIR/extern/phpunit4.txt" "$PRJDIR/extern/phpunit5.txt"; do
@@ -751,21 +721,6 @@ pushd $PRJDIR >> /dev/null
   make_link "$PRJDIR/bin" "../extern/phpunit4/phpunit4.phar" "phpunit4"
   make_link "$PRJDIR/bin" "../extern/phpunit5/phpunit5.phar" "phpunit5"
   make_link "$PRJDIR/bin" "../extern/phpunit6/phpunit6.phar" "phpunit6"
-
-  ## Download "drush" addons
-  if [ -z "$IS_FORCE" -a -e "$PRJDIR/extern/drush-lib/backdrop" -a "$(cat $PRJDIR/extern/drush-lib-backdrop.txt)" == "$DRUSH_BD_URL" ]; then
-    echo_comment "[[drush-backdrop ($PRJDIR/extern/drush-lib/backdrop) already exists. Skipping.]]"
-  else
-    download_url "$DRUSH_BD_URL" "$TMPDIR/drush-backdrop.zip"
-    [ -d "$PRJDIR/extern/drush-lib/backdrop" ] && rm -rf "$PRJDIR/extern/drush-lib/backdrop"
-    mkdir -p "$PRJDIR/extern/drush-lib/backdrop"
-    pushd "$PRJDIR/extern/drush-lib/backdrop" >> /dev/null
-    #  touch created-by-me
-      unzip "$TMPDIR/drush-backdrop.zip"
-    popd >> /dev/null
-    rm -f  "$TMPDIR/drush-backdrop.zip"
-    echo "$DRUSH_BD_URL" > "$PRJDIR/extern/drush-lib-backdrop.txt"
-  fi
 
   ## Download "hub"
   touch "$PRJDIR/extern/hub.txt"

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
     "totten/php-symbol-diff": "dev-master#54f869ca68a3cd75f3386f8490870369733d2c23",
     "civicrm/upgrade-test": "dev-master#b93207fd28ac90426e9c95d572068f2e907b08e2",
     "drupal/coder": "dev-8.x-2.x-civi#a1fab2860d916519bae5574b73067bb1c749b133",
+    "civicrm/composer-downloads-plugin": "~2.0",
     "squizlabs/php_codesniffer": ">=2.7 <4.0"
   },
   "repositories": [
@@ -30,5 +31,25 @@
       "type": "git",
       "url": "https://github.com/totten/paratest.git"
     }
-  ]
+  ],
+  "extra": {
+    "downloads": {
+      "amp": {"url": "https://download.civicrm.org/amp/amp.phar-2019-06-25-dc96b3da", "path": "bin/amp", "type": "phar"},
+      "box": {"url": "https://github.com/box-project/box2/releases/download/2.7.5/box-2.7.5.phar", "path": "bin/box", "type": "phar"},
+      "civici": {"url": "https://download.civicrm.org/civici/civici-0.1.3.phar", "path": "bin/civici", "type": "phar"},
+      "civistrings": {"url": "https://download.civicrm.org/civistrings/civistrings.phar-2018-04-11-93987d92", "path": "bin/civistrings", "type": "phar"},
+      "civix": {"url": "https://download.civicrm.org/civix/civix.phar-2019-08-21-cf6cefcd", "path": "bin/civix", "type": "phar"},
+      "codecept-php5": {"url": "https://codeception.com/releases/2.3.6/php54/codecept.phar", "path": "bin/_codecept-php5.phar", "type": "phar"},
+      "codecept-php7": {"url": "https://codeception.com/releases/2.3.6/codecept.phar", "path": "bin/_codecept-php7.phar", "type": "phar"},
+      "cv": {"url": "https://download.civicrm.org/cv/cv.phar-2019-08-20-14fe9da8", "path": "bin/cv", "type": "phar"},
+      "drush8": {"url": "https://github.com/drush-ops/drush/releases/download/8.1.18/drush.phar", "path": "extern/drush8.phar", "type": "phar"},
+      "drush-backdrop": {"url": "https://github.com/backdrop-contrib/drush/archive/1.0.0.zip", "path": "extern/drush-lib/backdrop"},
+      "git-scan": {"url": "https://download.civicrm.org/git-scan/git-scan.phar-2019-04-08-24bd3fa1", "path": "bin/git-scan", "type": "phar"},
+      "joomla": {"url": "https://download.civicrm.org/joomlatools-console/joomla.phar-2017-06-19-62ff6a9df", "path": "bin/joomla", "type": "phar"},
+      "phpunit4": {"url": "https://phar.phpunit.de/phpunit-4.8.21.phar", "path": "extern/phpunit4/phpunit4.phar", "type": "phar"},
+      "phpunit5": {"url": "https://phar.phpunit.de/phpunit-5.phar", "path": "extern/phpunit5/phpunit5.phar", "type": "phar"},
+      "phpunit6": {"url": "https://phar.phpunit.de/phpunit-6.phar", "path": "extern/phpunit6/phpunit6.phar", "type": "phar"},
+      "wp": {"url": "https://github.com/wp-cli/wp-cli/releases/download/v2.0.1/wp-cli-2.0.1.phar", "path": "bin/wp", "type": "phar"}
+    }
+  }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,59 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bcef9c731dbf71d0f5eede787ea1d5a6",
+    "content-hash": "ef49c3663a3aed4bde4dda4ca071626c",
     "packages": [
+        {
+            "name": "civicrm/composer-downloads-plugin",
+            "version": "v2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/civicrm/composer-downloads-plugin.git",
+                "reference": "869b7a12f57b2d912f0ea77d5c33c1518b8de27d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/civicrm/composer-downloads-plugin/zipball/869b7a12f57b2d912f0ea77d5c33c1518b8de27d",
+                "reference": "869b7a12f57b2d912f0ea77d5c33c1518b8de27d",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.1",
+                "php": ">=5.6",
+                "togos/gitignore": "~1.1.1"
+            },
+            "require-dev": {
+                "composer/composer": "~1.0",
+                "friendsofphp/php-cs-fixer": "^2.3",
+                "phpunit/phpunit": "^5.7",
+                "totten/process-helper": "^1.0.1"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "LastCall\\DownloadsPlugin\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "LastCall\\DownloadsPlugin\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Rob Bayliss",
+                    "email": "rob@lastcallmedia.com"
+                },
+                {
+                    "name": "Tim Otten",
+                    "email": "totten@civicrm.org"
+                }
+            ],
+            "description": "Composer plugin for downloading additional files within any composer package.",
+            "time": "2019-08-22T10:56:51+00:00"
+        },
         {
             "name": "civicrm/upgrade-test",
             "version": "dev-master",
@@ -423,12 +474,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "84c0c150c1520995f09ea9e47e817068b353cb0f"
+                "reference": "cfd510c047359b6a48197f3bc08c9d260e68a108"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/84c0c150c1520995f09ea9e47e817068b353cb0f",
-                "reference": "84c0c150c1520995f09ea9e47e817068b353cb0f",
+                "url": "https://api.github.com/repos/symfony/config/zipball/cfd510c047359b6a48197f3bc08c9d260e68a108",
+                "reference": "cfd510c047359b6a48197f3bc08c9d260e68a108",
                 "shasum": ""
             },
             "require": {
@@ -660,7 +711,7 @@
                 },
                 {
                     "name": "Gert de Pagter",
-                    "email": "backendtea@gmail.com"
+                    "email": "BackEndTea@gmail.com"
                 }
             ],
             "description": "Symfony polyfill for ctype functions",
@@ -786,6 +837,39 @@
             "time": "2019-03-25T07:48:46+00:00"
         },
         {
+            "name": "togos/gitignore",
+            "version": "1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/TOGoS/PHPGitIgnore.git",
+                "reference": "32bc0830e4123f670adcbf5ddda5bef362f4f4d4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/TOGoS/PHPGitIgnore/zipball/32bc0830e4123f670adcbf5ddda5bef362f4f4d4",
+                "reference": "32bc0830e4123f670adcbf5ddda5bef362f4f4d4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.2"
+            },
+            "require-dev": {
+                "togos/simpler-test": "1.1.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "TOGoS_GitIgnore_": "src/main/php/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Parser for .gitignore (and sparse-checkout, and anything else using the same format) files",
+            "time": "2019-04-19T19:16:58+00:00"
+        },
+        {
             "name": "totten/php-symbol-diff",
             "version": "dev-master",
             "source": {
@@ -801,9 +885,6 @@
             },
             "require": {
                 "nikic/php-parser": "^1.4"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "3.7.*"
             },
             "bin": [
                 "bin/php-symbol-diff",
@@ -861,13 +942,13 @@
             "authors": [
                 {
                     "name": "James Logsdon",
-                    "email": "jlogsdon@php.net",
-                    "role": "Developer"
+                    "role": "Developer",
+                    "email": "jlogsdon@php.net"
                 },
                 {
                     "name": "Daniel Bachhuber",
-                    "email": "daniel@handbuilt.co",
-                    "role": "Maintainer"
+                    "role": "Maintainer",
+                    "email": "daniel@handbuilt.co"
                 }
             ],
             "description": "Console utilities for PHP",


### PR DESCRIPTION
Before
------

There are ~16 PHAR/ZIP files downloaded via bash script in `civi-download-tools`

After
-----

Those same ~16 PHAR/ZIP files are downlaoded via `composer-downloads-plugin`.

Comments
--------

* Still allows multiple versions of different tools (i.e. phpunit5.phar + phpunit6.phar).
* The notation is more pithy/readable (less far-flung/less boiler-plate)
* When switching back/forth between revisions of buildkit with different versions of each tool, you'd get the benefit composer's cache

I've done some `r-run` on one laptop, but this is a bit of change, so we
should do some `r-run` in other contexts.