### PR TITLE
Add environment variable for customizing the "app/config" types

### DIFF
--- a/app/civibuild.conf.tmpl
+++ b/app/civibuild.conf.tmpl
@@ -35,11 +35,11 @@
 # APACHE_VHOST_ALIAS=1
 
 #############################################################################
-## Example: an extra site configuration directory. You can put your custop site
+## Example: an extra site configuration directory. You can put your custom site
 ## types in this directory.
 ## No trailing slash.
 
-# EXTRA_SITE_CONFIG_DIR = "$HOME/extra_site_configs"
+# CIVIBUILD_PATH="$HOME/extra_site_configs:$CIVIBUILD_PATH"
 
 #############################################################################
 ## Example: Place all builds in /srv/www.

--- a/app/civibuild.conf.tmpl
+++ b/app/civibuild.conf.tmpl
@@ -35,6 +35,13 @@
 # APACHE_VHOST_ALIAS=1
 
 #############################################################################
+## Example: an extra site configuration directory. You can put your custop site
+## types in this directory.
+## No trailing slash.
+
+# EXTRA_SITE_CONFIG_DIR = "$HOME/extra_site_configs"
+
+#############################################################################
 ## Example: Place all builds in /srv/www.
 
 # BLDDIR=/srv/www

--- a/src/civibuild.compute-defaults.sh
+++ b/src/civibuild.compute-defaults.sh
@@ -16,6 +16,14 @@
 [ -z "$WEB_ROOT" ]           && WEB_ROOT="$BLDDIR/$SITE_NAME"
 [ -z "$CMS_ROOT" ]           && CMS_ROOT="$WEB_ROOT"
 
+# Check whether the extra site config dir is set and whether the site type
+# exists in that directory.
+if [ -n  "$EXTRA_SITE_CONFIG_DIR" ]; then
+  if [ -d "$EXTRA_SITE_CONFIG_DIR/$SITE_TYPE" ]; then
+    SITE_CONFIG_DIR="$EXTRA_SITE_CONFIG_DIR/$SITE_TYPE"
+  fi
+fi
+
 [ -z "$SITE_CONFIG_DIR" ]    && SITE_CONFIG_DIR="$PRJDIR/app/config/$SITE_TYPE"
 
 if [ -z "$CMS_URL" ]; then

--- a/src/civibuild.compute-defaults.sh
+++ b/src/civibuild.compute-defaults.sh
@@ -16,15 +16,8 @@
 [ -z "$WEB_ROOT" ]           && WEB_ROOT="$BLDDIR/$SITE_NAME"
 [ -z "$CMS_ROOT" ]           && CMS_ROOT="$WEB_ROOT"
 
-# Check whether the extra site config dir is set and whether the site type
-# exists in that directory.
-if [ -n  "$EXTRA_SITE_CONFIG_DIR" ]; then
-  if [ -d "$EXTRA_SITE_CONFIG_DIR/$SITE_TYPE" ]; then
-    SITE_CONFIG_DIR="$EXTRA_SITE_CONFIG_DIR/$SITE_TYPE"
-  fi
-fi
-
-[ -z "$SITE_CONFIG_DIR" ]    && SITE_CONFIG_DIR="$PRJDIR/app/config/$SITE_TYPE"
+CIVIBUILD_PATH="$CIVIBUILD_PATH:$PRJDIR/app/config"
+[ -z "$SITE_CONFIG_DIR" ]    && SITE_CONFIG_DIR=$(cvutil_path_search "$SITE_TYPE" "$CIVIBUILD_PATH")
 
 if [ -z "$CMS_URL" ]; then
   if [ "%AUTO%" == "$URL_TEMPLATE" ]; then

--- a/src/civibuild.defaults.sh
+++ b/src/civibuild.defaults.sh
@@ -20,6 +20,18 @@
 # BLDDIR=
 
 ###############################################################################
+## External variables (inherited from user's shell environment)
+
+## Location of all mutable files (site-builds, logs, tmp data, etc).
+## If blank/omitted, then use a default file structure relative to `civibuild`'s bin.
+# CIVIBUILD_HOME=
+
+## When looking for instructions to do a build, search this list of folders.
+## (example: $HOME/.civibuild/types:/etc/civibuild/types:/usr/share/buildkit/app/config)
+## (note: The built-in folder "$PRJDIR/app/config" is automatically appended.)
+# CIVIBUILD_PATH=
+
+###############################################################################
 ## Common variables
 
 ## The name of on-going action (eg "create" or "reset")
@@ -31,7 +43,7 @@ SITE_NAME=
 ## Codename for the build scripts (default: $SITE_NAME)
 SITE_TYPE=
 
-## Location of the build scripts (default: app/config/$SITE_TYPE)
+## Location of the build scripts (default: search $CIVIBUILD_PATH for $SITE_TYPE)
 SITE_CONFIG_DIR=
 
 ## Optional identifier to distinguish subsites in a multi-site build

--- a/src/civibuild.lib.sh
+++ b/src/civibuild.lib.sh
@@ -37,6 +37,21 @@ function cvutil_assertvars() {
 }
 
 ###############################################################################
+## Find the location of <item> in a list of paths.
+## usage: cvutil_path_search <item> <parent1>:<parent2>:...
+## example: cvutil_path_search ls /usr/local/bin:/usr/bin:/bin
+function cvutil_path_search() {
+  local search_target="$1"
+  local search_paths="$2"
+  printf %s "$search_paths" | awk 'BEGIN {RS=":"}; 1' | while read candidate ; do
+    if [ -n "$candidate" -a -e "$candidate/$search_target" ]; then
+      echo "$candidate/$search_target"
+      break
+    fi
+  done
+}
+
+###############################################################################
 ## Prompt user for confirmation
 ## (In automated scripts or blank response, use default)
 ##


### PR DESCRIPTION
With this PR it is possible to declare a configuration option `EXTRA_SITE_CONFIG_DIR` this directory could contain custom site types (without overriding existing ones). 