### PR TITLE
For 5.17 and 5.18 versions bind to using 4.5.2 of apiv4 otherwise dow…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,7 @@ bin/phpunit.bat
 bin/phpunit4
 bin/phpunit5
 bin/phpunit6
+bin/phpunit7
 bin/protractor
 bin/webdriver-manager
 bin/wp

--- a/app/config/backdrop-demo/download.sh
+++ b/app/config/backdrop-demo/download.sh
@@ -20,14 +20,7 @@ pushd "$WEB_ROOT/web/modules" >> /dev/null
   git clone ${CACHE_DIR}/civicrm/civicrm-core.git      -b "$CIVI_VERSION"     civicrm
   git clone ${CACHE_DIR}/civicrm/civicrm-backdrop.git  -b "1.x-$CIVI_VERSION" civicrm/backdrop
   git clone ${CACHE_DIR}/civicrm/civicrm-packages.git  -b "$CIVI_VERSION"     civicrm/packages
-  case "$CIVI_VERSION" in
-    5.17|5.18)
-     git clone "${CACHE_DIR}/civicrm/api4.git"                                -b "4.5.2"             civicrm/ext/api4
-     ;;
-  *)
-     EXTCIVIVER=$( php -r '$x=simplexml_load_file("civicrm/xml/version.xml"); echo $x->version_no;' )
-     cv dl -b "@https://civicrm.org/extdir/ver=$EXTCIVIVER|cms=Drupal|status=|ready=/org.civicrm.api4.xml" --to="$WEB_ROOT/web/modules/civicrm/ext/api4" --dev
-  esac
+  api4_download_conditional civicrm                                           civicrm/ext/api4
   git_set_hooks civicrm-drupal      civicrm/backdrop   "../tools/scripts/git"
   git_set_hooks civicrm-core        civicrm            "tools/scripts/git"
   git_set_hooks civicrm-packages    civicrm/packages   "../tools/scripts/git"

--- a/app/config/backdrop-demo/download.sh
+++ b/app/config/backdrop-demo/download.sh
@@ -20,8 +20,14 @@ pushd "$WEB_ROOT/web/modules" >> /dev/null
   git clone ${CACHE_DIR}/civicrm/civicrm-core.git      -b "$CIVI_VERSION"     civicrm
   git clone ${CACHE_DIR}/civicrm/civicrm-backdrop.git  -b "1.x-$CIVI_VERSION" civicrm/backdrop
   git clone ${CACHE_DIR}/civicrm/civicrm-packages.git  -b "$CIVI_VERSION"     civicrm/packages
-  git clone ${CACHE_DIR}/civicrm/api4.git              -b "master"            civicrm/ext/api4
-
+  case "$CIVI_VERSION" in
+    5.17|5.18)
+     git clone "${CACHE_DIR}/civicrm/api4.git"                                -b "4.5.2"             civicrm/ext/api4
+     ;;
+  *)
+     EXTCIVIVER=$( php -r '$x=simplexml_load_file("civicrm/xml/version.xml"); echo $x->version_no;' )
+     cv dl -b "@https://civicrm.org/extdir/ver=$EXTCIVIVER|cms=Drupal|status=|ready=/org.civicrm.api4.xml" --to="$WEB_ROOT/web/modules/civicrm/ext/api4" --dev
+  esac
   git_set_hooks civicrm-drupal      civicrm/backdrop   "../tools/scripts/git"
   git_set_hooks civicrm-core        civicrm            "tools/scripts/git"
   git_set_hooks civicrm-packages    civicrm/packages   "../tools/scripts/git"

--- a/app/config/drupal-clean/download.sh
+++ b/app/config/drupal-clean/download.sh
@@ -18,17 +18,7 @@ pushd "$WEB_ROOT/web"
     git clone "${CACHE_DIR}/civicrm/civicrm-drupal.git"                      -b "7.x-$CIVI_VERSION"  civicrm/drupal
     git clone "${CACHE_DIR}/civicrm/civicrm-packages.git"                    -b "$CIVI_VERSION"      civicrm/packages
     git clone "${CACHE_DIR}/eileenmcnaughton/civicrm_developer.git"          -b master               civicrm_developer
-
-    ## The API test suite now supports a dual-version mode (i.e. if APIv3 and APIv4 are both present, it runs some tests against both).
-    ## At time of writing, for several recent versions of core, api_v3_AllTests won't pass unless API4 v4.5 is installed.
-    case "$CIVI_VERSION" in
-     5.17|5.18)
-      git clone "${CACHE_DIR}/civicrm/api4.git"                                -b "4.5.2"             civicrm/ext/api4
-      ;;
-     *)
-      EXTCIVIVER=$( php -r '$x=simplexml_load_file("civicrm/xml/version.xml"); echo $x->version_no;' )
-      cv dl -b "@https://civicrm.org/extdir/ver=$EXTCIVIVER|cms=Drupal|status=|ready=/org.civicrm.api4.xml" --to="$WEB_ROOT/web/sites/all/modules/civicrm/ext/api4" --dev
-     esac
+    api4_download_conditional civicrm                                                                civicrm/ext/api4
 
     extract-url --cache-ttl 172800 civicrm=http://download.civicrm.org/civicrm-l10n-core/archives/civicrm-l10n-daily.tar.gz
     ## or https://raw.github.com/civicrm/l10n/master/po/fr_CA/civicrm.mo => civicrm/l10n/fr_CA/LC_MESSAGES/

--- a/app/config/drupal-clean/download.sh
+++ b/app/config/drupal-clean/download.sh
@@ -21,7 +21,14 @@ pushd "$WEB_ROOT/web"
 
     ## The API test suite now supports a dual-version mode (i.e. if APIv3 and APIv4 are both present, it runs some tests against both).
     ## At time of writing, for several recent versions of core, api_v3_AllTests won't pass unless API4 v4.5 is installed.
-    git clone "${CACHE_DIR}/civicrm/api4.git"                                -b "master"             civicrm/ext/api4
+    case "$CIVI_VERSION" in
+     5.17|5.18)
+      git clone "${CACHE_DIR}/civicrm/api4.git"                                -b "4.5.2"             civicrm/ext/api4
+      ;;
+     *)
+      EXTCIVIVER=$( php -r '$x=simplexml_load_file("civicrm/xml/version.xml"); echo $x->version_no;' )
+      cv dl -b "@https://civicrm.org/extdir/ver=$EXTCIVIVER|cms=Drupal|status=|ready=/org.civicrm.api4.xml" --to="$WEB_ROOT/web/sites/all/modules/civicrm/ext/api4" --dev
+     esac
 
     extract-url --cache-ttl 172800 civicrm=http://download.civicrm.org/civicrm-l10n-core/archives/civicrm-l10n-daily.tar.gz
     ## or https://raw.github.com/civicrm/l10n/master/po/fr_CA/civicrm.mo => civicrm/l10n/fr_CA/LC_MESSAGES/

--- a/app/config/drupal-demo/download.sh
+++ b/app/config/drupal-demo/download.sh
@@ -21,7 +21,15 @@ pushd "$WEB_ROOT/web"
     git clone "${CACHE_DIR}/civicrm/civicrm-core.git"                        -b "$CIVI_VERSION"      civicrm
     git clone "${CACHE_DIR}/civicrm/civicrm-drupal.git"                      -b "7.x-$CIVI_VERSION"  civicrm/drupal
     git clone "${CACHE_DIR}/civicrm/civicrm-packages.git"                    -b "$CIVI_VERSION"      civicrm/packages
-    git clone "${CACHE_DIR}/civicrm/api4.git"                                -b "master"             civicrm/ext/api4
+    case "$CIVI_VERSION" in
+     5.17|5.18)
+      git clone "${CACHE_DIR}/civicrm/api4.git"                                -b "4.5.2"             civicrm/ext/api4
+      ;;
+     *)
+      EXTCIVIVER=$( php -r '$x=simplexml_load_file("civicrm/xml/version.xml"); echo $x->version_no;' )
+      cv dl -b "@https://civicrm.org/extdir/ver=$EXTCIVIVER|cms=Drupal|status=|ready=/org.civicrm.api4.xml" --to="$WEB_ROOT/web/sites/all/modules/civicrm/ext/api4" --dev
+     esac
+
     git clone "${CACHE_DIR}/eileenmcnaughton/civicrm_developer.git"          -b master               civicrm_developer
     git clone "${CACHE_DIR}/civicrm/civivolunteer.git"                       -b "$VOL_VERSION"       civicrm/tools/extensions/civivolunteer
     git clone "${CACHE_DIR}/ginkgostreet/org.civicrm.angularprofiles.git"    -b "$NG_PRFL_VERSION"   civicrm/tools/extensions/org.civicrm.angularprofiles

--- a/app/config/drupal-demo/download.sh
+++ b/app/config/drupal-demo/download.sh
@@ -21,15 +21,7 @@ pushd "$WEB_ROOT/web"
     git clone "${CACHE_DIR}/civicrm/civicrm-core.git"                        -b "$CIVI_VERSION"      civicrm
     git clone "${CACHE_DIR}/civicrm/civicrm-drupal.git"                      -b "7.x-$CIVI_VERSION"  civicrm/drupal
     git clone "${CACHE_DIR}/civicrm/civicrm-packages.git"                    -b "$CIVI_VERSION"      civicrm/packages
-    case "$CIVI_VERSION" in
-     5.17|5.18)
-      git clone "${CACHE_DIR}/civicrm/api4.git"                                -b "4.5.2"             civicrm/ext/api4
-      ;;
-     *)
-      EXTCIVIVER=$( php -r '$x=simplexml_load_file("civicrm/xml/version.xml"); echo $x->version_no;' )
-      cv dl -b "@https://civicrm.org/extdir/ver=$EXTCIVIVER|cms=Drupal|status=|ready=/org.civicrm.api4.xml" --to="$WEB_ROOT/web/sites/all/modules/civicrm/ext/api4" --dev
-     esac
-
+    api4_download_conditional civicrm                                                                civicrm/ext/api4
     git clone "${CACHE_DIR}/eileenmcnaughton/civicrm_developer.git"          -b master               civicrm_developer
     git clone "${CACHE_DIR}/civicrm/civivolunteer.git"                       -b "$VOL_VERSION"       civicrm/tools/extensions/civivolunteer
     git clone "${CACHE_DIR}/ginkgostreet/org.civicrm.angularprofiles.git"    -b "$NG_PRFL_VERSION"   civicrm/tools/extensions/org.civicrm.angularprofiles

--- a/app/config/wp-case/download.sh
+++ b/app/config/wp-case/download.sh
@@ -29,15 +29,7 @@ pushd $WEB_ROOT/wp-content/plugins >> /dev/null
   git clone ${CACHE_DIR}/civicrm/civicrm-wordpress.git                -b "$CIVI_VERSION" civicrm
   git clone ${CACHE_DIR}/civicrm/civicrm-core.git                     -b "$CIVI_VERSION" civicrm/civicrm
   git clone ${CACHE_DIR}/civicrm/civicrm-packages.git                 -b "$CIVI_VERSION" civicrm/civicrm/packages
-  case "$CIVI_VERSION" in
-   5.17|5.18)
-     git clone "${CACHE_DIR}/civicrm/api4.git"                                -b "4.5.2"             civicrm/ext/api4
-     ;;
-   *)
-     EXTCIVIVER=$( php -r '$x=simplexml_load_file("civicrm/xml/version.xml"); echo $x->version_no;' )
-     cv dl -b "@https://civicrm.org/extdir/ver=$EXTCIVIVER|cms=Drupal|status=|ready=/org.civicrm.api4.xml" --to="$WEB_ROOT/web/wp-content/plugins/civicrm/civicrm/ext/api4" --dev
-  esac
-  git clone ${CACHE_DIR}/civicrm/api4.git                             -b "master"        civicrm/civicrm/ext/api4
+  api4_download_conditional civicrm/civicrm                                              civicrm/civicrm/ext/api4
   git clone ${CACHE_DIR}/civicrm/civicrm-demo-wp.git                  -b master          civicrm-demo-wp
 
   mkdir -p civicrm/civicrm/ext

--- a/app/config/wp-case/download.sh
+++ b/app/config/wp-case/download.sh
@@ -29,6 +29,14 @@ pushd $WEB_ROOT/wp-content/plugins >> /dev/null
   git clone ${CACHE_DIR}/civicrm/civicrm-wordpress.git                -b "$CIVI_VERSION" civicrm
   git clone ${CACHE_DIR}/civicrm/civicrm-core.git                     -b "$CIVI_VERSION" civicrm/civicrm
   git clone ${CACHE_DIR}/civicrm/civicrm-packages.git                 -b "$CIVI_VERSION" civicrm/civicrm/packages
+  case "$CIVI_VERSION" in
+   5.17|5.18)
+     git clone "${CACHE_DIR}/civicrm/api4.git"                                -b "4.5.2"             civicrm/ext/api4
+     ;;
+   *)
+     EXTCIVIVER=$( php -r '$x=simplexml_load_file("civicrm/xml/version.xml"); echo $x->version_no;' )
+     cv dl -b "@https://civicrm.org/extdir/ver=$EXTCIVIVER|cms=Drupal|status=|ready=/org.civicrm.api4.xml" --to="$WEB_ROOT/web/wp-content/plugins/civicrm/civicrm/ext/api4" --dev
+  esac
   git clone ${CACHE_DIR}/civicrm/api4.git                             -b "master"        civicrm/civicrm/ext/api4
   git clone ${CACHE_DIR}/civicrm/civicrm-demo-wp.git                  -b master          civicrm-demo-wp
 

--- a/app/config/wp-demo/download.sh
+++ b/app/config/wp-demo/download.sh
@@ -24,15 +24,7 @@ pushd "$WEB_ROOT/web/wp-content/plugins" >> /dev/null
   git clone ${CACHE_DIR}/civicrm/civicrm-wordpress.git                -b "$CIVI_VERSION" civicrm
   git clone ${CACHE_DIR}/civicrm/civicrm-core.git                     -b "$CIVI_VERSION" civicrm/civicrm
   git clone ${CACHE_DIR}/civicrm/civicrm-packages.git                 -b "$CIVI_VERSION" civicrm/civicrm/packages
-  case "$CIVI_VERSION" in
-    5.17|5.18)
-      git clone "${CACHE_DIR}/civicrm/api4.git"                                -b "4.5.2"             civicrm/civicrm/ext/api4
-      ;;
-    *)
-      EXTCIVIVER=$( php -r '$x=simplexml_load_file("civicrm/xml/version.xml"); echo $x->version_no;' )
-      cv dl -b "@https://civicrm.org/extdir/ver=$EXTCIVIVER|cms=Drupal|status=|ready=/org.civicrm.api4.xml" --to="$WEB_ROOT/web/wp-content/plugins/civicrm/civicrm/ext/api4" --dev
-  esac
-  git clone ${CACHE_DIR}/civicrm/api4.git                             -b master          civicrm/civicrm/ext/api4
+  api4_download_conditional civicrm/civicrm                                              civicrm/civicrm/ext/api4
   git clone ${CACHE_DIR}/civicrm/civicrm-demo-wp.git                  -b master          civicrm-demo-wp
   git clone ${CACHE_DIR}/civicrm/civivolunteer.git                    -b "$VOL_VERSION"  civicrm/civicrm/tools/extensions/civivolunteer
   git clone ${CACHE_DIR}/ginkgostreet/org.civicrm.angularprofiles.git -b "$NG_PRFL_VERSION" civicrm/civicrm/tools/extensions/org.civicrm.angularprofiles

--- a/app/config/wp-demo/download.sh
+++ b/app/config/wp-demo/download.sh
@@ -24,6 +24,14 @@ pushd "$WEB_ROOT/web/wp-content/plugins" >> /dev/null
   git clone ${CACHE_DIR}/civicrm/civicrm-wordpress.git                -b "$CIVI_VERSION" civicrm
   git clone ${CACHE_DIR}/civicrm/civicrm-core.git                     -b "$CIVI_VERSION" civicrm/civicrm
   git clone ${CACHE_DIR}/civicrm/civicrm-packages.git                 -b "$CIVI_VERSION" civicrm/civicrm/packages
+  case "$CIVI_VERSION" in
+    5.17|5.18)
+      git clone "${CACHE_DIR}/civicrm/api4.git"                                -b "4.5.2"             civicrm/civicrm/ext/api4
+      ;;
+    *)
+      EXTCIVIVER=$( php -r '$x=simplexml_load_file("civicrm/xml/version.xml"); echo $x->version_no;' )
+      cv dl -b "@https://civicrm.org/extdir/ver=$EXTCIVIVER|cms=Drupal|status=|ready=/org.civicrm.api4.xml" --to="$WEB_ROOT/web/wp-content/plugins/civicrm/civicrm/ext/api4" --dev
+  esac
   git clone ${CACHE_DIR}/civicrm/api4.git                             -b master          civicrm/civicrm/ext/api4
   git clone ${CACHE_DIR}/civicrm/civicrm-demo-wp.git                  -b master          civicrm-demo-wp
   git clone ${CACHE_DIR}/civicrm/civivolunteer.git                    -b "$VOL_VERSION"  civicrm/civicrm/tools/extensions/civivolunteer

--- a/src/civibuild.lib.sh
+++ b/src/civibuild.lib.sh
@@ -530,10 +530,11 @@ function api4_download_conditional() {
   fi
 
   case "$CIVI_VERSION" in
-    ## api4@4.5 is roughly same timeframe as core@5.17 and 5.18 (and early-5.19.alpha)
-    ## api4@4.4 sounds plausiblish for slightly older things
-    5.17*|5.18*|5.19*) git clone "${CACHE_DIR}/civicrm/api4.git" -b "4.5" "$api4_path" ;;
-    5.14*|5.15*) git clone "${CACHE_DIR}/civicrm/api4.git" -b "4.4" "$api4_path" ;;
+    ## Circa v5.16 (3e20c1acb397d6dfe?), api4+core got into a bidrectional dependency, and api4@~4.5
+    ## seems to be the closest release that corresponds to the dev-periods of 5.16-5.18.
+    ## Circa v5.19.alpha1 (#15309), api4 should be merged into core.
+    5.16*|5.17*|5.18*|5.19*) git clone "${CACHE_DIR}/civicrm/api4.git" -b "4.5" "$api4_path" ;;
+    # 5.14*|5.15*) git clone "${CACHE_DIR}/civicrm/api4.git" -b "4.4" "$api4_path" ;;
     *) echo -n ;; ## Shrug
       ##EXTCIVIVER=$( php -r '$x=simplexml_load_file("civicrm/xml/version.xml"); echo $x->version_no;' )
       ##cv dl -b "@https://civicrm.org/extdir/ver=$EXTCIVIVER|cms=Drupal|status=|ready=/org.civicrm.api4.xml" --to="$WEB_ROOT/web/sites/all/modules/civicrm/ext/api4" --dev

--- a/src/civibuild.lib.sh
+++ b/src/civibuild.lib.sh
@@ -509,6 +509,38 @@ function amp_uninstall() {
 }
 
 ###############################################################################
+## Download APIv4, if it's not built into the target version of Civi
+## usage: api4_download_conditional <civicrm-path> <api4-path>
+function api4_download_conditional() {
+  cvutil_assertvars api4_download_conditional CIVI_VERSION CACHE_DIR
+  local civi_path="$1"
+  local api4_path="$2"
+
+  if [ -z "$api4_path" -o -z "$civi_path" ]; then
+    cvutil_fatal "Cannot download api4: Target path not specified"
+  fi
+
+  if [ ! -e "$civi_path" ]; then
+    cvutil_fatal "Cannot download api4: Must download civicrm-core first"
+  fi
+
+  if [ -e "$civi_path/Civi/Api4" ]; then
+    ## Circa 5.19.alpha, api4 is merged into core.
+    return;
+  fi
+
+  case "$CIVI_VERSION" in
+    ## api4@4.5 is roughly same timeframe as core@5.17 and 5.18 (and early-5.19.alpha)
+    ## api4@4.4 sounds plausiblish for slightly older things
+    5.17*|5.18*|5.19*) git clone "${CACHE_DIR}/civicrm/api4.git" -b "4.5" "$api4_path" ;;
+    5.14*|5.15*) git clone "${CACHE_DIR}/civicrm/api4.git" -b "4.4" "$api4_path" ;;
+    *) echo -n ;; ## Shrug
+      ##EXTCIVIVER=$( php -r '$x=simplexml_load_file("civicrm/xml/version.xml"); echo $x->version_no;' )
+      ##cv dl -b "@https://civicrm.org/extdir/ver=$EXTCIVIVER|cms=Drupal|status=|ready=/org.civicrm.api4.xml" --to="$WEB_ROOT/web/sites/all/modules/civicrm/ext/api4" --dev
+  esac
+}
+
+###############################################################################
 ## Generate config files and setup database
 function civicrm_install() {
   cvutil_assertvars civicrm_install CIVI_CORE CIVI_FILES CIVI_TEMPLATEC CIVI_DOMAIN_NAME CIVI_DOMAIN_EMAIL


### PR DESCRIPTION
…nload from the extensions directory. Eventually we will want to stop this on master/5.19 and up but that can come later

This pegs the version downloaded to be a specific tag version of apiv4 because 5.17 will only download 4.4.x versions of api4 

Eventually we will want a conditional on master and other branches until we get rid of 5.17/5.18 etc