### PR TITLE
Change days before stale and messaging

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,7 +13,8 @@ jobs:
     - uses: actions/stale@v1
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        stale-issue-message: 'Stale issue message'
-        stale-pr-message: 'Stale pull request message'
+        stale-issue-message: 'This issue has gone 30 days with no activity, it has been marked stale.'
+        stale-pr-message: 'This pull request has reached 30 days with no activity, it has been marked as stale.'
         stale-issue-label: 'no-issue-activity'
         stale-pr-label: 'no-pr-activity'
+        days-before-stale: 30


### PR DESCRIPTION
Drops the value of `days-before-stale` from 60 to 30 and introduces more useful messaging.

If we like this we should cascade across the other Repos with actions turned on for this.