### PR TITLE
Fixing a stray "(".

### DIFF
--- a/bin/civi-download-tools
+++ b/bin/civi-download-tools
@@ -306,7 +306,7 @@ function get_system_installer() {
     source /etc/lsb-release
   fi
   case "$DISTRIB_CODENAME" in
-    (jessie|stretch|buster|xenial|bionic|cosmic|disco)
+    jessie|stretch|buster|xenial|bionic|cosmic|disco)
       echo "do_system_$DISTRIB_CODENAME"
       ;;
     *)


### PR DESCRIPTION
When removing the old EoL version I inadvertently added a "(" to the start of a case/switch block.

This reverts that erroneous change.