### PR TITLE
wp-demo, wp-case - Initialize wpLoadPhp

### DIFF
--- a/app/config/wp-case/install.sh
+++ b/app/config/wp-case/install.sh
@@ -42,6 +42,7 @@ wp theme install twentythirteen --activate
 wp eval '$home = get_page_by_title("Welcome to CiviCRM with WordPress"); update_option("page_on_front", $home->ID); update_option("show_on_front", "page");'
 
 wp plugin activate civicrm
+wp eval '$c=[civi_wp(), "add_wpload_setting"]; if (is_callable($c)) $c();' ## Temporary workaround, init wpLoadPhp
 wp plugin activate civicrm-demo-wp
 
 echo '{"enable_components":["CiviMail","CiviReport","CiviCase"]}' | cv api setting.create --in=json

--- a/app/config/wp-demo/install.sh
+++ b/app/config/wp-demo/install.sh
@@ -57,6 +57,7 @@ wp theme install twentythirteen --activate
 wp eval '$home = get_page_by_title("Welcome to CiviCRM with WordPress"); update_option("page_on_front", $home->ID); update_option("show_on_front", "page");'
 
 wp plugin activate civicrm
+wp eval '$c=[civi_wp(), "add_wpload_setting"]; if (is_callable($c)) $c();' ## Temporary workaround, init wpLoadPh
 wp plugin activate civicrm-demo-wp
 wp plugin install civicrm-admin-utilities
 wp plugin install gutenberg


### PR DESCRIPTION
This is a follow-up to https://lab.civicrm.org/dev/core/issues/1412 (especially https://github.com/civicrm/civicrm-core/pull/15922). The issue yielded a new E2E test.

For the `wp-cli` use-case, the test implicitly relies on the setting `wpLoadPhp`, which is usually initialized on the first browser-based page-view of the admin UI. However, in scripted E2E, we don't start out with a browser-based page-view.

Aside: It's a bit frustrating that we still don't have a good unified place for install logic. I'd vote for switching to `civicrm-setup` by default, and then you can initialize WP-specific path settings [here](https://github.com/civicrm/civicrm-setup/blob/01019db/plugins/init/WordPress.civi-setup.php#L60-L64).