### PR TITLE
Allow for backdrop installs to run the upgrade tests

### DIFF
--- a/src/command/upgrade-test.run.sh
+++ b/src/command/upgrade-test.run.sh
@@ -1,5 +1,5 @@
 ## civicrm-upgrade-test only works with drush right now
-if grep -q drupal "$CMS_ROOT/index.php" ; then
+if grep -q drupal "$CMS_ROOT/index.php" || grep -q backdrop "$CMS_ROOT/index.php" ; then
   cvutil_makeparent "$UPGRADE_LOG_DIR"
   cvutil_mkdir "$UPGRADE_LOG_DIR"
   pushd "$PRJDIR/vendor/civicrm/upgrade-test/databases" > /dev/null
@@ -7,5 +7,5 @@ if grep -q drupal "$CMS_ROOT/index.php" ; then
     ../civicrm-upgrade-test --db "$CIVI_DB_NAME" --db-args "$CIVI_DB_ARGS" --web "$CMS_ROOT" --out "$UPGRADE_LOG_DIR" --junit-xml "$UPGRADE_LOG_DIR/civicrm-upgrade-test.xml" "${ARGS[@]:2}"
   popd > /dev/null
 else
-  echo "Skipped. civicrm-upgrade-test currently requires Drupal 7 and Drush."
+  echo "Skipped. civicrm-upgrade-test currently requires Drupal 7 or Backdrop and Drush."
 fi


### PR DESCRIPTION
This PR depends on the changes made to the upgrade-test repo here https://github.com/civicrm/civicrm-upgrade-test/pull/3/files, I have tested this on my local dev and seems to work fine