### PR TITLE
Switch drupal, wordpress, backdrop phpunit test runner to be phpunit6…

### DIFF
--- a/bin/civi-test-run
+++ b/bin/civi-test-run
@@ -1,6 +1,14 @@
 #!/bin/bash
 set -e
-PHPUNIT=phpunit5
+
+function getPhpunitVer() {
+  CIVIVER=$(getCiviVer)
+  if [ $(php -r "echo version_compare('$CIVIVER', '5.21', '>=');") ]; then
+    echo "phpunit6 --printer \Civi\Test\TAP"
+  else
+    echo 'phpunit5 --tap'
+  fi
+}
 
 #################################################
 ## Helpers
@@ -108,7 +116,7 @@ function junit_cleanup() {
 
 function task_phpunit_drupal() {
   $GUARD pushd "$CIVI_CORE/drupal"
-  if ! $GUARD $PHPUNIT --tap --log-junit "$JUNITDIR/phpunit_drupal.xml" $EXCLUDE_GROUP ; then
+  if ! $GUARD $(getPhpunitVer) --log-junit "$JUNITDIR/phpunit_drupal.xml" $EXCLUDE_GROUP ; then
     EXITCODES="$EXITCODES phpunit-drupal"
   fi
   echo "Found EXITCODES=\"$EXITCODES\""
@@ -119,7 +127,7 @@ function task_phpunit_drupal() {
 
 function task_phpunit_wordpress() {
   $GUARD pushd "$CIVI_CORE/.."
-  if ! $GUARD $PHPUNIT --tap --log-junit "$JUNITDIR/phpunit_wordpress.xml" $EXCLUDE_GROUP ; then
+  if ! $GUARD $(getPhpunitVer) --log-junit "$JUNITDIR/phpunit_wordpress.xml" $EXCLUDE_GROUP ; then
     EXITCODES="$EXITCODES phpunit-wordpress"
   fi
   echo "Found EXITCODES=\"$EXITCODES\""
@@ -130,7 +138,7 @@ function task_phpunit_wordpress() {
 
 function task_phpunit_backdrop() {
   $GUARD pushd "$CIVI_CORE/backdrop"
-  if ! $GUARD $PHPUNIT --tap --log-junit "$JUNITDIR/phpunit_backdrop.xml" $EXCLUDE_GROUP ; then
+  if ! $GUARD $(getPhpunitVer) --log-junit "$JUNITDIR/phpunit_backdrop.xml" $EXCLUDE_GROUP ; then
     EXITCODES="$EXITCODES phpunit-backdrop"
   fi
   echo "Found EXITCODES=\"$EXITCODES\""

--- a/bin/civi-test-run
+++ b/bin/civi-test-run
@@ -3,7 +3,7 @@ set -e
 
 function getPhpunitVer() {
   CIVIVER=$(getCiviVer)
-  if [ $(php -r "echo version_compare('$CIVIVER', '5.21', '>=');") ]; then
+  if [ $(php -r "echo version_compare('$CIVIVER', '5.22', '>=');") ]; then
     echo "phpunit6 --printer \Civi\Test\TAP"
   else
     echo 'phpunit5 --tap'


### PR DESCRIPTION
… for civiversions above 5.21

Now that PRs for https://lab.civicrm.org/dev/core/issues/1194 have been merged as detailed in https://lab.civicrm.org/dev/core/issues/1194#note_29301 i figure we should do this