### PR TITLE
Fix WP E2E Unit tests runs

### DIFF
--- a/app/config/wp-case/install.sh
+++ b/app/config/wp-case/install.sh
@@ -48,6 +48,7 @@ wp plugin activate civicrm-demo-wp
 echo '{"enable_components":["CiviMail","CiviReport","CiviCase"]}' | cv api setting.create --in=json
 civicrm_apply_demo_defaults
 cv ev 'if(is_callable(array("CRM_Core_BAO_CMSUser","synchronize"))){CRM_Core_BAO_CMSUser::synchronize(FALSE);}else{CRM_Utils_System::synchronizeUsers();}'
+wp eval 'civicrm_activate();'
 
 ## Install Shoreditch and CiviCase
 cv en shoreditch styleguide civicase

--- a/app/config/wp-demo/install.sh
+++ b/app/config/wp-demo/install.sh
@@ -65,7 +65,7 @@ wp plugin install gutenberg-ramp --activate
 
 civicrm_apply_demo_defaults
 cv ev 'if(is_callable(array("CRM_Core_BAO_CMSUser","synchronize"))){CRM_Core_BAO_CMSUser::synchronize(FALSE);}else{CRM_Utils_System::synchronizeUsers();}'
-
+wp eval 'civicrm_activate();'
 wp role create civicrm_admin 'CiviCRM Administrator'
 wp cap add civicrm_admin \
   read \


### PR DESCRIPTION
This fixed the E2E test failure on the path url test locally for me however i would be curious if @kcristiano  or @christianwach  had any ideas as to why this is needed in the first place