### PR TITLE
cvutil_inject_settings() - Soften reliance on CMS_VERSION

### DIFF
--- a/src/civibuild.lib.sh
+++ b/src/civibuild.lib.sh
@@ -213,7 +213,8 @@ function cvutil_inject_settings() {
   local FILE="$1"
   local NAME="$2"
   local PREAMBLE="$3"
-  cvutil_assertvars cvutil_inject_settings PRJDIR SITE_NAME SITE_TYPE SITE_CONFIG_DIR SITE_ID SITE_TOKEN PRIVATE_ROOT FILE NAME CMS_VERSION
+  cvutil_assertvars cvutil_inject_settings PRJDIR SITE_NAME SITE_TYPE SITE_CONFIG_DIR SITE_ID SITE_TOKEN PRIVATE_ROOT FILE NAME
+  # Note: CMS_VERSION ought to be defined for use in $civibuild['CMS_VERSION'], but it hasn't always been, and for most build-types its absence would be non-fatal.
 
   ## Prepare temp file
   local TMPFILE="${TMPDIR}/${SITE_TYPE}/${SITE_NAME}/${SITE_ID}.settings.tmp"


### PR DESCRIPTION
The CMS_VERSION was added to the list of required inputs so that it could be
passed through to `$civibuild['CMS_VERSION']` and then eventually to
`app/drupal.settings.d/pre.d/100-file_private_path-d8.php`.

Evidentally (from #503) some old builds did not record a `CMS_VERSION`, so
the assertion raises a fatal.  I'm not certain why - but regardless, the
situation should not be a fatal for most build types (since the value
normally isn't even used).