### PR TITLE
Create basepage for E2E tests

### DIFF
--- a/app/config/wp-case/install.sh
+++ b/app/config/wp-case/install.sh
@@ -109,3 +109,5 @@ wp user create "$DEMO_USER" "$DEMO_EMAIL" --role=civicrm_admin --user_pass="$DEM
 
 ## Ceate anonymous user role
 wp eval '$c=[civi_wp()->users->set_wp_user_capabilities()];if (is_callable($c)) $c();'
+## Force basepage
+wp eval '$c=[civi_wp()->basepage->create_wp_basepage()];if (is_callable($c)) $c();'

--- a/app/config/wp-demo/install.sh
+++ b/app/config/wp-demo/install.sh
@@ -153,6 +153,8 @@ wp cap add civicrm_admin \
 wp user create "$DEMO_USER" "$DEMO_EMAIL" --role=civicrm_admin --user_pass="$DEMO_PASS"
 ## Ceate anonymous user role
 wp eval '$c=[civi_wp()->users->set_wp_user_capabilities()];if (is_callable($c)) $c();'
+## Force basepage
+wp eval '$c=[civi_wp()->basepage->create_wp_basepage()];if (is_callable($c)) $c();'
 
 cv en angularprofiles volunteer
 


### PR DESCRIPTION
Currently the basepage is not created until the UI loads.   This loads it via wp-cli.   
