### PR TITLE
Gutenberg is here to stay

### DIFF
--- a/app/config/wp-demo/install.sh
+++ b/app/config/wp-demo/install.sh
@@ -61,7 +61,7 @@ wp eval '$c=[civi_wp(), "add_wpload_setting"]; if (is_callable($c)) $c();' ## Te
 wp plugin activate civicrm-demo-wp
 wp plugin install civicrm-admin-utilities
 wp plugin install gutenberg
-wp plugin install gutenberg-ramp --activate
+wp plugin install classic-editor --activate
 
 civicrm_apply_demo_defaults
 cv ev 'if(is_callable(array("CRM_Core_BAO_CMSUser","synchronize"))){CRM_Core_BAO_CMSUser::synchronize(FALSE);}else{CRM_Utils_System::synchronizeUsers();}'

--- a/app/config/wp-empty/install.sh
+++ b/app/config/wp-empty/install.sh
@@ -33,6 +33,6 @@ wp theme install twentythirteen --activate
 wp user create "$DEMO_USER" "$DEMO_EMAIL" --user_pass="$DEMO_PASS"
 
 wp plugin install gutenberg
-wp plugin install gutenberg-ramp --activate
+wp plugin install classic-editor --activate
 
 popd >> /dev/null


### PR DESCRIPTION
It's improved to the point we should not disable on test sites.  Remove gutenberg-ramp which disables the block editor, install and activate classic editor which allows switching between the new block editor and the classic editor