### PR TITLE
app/config/empty - Use the `web` directory

### DIFF
--- a/app/config/empty/download.sh
+++ b/app/config/empty/download.sh
@@ -1,2 +1,3 @@
 #!/bin/bash
 mkdir "$WEB_ROOT"
+mkdir "$WEB_ROOT/web"

--- a/app/config/empty/install.sh
+++ b/app/config/empty/install.sh
@@ -1,2 +1,3 @@
 #!/bin/bash
+[ -d "$WEB_ROOT/web" ] && CMS_ROOT="$WEB_ROOT/web"
 amp_install


### PR DESCRIPTION
This updates the profile to use `web` (like all the mainline buildtypes), which fixes support for apache-vdr configurations.