### PR TITLE
civibuild - Add subcommand "env-info"

### DIFF
--- a/src/civibuild.defaults.sh
+++ b/src/civibuild.defaults.sh
@@ -309,6 +309,7 @@ DECLARED_ACTIONS="
   destroy
   download dl
   edit
+  env-info
   install reinstall
   list
   phpunit-info

--- a/src/civibuild.parse.sh
+++ b/src/civibuild.parse.sh
@@ -20,7 +20,7 @@ function civibuild_parse_unnamed_params() {
       continue
     fi
 
-    if [ `echo "$ACTION" | egrep -c 'snapshots|restore-all|list|cache-warmup'` -eq 1 ]; then
+    if [ `echo "$ACTION" | egrep -c 'snapshots|restore-all|list|cache-warmup|env-info'` -eq 1 ]; then
       # dont parse site-name
       break
     fi
@@ -30,7 +30,7 @@ function civibuild_parse_unnamed_params() {
 
   [ -z "$ACTION" ] && civibuild_app_usage
 
-  if [ `echo "$ACTION" | egrep -c 'snapshots|restore-all|list|cache-warmup'` -eq 0 ]; then
+  if [ `echo "$ACTION" | egrep -c 'snapshots|restore-all|list|cache-warmup|env-info'` -eq 0 ]; then
 
     if [ -z "$SITE_NAME" ]; then
       civibuild_detect_site_name

--- a/src/command/env-info.run.sh
+++ b/src/command/env-info.run.sh
@@ -1,3 +1,6 @@
+## "civibuild env-info": Display a report about the general tools/paths of the civibuild environment.
+## Note that this is different from "civibuild show <build-name>" which reports on the values for a specific build.
+
 ## usage: env_report_cmd <cmd-name> <cmd-version-info-options>
 function env_report_cmd() {
   local cmd="$1"
@@ -17,7 +20,17 @@ function env_report_var() {
   printf '[32mVARIABLE[0m: [33m%s[0m=[33m%s[0m\n' "$1" "$2"
 }
 
-env_report_cmd alskdjf -v
+## usage: env_report_special <pseudo-var-name> <bash-lookup-expr>
+function env_report_special() {
+  printf '[32mSPECIAL[0m: [33m%s[0m: [33m%s[0m\n' "$1" "$2"
+  eval "$2" 2>&1 | while read LINE ; do echo "> $LINE" ; done
+  echo
+}
+
+echo '[32m==========================================[0m'
+echo '[32m==========[[33m civibuild env-info [32m]==========[0m'
+echo '[32m==========================================[0m'
+
 env_report_cmd amp --version
 env_report_cmd apachectl -V
 env_report_cmd bash --version
@@ -28,6 +41,8 @@ env_report_cmd cv --version
 env_report_cmd drush --version
 env_report_cmd git --version
 env_report_cmd git-scan --version
+env_report_cmd memcached --version
+env_report_cmd redis-cli --version
 env_report_cmd mysql --version
 env_report_cmd mysqld --version
 env_report_cmd mysqldump --version
@@ -40,9 +55,13 @@ env_report_cmd phpunit7 --version
 env_report_cmd pogo --version
 env_report_cmd wp --version
 
+env_report_special MYSQLD_VERSION "echo 'select version()' | amp sql -a | tail -n1"
+env_report_special AMP_CONFIG "amp config:get | grep '\(httpd_type\|hosts_type\|db_type\|perm_type\|ram_disk_type\|httpd_restart_command\)'"
+
 env_report_var BINDIR "$BINDIR"
 env_report_var PRJDIR "$PRJDIR"
 env_report_var TMPDIR "$TMPDIR"
 env_report_var BLDDIR "$BLDDIR"
 env_report_var CIVIBUILD_HOME "$CIVIBUILD_HOME"
 env_report_var CIVIBUILD_PATH "$CIVIBUILD_PATH"
+env_report_var AMPHOME "$AMPHOME"

--- a/src/command/env-info.run.sh
+++ b/src/command/env-info.run.sh
@@ -1,0 +1,48 @@
+## usage: env_report_cmd <cmd-name> <cmd-version-info-options>
+function env_report_cmd() {
+  local cmd="$1"
+  shift
+  local fullpath="$(which "$cmd")"
+  if [ -z "$fullpath" ]; then
+    printf '[32mCOMMAND[0m: [33m%s[0m [31mMISSING[0m\n' "$cmd"
+  else
+    printf '[32mCOMMAND[0m: [33m%s[0m ([33m%s[0m)\n' "$cmd" "$fullpath"
+    $cmd "$@" 2>&1 | while read LINE ; do echo "> $LINE" ; done
+  fi
+  echo
+}
+
+## usage: env_report_var <var-name> <var-value>
+function env_report_var() {
+  printf '[32mVARIABLE[0m: [33m%s[0m=[33m%s[0m\n' "$1" "$2"
+}
+
+env_report_cmd alskdjf -v
+env_report_cmd amp --version
+env_report_cmd apachectl -V
+env_report_cmd bash --version
+env_report_cmd civistrings --version
+env_report_cmd civix --version
+env_report_cmd composer --version
+env_report_cmd cv --version
+env_report_cmd drush --version
+env_report_cmd git --version
+env_report_cmd git-scan --version
+env_report_cmd mysql --version
+env_report_cmd mysqld --version
+env_report_cmd mysqldump --version
+env_report_cmd node --version
+env_report_cmd php --version
+env_report_cmd php-fpm --version
+env_report_cmd phpunit5 --version
+env_report_cmd phpunit6 --version
+env_report_cmd phpunit7 --version
+env_report_cmd pogo --version
+env_report_cmd wp --version
+
+env_report_var BINDIR "$BINDIR"
+env_report_var PRJDIR "$PRJDIR"
+env_report_var TMPDIR "$TMPDIR"
+env_report_var BLDDIR "$BLDDIR"
+env_report_var CIVIBUILD_HOME "$CIVIBUILD_HOME"
+env_report_var CIVIBUILD_PATH "$CIVIBUILD_PATH"

--- a/src/help/default.hlp
+++ b/src/help/default.hlp
@@ -25,6 +25,7 @@ civibuild [options] command
   [32mclone-destroy[0m         Destroy a database clone
  [33mOther[0m
   [32mcache-warmup[0m          Proactively update git cache
+  [32menv-info[0m              Summarize the local build environment
   [32mphpunit-info[0m          Show configuration tips on using PHPUnit
   [32mupgrade-test[0m          Loads each DB snapshot and runs the current upgrade logic
 

--- a/src/help/env-info.hlp
+++ b/src/help/env-info.hlp
@@ -1,0 +1,6 @@
+[33mUsage:[0m
+  env
+
+[33mNB:[0m For more civibuild documentation see https://docs.civicrm.org/dev/en/latest/tools/civibuild/
+
+[0m


### PR DESCRIPTION
This command dumps basic information about the environment in which we're doing the build (e.g.  PHP and MySQL versions).

It should be useful for adding to the console output on CI test jobs - i.e. so that every job log indicates the versions of the key tools that were used within that test run.