### PR TITLE
Remove composer log hack now that composer depdancy has been fixed up…

### DIFF
--- a/src/civibuild.lib.sh
+++ b/src/civibuild.lib.sh
@@ -574,17 +574,16 @@ function civicrm_download_composer_d8() {
   local EXTRA_PATCH=()
 
   case "$CIVI_VERSION" in
-    5.21*) EXTRA_COMPOSER+=( "civicrm/civicrm-setup:0.4.0 as 0.2.99" ) ; EXTRA_COMPOSER+=( 'cache/integration-tests:dev-master#b97328797ab199f0ac933e39842a86ab732f21f9' ) ; EXTRA_PATCH+=( "https://github.com/civicrm/civicrm-core/pull/16328" ); ;;
-    5.22*) EXTRA_COMPOSER+=( "civicrm/civicrm-setup:0.4.0 as 0.2.99" ) ; EXTRA_COMPOSER+=( 'cache/integration-tests:dev-master#b97328797ab199f0ac933e39842a86ab732f21f9' ) ; EXTRA_PATCH+=( "https://github.com/civicrm/civicrm-core/pull/16413" ); ;;
-    5.23*) EXTRA_COMPOSER+=( 'cache/integration-tests:dev-master#b97328797ab199f0ac933e39842a86ab732f21f9' ); ;;
-    5.24*) echo "No extra patches required" ; ;;
-    5.25*) echo "No extra patches required" ; ;;
-    5.26*) echo "No extra patches required" ; ;;
+    5.21*) EXTRA_COMPOSER+=( "civicrm/civicrm-setup:0.4.0 as 0.2.99" ) ; EXTRA_COMPOSER+=( 'cache/integration-tests:dev-master#b97328797ab199f0ac933e39842a86ab732f21f9' ) ; EXTRA_PATCH+=( "https://github.com/civicrm/civicrm-core/pull/16328" ); EXTRA_COMPOSER+=( 'pear/pear_exception:1.0.1 as 1.0.0'); ;;
+    5.22*) EXTRA_COMPOSER+=( "civicrm/civicrm-setup:0.4.0 as 0.2.99" ) ; EXTRA_COMPOSER+=( 'cache/integration-tests:dev-master#b97328797ab199f0ac933e39842a86ab732f21f9' ) ; EXTRA_PATCH+=( "https://github.com/civicrm/civicrm-core/pull/16413" ); EXTRA_COMPOSER+=( 'pear/pear_exception:1.0.1 as 1.0.0'); ;;
+    5.23*) EXTRA_COMPOSER+=( 'cache/integration-tests:dev-master#b97328797ab199f0ac933e39842a86ab732f21f9' ); EXTRA_COMPOSER+=( 'pear/pear_exception:1.0.1 as 1.0.0'); ;;
+    5.24*) EXTRA_COMPOSER+=( 'pear/pear_exception:1.0.1 as 1.0.0') ; ;;
+    5.25*) EXTRA_COMPOSER+=( 'pear/pear_exception:1.0.1 as 1.0.0') ; ;;
+    5.26*) EXTRA_COMPOSER+=( 'pear/pear_exception:1.0.1 as 1.0.0') ; ;;
     ## Need 5.27? Maybe it's time to remove all this...
     master) echo "No extra patches required" ; ;;
     *) cvutil_fatal "This build type is temporarily limited to branches which have a corresponding patchset." ; ;;
   esac
-  EXTRA_COMPOSER+=( 'pear/pear_exception:1.0.1 as 1.0.0') ## weird conflict in drupal-composer/drupal-project
 
   composer require civicrm/civicrm-asset-plugin:'~1.0.0' "${EXTRA_COMPOSER[@]}" civicrm/civicrm-{core,packages,drupal-8}:"$CIVI_VERSION_COMP" --prefer-source
   [ -n "$EXTRA_PATCH" ] && git scan am -N "${EXTRA_PATCH[@]}"


### PR DESCRIPTION
…stream

Now that https://github.com/civicrm/civicrm-core/pull/17460 has been merged we can reduce the composer hacks around pear log for master