### PR TITLE
dev/core#1781 - civi-test-run - Explicitly choose TIME_FUNC

### DIFF
--- a/bin/civi-test-run
+++ b/bin/civi-test-run
@@ -260,6 +260,15 @@ elif [[ " $SUITES " =~ \ all\  ]]; then
   exit 3
 fi
 
+## dev/core#1781: Some tests exhibit flakiness due to the timing/pacing/happenstance of execution. TIME_FUNC helps to deterministically simulate some of this variation.
+if [ -n "$TIME_FUNC" ]; then
+  echo "(Clock simulation) Tests will use inherited option TIME_FUNC=$TIME_FUNC"
+else
+  TIME_FUNC=$( php -r '$a=$argv; array_shift($a); shuffle($a); echo $a[0];' natural natural frozen linear:500 linear:1250 prng:500 prng:666 prng:1000 prng:1500 )
+  echo "(Clock simulation) No TIME_FUNC was specified. Using TIME_FUNC=$TIME_FUNC"
+fi
+export TIME_FUNC
+
 ## Main
 for TESTTYPE in $SUITES ; do
   case "$TESTTYPE" in


### PR DESCRIPTION
In https://lab.civicrm.org/dev/core/-/issues/1781, it was pointed out that certain flaky tests behave
differently depending on how time passes during the test run; eg with ActionScheduleTest:

* If you let time time progress naturally, then it sometimes passes... and sometimes fails...
* If you simulate time as frozen, then it always passes
* If you simulate time as progressing at pseudorandom pace (`prng:1500`), then it always fails.

In 5.27+, the `TIME_FUNC` variable gives some control over this.

With this change:

* Some test jobs might explicitly designate a `TIME_FUNC`; e.g. `CiviCRM-Core-PR`
  would always run with the same option.
* Any other test jobs would randomly choose among different options of `TIME_FUNC`.
* In either case, the choice of `TIME_FUNC` would be visible in the console log.