### PR TITLE
mysql-common/my.cnf.php - Encourage code that's less brittle

### DIFF
--- a/.loco/config/mysql-common/my.cnf.php
+++ b/.loco/config/mysql-common/my.cnf.php
@@ -1,7 +1,9 @@
 <?php
 function ver() {
   static $ver = NULL;
-  if ($ver === NULL) $ver = `mysqld --version`;
+  if ($ver === NULL) {
+    $ver = getenv('FORCE_MY_CNF_VERSION') ?: `mysqld --version`;
+  }
   return $ver;
 }
 function matchVer($pat) {return (bool) preg_match($pat, ver());}

--- a/.loco/config/mysql-common/my.cnf.php
+++ b/.loco/config/mysql-common/my.cnf.php
@@ -18,8 +18,8 @@ read_buffer_size = 1M
 read_rnd_buffer_size = 4M
 myisam_sort_buffer_size = 64M
 thread_cache_size = 8
-<?php if (!matchVer('/Ver 8.0/')) { ?>query_cache_size= 16M<?php } ?>
-<?php if (matchVer('/Ver 8.0/')) { ?>default_authentication_plugin = mysql_native_password<?php } ?>
+<?php if (!matchVer('/Ver 8.0/')) { printf("query_cache_size= 16M\n"); } ?>
+<?php if (matchVer('/Ver 8.0/')) { printf("default_authentication_plugin = mysql_native_password\n"); } ?>
 # Try number of CPU's*2 for thread_concurrency
 #MariaDB?# thread_concurrency = 8
 
@@ -36,10 +36,8 @@ innodb_file_per_table = 1
 #innodb_flush_log_at_trx_commit = 1
 #innodb_lock_wait_timeout = 50
 
-<?php if (matchVer('/Ver 5.6/')) { ?>
-innodb_large_prefix = 1
-<?php } ?>
-<?php if (!matchVer('/Ver 8.0/')) { ?>innodb_file_format = Barracuda<?php } ?>
+<?php if (matchVer('/Ver 5.6/')) { printf("innodb_large_prefix = 1\n"); } ?>
+<?php if (!matchVer('/Ver 8.0/')) { printf("innodb_file_format = Barracuda\n"); } ?>
 
 <?php if (matchVer('/Ver 5.7/')) { ?>
 # https://expressionengine.com/blog/mysql-5.7-server-os-x-has-gone-away


### PR DESCRIPTION
There's a small quirk in PHP's templating notation - if you end a line with `?>`, then the subsequent newline will be trimmed. Compare: https://gist.github.com/totten/7590dcf855300e6866b1289afa50fa64

In the context of `my.cnf.php`, trimming the newline can cause things to run together unexpectedly. For example, on MySQL 5.6/5.7 these lines run together:

```
query_cache_size= 16M# Try number of CPU's*2 for thread_concurrency
```

On MySQL 8.0, these run together:

```
default_authentication_plugin = mysql_native_password# Try number of CPU's*2 for thread_concurrency
```

I suppose these examples haven't produced a hard failure because they're comments.  But the comments are clearly describing the wrong thing.

This patch tries to make the pattern a little bit safer to reproduce so that we don't make similar mistakes in the future.

