### PR TITLE
Disable WP Fatal Error Handler

### DIFF
--- a/app/config/wp-demo/install.sh
+++ b/app/config/wp-demo/install.sh
@@ -169,4 +169,7 @@ wp cap add civicrm_admin \
 wp civicrm api StatusPreference.create ignore_severity=critical name=checkOutboundMail
 wp civicrm api StatusPreference.create ignore_severity=critical name=checkLastCron
 
+# Disable WP fatal error handler as it gets in the way of debugging.
+wp config set WP_DISABLE_FATAL_ERROR_HANDLER true --raw
+
 popd >> /dev/null


### PR DESCRIPTION
WP has a fatal error handler.  It intercepts errors and emails the site owner.   However, it will trap the error before it is written to CiviCRM's ConfigAndLog Directory.

Setting the constant in wp-config.php fixes this.