### PR TITLE
Allow for upgrade tests to be run against wordpress

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
   "require": {
     "php": ">=5.3.3",
     "totten/php-symbol-diff": "dev-master#54f869ca68a3cd75f3386f8490870369733d2c23",
-    "civicrm/upgrade-test": "dev-master#7ddd3d941b67644ac89f45e8359b8a36bfc34d6c",
+    "civicrm/upgrade-test": "dev-master#03e554787f378900f870a030cf2575d3cd49900f",
     "drupal/coder": "dev-8.x-2.x-civi#303765f4dfea97530f0ceea0919eeb525cf0c3aa",
     "civicrm/composer-downloads-plugin": "~2.1",
     "squizlabs/php_codesniffer": ">=2.7 <4.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6942c496755fd19178c3ec632c8da089",
+    "content-hash": "d6502921b3d358781b5ac60a3feee5d0",
     "packages": [
         {
             "name": "civicrm/composer-downloads-plugin",
@@ -63,12 +63,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/civicrm/civicrm-upgrade-test.git",
-                "reference": "7ddd3d941b67644ac89f45e8359b8a36bfc34d6c"
+                "reference": "03e554787f378900f870a030cf2575d3cd49900f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/civicrm/civicrm-upgrade-test/zipball/7ddd3d941b67644ac89f45e8359b8a36bfc34d6c",
-                "reference": "7ddd3d941b67644ac89f45e8359b8a36bfc34d6c",
+                "url": "https://api.github.com/repos/civicrm/civicrm-upgrade-test/zipball/03e554787f378900f870a030cf2575d3cd49900f",
+                "reference": "03e554787f378900f870a030cf2575d3cd49900f",
                 "shasum": ""
             },
             "bin": [
@@ -87,7 +87,7 @@
             ],
             "description": "Collection of scripts and data-files for testing CiviCRM upgrades",
             "homepage": "https://github.com/civicrm/civicrm-upgrade-test",
-            "time": "2020-07-06T02:33:23+00:00"
+            "time": "2020-07-17T23:40:27+00:00"
         },
         {
             "name": "composer/semver",
@@ -711,7 +711,7 @@
                 },
                 {
                     "name": "Gert de Pagter",
-                    "email": "BackEndTea@gmail.com"
+                    "email": "backendtea@gmail.com"
                 }
             ],
             "description": "Symfony polyfill for ctype functions",
@@ -886,6 +886,9 @@
             "require": {
                 "nikic/php-parser": "^1.4"
             },
+            "require-dev": {
+                "phpunit/phpunit": "3.7.*"
+            },
             "bin": [
                 "bin/php-symbol-diff",
                 "bin/git-php-symbol-diff"
@@ -942,13 +945,13 @@
             "authors": [
                 {
                     "name": "James Logsdon",
-                    "role": "Developer",
-                    "email": "jlogsdon@php.net"
+                    "email": "jlogsdon@php.net",
+                    "role": "Developer"
                 },
                 {
                     "name": "Daniel Bachhuber",
-                    "role": "Maintainer",
-                    "email": "daniel@handbuilt.co"
+                    "email": "daniel@handbuilt.co",
+                    "role": "Maintainer"
                 }
             ],
             "description": "Console utilities for PHP",

--- a/src/command/upgrade-test.run.sh
+++ b/src/command/upgrade-test.run.sh
@@ -1,5 +1,5 @@
 ## civicrm-upgrade-test only works with drush right now
-if grep -q drupal "$CMS_ROOT/index.php" || grep -q backdrop "$CMS_ROOT/index.php" ; then
+if grep -q drupal "$CMS_ROOT/index.php" || grep -q backdrop "$CMS_ROOT/index.php" || [ -f "$CMS_ROOT/wp-config.php" ] ; then
   cvutil_makeparent "$UPGRADE_LOG_DIR"
   cvutil_mkdir "$UPGRADE_LOG_DIR"
   pushd "$PRJDIR/vendor/civicrm/upgrade-test/databases" > /dev/null


### PR DESCRIPTION
This requires https://github.com/civicrm/civicrm-upgrade-test/pull/7 to work