### PR TITLE
infra/ops#955 - Add bknix-ci-cleanup

### DIFF
--- a/app/bknix-ci-cleanup.d/bknix-ci.yml
+++ b/app/bknix-ci-cleanup.d/bknix-ci.yml
@@ -1,0 +1,44 @@
+tasks:
+  - { templateSet: BKNIX_CI, vars: {HOME: '/home/jenkins', PROFILE: 'dfl'} }
+  - { templateSet: BKNIX_CI, vars: {HOME: '/home/jenkins', PROFILE: 'min'} }
+  - { templateSet: BKNIX_CI, vars: {HOME: '/home/jenkins', PROFILE: 'max'} }
+  - { templateSet: BKNIX_CI, vars: {HOME: '/home/jenkins', PROFILE: 'old'} }
+  - { templateSet: BKNIX_CI, vars: {HOME: '/home/jenkins', PROFILE: 'edge'} }
+  - { templateSet: BKNIX_CI, vars: {HOME: '/home/publisher', PROFILE: 'dfl'} }
+  - { templateSet: BKNIX_CI, vars: {HOME: '/home/publisher', PROFILE: 'min'} }
+  - { templateSet: BKNIX_CI, vars: {HOME: '/home/publisher', PROFILE: 'max'} }
+  - { templateSet: BKNIX_CI, vars: {HOME: '/home/publisher', PROFILE: 'old'} }
+  - { templateSet: BKNIX_CI, vars: {HOME: '/home/publisher', PROFILE: 'edge'} }
+
+templateSets:
+  BKNIX_CI:
+    - { level: 0, template: CIVIBUILD_CLEANUP, vars: {EXPIRE_AFTER: 120, REDUNDANT_AFTER: 4} }
+    - { level: 1, template: CIVIBUILD_CLEANUP, vars: {EXPIRE_AFTER: 96, REDUNDANT_AFTER: 3} }
+    - { level: 2, template: CIVIBUILD_CLEANUP, vars: {EXPIRE_AFTER: 72, REDUNDANT_AFTER: 3} }
+    - { level: 3, template: CIVIBUILD_CLEANUP, vars: {EXPIRE_AFTER: 48, REDUNDANT_AFTER: 2} }
+    - { level: 4, template: CIVIBUILD_CLEANUP, vars: {EXPIRE_AFTER: 24, REDUNDANT_AFTER: 1} }
+    - { level: 0, template: MYCNF_CLEANUP, vars: {DAYS: 45} }
+    - { level: 1, template: MYCNF_CLEANUP, vars: {DAYS: 30} }
+    - { level: 2, template: MYCNF_CLEANUP, vars: {DAYS: 14} }
+    - { level: 3, template: MYCNF_CLEANUP, vars: {DAYS: 7} }
+    - { level: 4, template: MYCNF_CLEANUP, vars: {DAYS: 1} }
+
+templates:
+  CIVIBUILD_CLEANUP:
+    ## This task is only used of the `condition` returns success.
+    condition: 'test "$HOME" = {{HOME|s}} -a -d {{HOME|s}}/bknix-{{PROFILE|s}}/build'
+
+    ## The shell command to run. This should delete some stuff.
+    cmd: 'eval $( use-bknix {{PROFILE|s}} ) find-stale-builds {{HOME|s}}/bknix-{{PROFILE|s}}/build {{EXPIRE_AFTER|s}} {{REDUNDANT_AFTER|s}} | while read BLD ; do echo y | civibuild destroy $(basename $BLD) ; done'
+
+    ## The command may the side-effect of reducing disk-usage in various folders. List them.
+    paths:
+      - '{{HOME}}/bknix-{{PROFILE}}/build'
+      - '{{HOME}}/_bknix/ramdisk/{{PROFILE}}'
+      - '{{HOME}}/_bknix/amp/{{PROFILE}}'
+
+  MYCNF_CLEANUP:
+    condition: 'test "$HOME" = {{HOME|s}} -a -d {{HOME|s}}/_bknix/amp/{{PROFILE|s}} '
+    cmd: 'find {{HOME|s}}/_bknix/amp/{{PROFILE|s}}/my.cnf.d -name my.cnf-\* -ctime +{{DAYS|s}} -delete'
+    paths:
+      - '{{HOME}}/_bknix/amp/{{PROFILE}}'

--- a/app/bknix-ci-cleanup.d/user-tmp.yml
+++ b/app/bknix-ci-cleanup.d/user-tmp.yml
@@ -1,0 +1,12 @@
+tasks:
+  - { level: 0, template: USER_TMP, vars: {DAYS: 45} }
+  - { level: 1, template: USER_TMP, vars: {DAYS: 30} }
+  - { level: 2, template: USER_TMP, vars: {DAYS: 15} }
+  - { level: 3, template: USER_TMP, vars: {DAYS: 7} }
+  - { level: 4, template: USER_TMP, vars: {DAYS: 1} }
+
+templates:
+  USER_TMP:
+    cmd: 'find /tmp -user "$USER" -mtime +{{DAYS|s}} -delete 2>&1 | grep -v "Permission denied"'
+    condition: 'test -d /tmp'
+    paths: ['/tmp']

--- a/bin/bknix-ci-cleanup
+++ b/bin/bknix-ci-cleanup
@@ -164,7 +164,7 @@ $c['ymlConfig'] = function($io) {
   $files = (array) glob(dirname(__DIR__) . '/app/bknix-ci-cleanup.d/*.yml');
   $ymlConfig = ['templates' => [], 'templateSets' => [], 'tasks' => []];
   foreach ($files as $file) {
-    $io->writeln("<comment>PARSING</comment>: Load file <info>$file</info>");
+    $io->writeln("<comment>PARSING</comment>: Config file <info>$file</info>");
     $yml = Yaml::parse(file_get_contents($file));
 
     // Propagate file-scoped vars
@@ -246,7 +246,7 @@ $c['createTask()'] = function($params, $getPartition, SymfonyStyle $io, $ymlConf
 
   $partitions = [];
   foreach ($task->paths as $path) {
-    $part = $getPartition($path);
+    $part = $getPartition(realpath($path));
     if ($part) {
       $partitions[] = $part;
     }
@@ -287,21 +287,39 @@ $c['findTasks()'] = function($criteria, $allTasks) {
 /**
  * Determine the root mount-point for the partition which has $tgtPath.
  *
+ * Ambiguity: if there are symlinks, do you care about the partition where the
+ * symlink lives or the partition where (ultimate) the symlink-target lives? Use
+ * `$getPartition(realpath(...))` if you need the target.
+ *
  * @param string $tgtPath
  *   Ex: '/home/foo/.bashrc'
  * @param Cmdr $cmdr
  *   (injected)
  * @return string
- *   Ex: '/home'
+ *   Ex: '/home' or '/'
  */
 $c['getPartition()'] = function($tgtPath, Cmdr $cmdr) {
-  static $cache = [];
-  if (!isset($cache[$tgtPath])) {
-    $cache[$tgtPath] = trim($cmdr->run('df -P {{TGT|s}} | sed -n \'$s/[^%]*%[[:blank:]]*//p\'', [
-      'TGT' => $tgtPath,
-    ]));
+  $withSlash = function($x) {return rtrim($x, '/') . '/'; };
+
+  static $partitions = NULL;
+  if ($partitions === NULL) {
+    $partitions = explode("\n", $cmdr->run('df --out=target | grep -v "^Mounted on"'));
+    foreach ($partitions as &$p) {
+      $p = $withSlash($p);
+    }
   }
-  return $cache[$tgtPath];
+
+  $tgtPath = $withSlash($tgtPath);
+  $bestMatch = NULL;
+  foreach ($partitions as $partition) {
+    if (strpos($tgtPath, $partition) === 0) {
+      if ($bestMatch === NULL || strlen($bestMatch) < strlen($partition)) {
+        $bestMatch = $partition;
+      }
+    }
+  }
+
+  return $bestMatch === '/' ? '/' : rtrim($bestMatch, '/');
 };
 
 /**

--- a/bin/bknix-ci-cleanup
+++ b/bin/bknix-ci-cleanup
@@ -3,12 +3,14 @@
 #!depdir '../extern/bknix-ci-cleanup'
 #!ttl 10 years
 #!require symfony/var-dumper: ~3.0
+#!require symfony/yaml: ~3.0
 #!require clippy/std: ~0.3.0
 namespace Clippy;
 
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Process\Process;
+use Symfony\Component\Yaml\Yaml;
 
 $c = clippy()->register(plugins());
 
@@ -115,38 +117,34 @@ class CleanupTask {
    * @var string[]
    */
   public $partitions = [];
+
+  /**
+   * Optional bash command. The rule is only used if the command returns success.
+   *
+   * @var string|null
+   */
+  public $condition = NULL;
 }
 
 /**
- * Get a list of bknix profiles.
- *
- * @return string[]
- */
-$c['allProfiles'] = function() {
-  return ['min', 'max', 'dfl', 'old', 'edge'];
-};
-
-/**
- * @param string[] $allProfiles
- * @param callable $createProfileTasks
  * @return CleanupTask[]
  */
-$c['allTasks'] = function($allProfiles, $createProfileTasks, $createTask, $cmdr) {
+$c['allTasks'] = function($createTask, $cmdr, $ymlConfig) {
   /** @var CleanupTask[] $tasks */
   $tasks = [];
 
-  foreach ($allProfiles as $profile) {
-    $tasks = array_merge($tasks, $createProfileTasks($profile));
-  }
-
-  $TMP_CLEANUP = 'find /tmp -user "$USER" -mtime +{{DAYS|s}} -delete 2>&1 | grep -v "Permission denied"';
-  foreach ([45, 30, 15, 7, 1] as $level => $days) {
-    if (file_exists('/tmp')) {
-      $tasks[] = $createTask([
-        'level' => $level,
-        'cmd' => $cmdr->escape($TMP_CLEANUP, ['DAYS' => $days]),
-        'paths' => ['/tmp'],
-      ]);
+  foreach ($ymlConfig['tasks'] ?? [] as $taskSpec) {
+    $newTasks = $createTask($taskSpec);
+    foreach ($newTasks as $task) {
+      if ($task->condition !== NULL && $task->condition !== '') {
+        /** @var Process $proc */
+        $proc = $cmdr->process($task->condition);
+        $proc->run();
+        if (!$proc->isSuccessful()) {
+          continue;
+        }
+      }
+      $tasks[] = $task;
     }
   }
 
@@ -158,60 +156,31 @@ $c['allTasks'] = function($allProfiles, $createProfileTasks, $createTask, $cmdr)
 };
 
 /**
- * Prepare a list of cleanup tasks for the given profile/environment.
- *
- * @param string $profile
- *   Ex: 'min', 'max'
- * @param callable $createTask
- *   (injected)
  * @return array
+ *   The aggregated YAML configuration
  */
-$c['createProfileTasks()'] = function($profile, $createTask, Cmdr $cmdr, SymfonyStyle $io) {
-  $bldDir = getenv('HOME') . '/bknix-' . $profile . '/build';
-  if (!file_exists($bldDir)) {
-    $io->writeln("<comment>SKIP</comment>: No builds found for profile <info>{$profile}</info> (<info>{$bldDir}</info>)");
-    return [];
-  }
+$c['ymlConfig'] = function($io) {
 
-  $PREFIX = 'eval $( use-bknix ' . $profile . ' -e ) ';
-  // $PREFIX = $cmdr->run('use-bknix {{PROFILE|s}} -e', ['PROFILE' => $profile]);
-  $CIVIBUILD_CLEANUP = 'find-stale-builds {{BLDDIR|s}} {{EXPIRE_AFTER|s}} {{REDUNDANT_AFTER|s}} | while read BLD ; do echo y | civibuild destroy $(basename $BLD) ; done';
-  $AMP_CLEANUP = '[ -d "$AMPHOME" -a -d "$AMPHOME/my.cnf.d" ] && find "$AMPHOME/my.cnf.d" -name \'my.cnf-*\' -ctime +{{DAYS|s}} -delete';
+  $files = (array) glob(dirname(__DIR__) . '/app/bknix-ci-cleanup.d/*.yml');
+  $ymlConfig = ['templates' => [], 'templateSets' => [], 'tasks' => []];
+  foreach ($files as $file) {
+    $io->writeln("<comment>PARSING</comment>: Load file <info>$file</info>");
+    $yml = Yaml::parse(file_get_contents($file));
 
-  $tasks = [];
-
-  foreach ([5, 4, 3, 2, 1] as $level => $days) {
-    $tasks[] = $createTask([
-      'level' => $level,
-      'cmd' => $cmdr->escape($PREFIX . $CIVIBUILD_CLEANUP, [
-        'BLDDIR' => $bldDir,
-        'EXPIRE_AFTER' => $days * 24,
-        'REDUNDANT_AFTER' => 4,
-      ]),
-      'paths' => [$bldDir, getenv('HOME') . "/_bknix/ramdisk/{$profile}", getenv('HOME') . "/_bknix/amp/{$profile}"],
-    ]);
-    $tasks[] = $createTask([
-      'level' => $level + 1,
-      'cmd' => $cmdr->escape($PREFIX . $CIVIBUILD_CLEANUP, [
-        'BLDDIR' => $bldDir,
-        'EXPIRE_AFTER' => $days * 24,
-        'REDUNDANT_AFTER' => 1,
-      ]),
-      'paths' => [$bldDir, getenv('HOME') . "/_bknix/ramdisk/{$profile}", getenv('HOME') . "/_bknix/amp/{$profile}"],
-    ]);
-  }
-
-  foreach ([45, 30, 15, 7, 1] as $level => $days) {
-    if (file_exists(getenv('HOME') . "/_bknix/amp/{$profile}")) {
-      $tasks[] = $createTask([
-        'level' => $level,
-        'cmd' => $cmdr->escape($PREFIX . $AMP_CLEANUP, ['DAYS' => $days]),
-        'paths' => [getenv('HOME') . "/_bknix/amp/{$profile}"],
-      ]);
+    // Propagate file-scoped vars
+    if (isset($yml['vars'])) {
+      foreach ($yml['tasks'] as &$task) {
+        $task['vars'] = array_merge($yml['vars'], $task['vars'] ?? []);
+      }
     }
+
+    // Merge into main list
+    $ymlConfig['templates'] = array_merge($ymlConfig['templates'] ?? [], $yml['templates'] ?? []);
+    $ymlConfig['templateSets'] = array_merge($ymlConfig['templateSets'] ?? [], $yml['templateSets'] ?? []);
+    $ymlConfig['tasks'] = array_merge($ymlConfig['tasks'] ?? [], $yml['tasks'] ?? []);
   }
 
-  return $tasks;
+  return $ymlConfig;
 };
 
 /**
@@ -220,12 +189,58 @@ $c['createProfileTasks()'] = function($profile, $createTask, Cmdr $cmdr, Symfony
  *   (injected)
  * @param SymfonyStyle $io
  *   (injected)
- * @return \Clippy\CleanupTask
+ * @param array $ymlConfig
+ * @param Cmdr $cmdr
+ * @return \Clippy\CleanupTask[]
  */
-$c['createTask()'] = function($params, $getPartition, $io) {
-  $task = new CleanupTask($params);
+$c['createTask()'] = function($params, $getPartition, SymfonyStyle $io, $ymlConfig, $cmdr) use ($c) {
 
+  if (isset($params['templateSet'])) {
+    if (!isset($ymlConfig['templateSets'][$params['templateSet']])) {
+      throw new \RuntimeException("Unrecognized templateSet: " . $params['templateSet']);
+    }
+    $newTasks = [];
+    foreach ($ymlConfig['templateSets'][$params['templateSet']] as $template) {
+      $newTaskParams = $template;
+      $newTaskParams['vars'] = array_merge($template['vars'] ?? [], $params['vars'] ?? []);
+      $newTasks = array_merge(
+        $c['createTask()']($newTaskParams, $getPartition, $io, $ymlConfig, $cmdr),
+        $newTasks
+      );
+    }
+    return $newTasks;
+  }
+
+  if (isset($params['template'])) {
+    if (!isset($ymlConfig['templates'][$params['template']])) {
+      throw new \RuntimeException("Unrecognized template: " . $params['template']);
+    }
+    $params = array_merge($ymlConfig['templates'][$params['template']], $params);
+    unset($params['template']);
+  }
+
+  $vars = $params['vars'] ?? [];
+  unset($params['vars']);
+
+  $task = new CleanupTask($params);
   foreach ($params as $k => $v) {
+    switch ($k) {
+      case 'level':
+        // No filtering needed.
+        break;
+
+      case 'cmd':
+      case 'condition':
+        $v = $cmdr->escape($v, $vars);
+        break;
+
+      case 'paths':
+      case 'partitions':
+        foreach ($v as &$item) {
+          $item = $cmdr->escape($item, $vars);
+        }
+        break;
+    }
     $task->{$k} = $v;
   }
 
@@ -235,13 +250,10 @@ $c['createTask()'] = function($params, $getPartition, $io) {
     if ($part) {
       $partitions[] = $part;
     }
-    else {
-      $io->writeln("<comment>Warning</comment>: Path <info>{$path}</info> appears to be invalid.");
-    }
   }
   $task->partitions = uniq($partitions);
 
-  return $task;
+  return [$task];
 };
 
 /**

--- a/bin/bknix-ci-cleanup
+++ b/bin/bknix-ci-cleanup
@@ -4,7 +4,7 @@
 #!ttl 10 years
 #!require symfony/var-dumper: ~3.0
 #!require symfony/yaml: ~3.0
-#!require clippy/std: ~0.3.0
+#!require clippy/std: ~0.3.1
 namespace Clippy;
 
 use Symfony\Component\Console\Output\OutputInterface;
@@ -60,7 +60,7 @@ $c['app']->command('run [-N|--dry-run] [--threshold=]', function($dryRun, $thres
         $io->writeln("<comment>DRY-RUN</comment>: " . $cmd);
       }
       else {
-        $cmdr->run(new Process($cmd));
+        $cmdr->passthru(new Process($cmd));
       }
     }
 

--- a/bin/bknix-ci-cleanup
+++ b/bin/bknix-ci-cleanup
@@ -8,6 +8,8 @@ namespace Clippy;
 
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Process\Process;
+
 $c = clippy()->register(plugins());
 
 ###############################################################################
@@ -35,34 +37,45 @@ $c['app']->command('dump', function($allTasks) {
 
 $c['app']->command('run [-N|--dry-run] [--threshold=]', function($dryRun, $threshold = 90, SymfonyStyle $io, $allTasks, $findTasks, $isPartitionFull, $cmdr) {
   $exitCode = 0;
+  $partitions = uniq(...array_column($allTasks, 'partitions'));
+  $levels = uniq(array_column($allTasks, 'level'));
 
-  $allPartitions = uniq(...array_column($allTasks, 'partitions'));
-  $io->writeln("<comment>PARTITIONS</comment>: <info>" . implode("</info>, <info>", $allPartitions) . "</info> (" . count($allPartitions) . ")");
+  $io->writeln("<comment>PARTITIONS</comment>: <info>" . implode("</info>, <info>", $partitions) . "</info> (" . count($partitions) . ")");
   $io->writeln("<comment>THRESHOLD</comment>: <info>" . $threshold . "%</info>");
 
-  foreach ($allPartitions as $partition) {
-    $levels = uniq(array_column($allTasks, 'level'));
-    do {
-      if (empty($levels)) {
-        $io->writeln("<error>Cannot reduce space on partition ({$partition}) to {$threshold}%. No more levels found.</error>");
-        $exitCode = 1;
-        break;
-      }
+  // Whiddle the $partitions. In each pass, we run the next level of (relevant) cleanups and remove any satisfactory partitions.
+  // Repeat until either (a) all partitions are satisfactory or (b) there are no more relevant cleanups.
+  while (TRUE) {
+    $partitions = array_filter($partitions, function($p) {
+      return file_exists($p);
+    });
+    $level = array_shift($levels);
 
-      $level = array_shift($levels);
-      $io->writeln("Clean up <info>{$partition}</info> at level <info>{$level}</info>.");
-      $tasks = $findTasks(['level' => $level, 'partition' => $partition]);
-      $cmds = uniq(array_column($tasks, 'cmd'));
-      foreach ($cmds as $cmd) {
-        if ($dryRun) {
-          $io->writeln("<comment>DRY-RUN</comment>: " . $cmd);
-        }
-        else {
-          $cmdr->run($cmd);
-        }
+    $io->writeln("Clean up level <info>{$level}</info> on partitions <info>" . implode("</info>, <info>", $partitions) . "</info>.");
+    $tasks = $findTasks(['level' => $level, 'partitions' => $partitions]);
+    foreach (uniq(array_column($tasks, 'cmd')) as $cmd) {
+      if ($dryRun) {
+        $io->writeln("<comment>DRY-RUN</comment>: " . $cmd);
       }
-    } while ($isPartitionFull($partition, $threshold));
+      else {
+        $cmdr->run(new Process($cmd));
+      }
+    }
+
+    $partitions = array_filter($partitions, function($p) use ($isPartitionFull, $threshold) {
+      return $isPartitionFull($p, $threshold);
+    });
+    if (empty($partitions)) {
+      $io->writeln("<comment>COMPLETE</comment>: All partitions meet the <info>" . $threshold . "%</info> threshold.");
+      break;
+    }
+    if (empty($levels)) {
+      $io->writeln("<error>Cannot reduce space to {$threshold}%. No more levels found.</error>");
+      $exitCode = 1;
+      break;
+    }
   }
+
   return $exitCode;
 });
 
@@ -244,6 +257,9 @@ $c['findTasks()'] = function($criteria, $allTasks) {
   return array_filter($allTasks, function($t) use ($criteria) {
     /** @var CleanupTask $t */
     if (isset($criteria['partition']) && !in_array($criteria['partition'], $t->partitions)) {
+      return FALSE;
+    }
+    if (isset($criteria['partitions']) && empty(array_intersect($criteria['partitions'], $t->partitions))) {
       return FALSE;
     }
     if (isset($criteria['level']) && $t->level != $criteria['level']) {

--- a/bin/bknix-ci-cleanup
+++ b/bin/bknix-ci-cleanup
@@ -1,0 +1,321 @@
+#!/usr/bin/env pogo
+<?php
+#!depdir '../extern/bknix-ci-cleanup'
+#!ttl 10 years
+#!require symfony/var-dumper: ~3.0
+#!require clippy/std: ~0.3.0
+namespace Clippy;
+
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+$c = clippy()->register(plugins());
+
+###############################################################################
+## About
+##
+## The ci-cleanup script aims to keep available capacity within certain boundaries.
+## To meet those boundaries, it will perform a series of increasingly aggressive cleanup tasks.
+##
+## - Initially, it runs the "level 0" tasks.
+##   Ex: Delete files older than 2 weeks.
+## - If there still isn't enough free space, then proceed to "level 1" tasks.
+##   Ex: Delete files older than 1 week.
+## - If there still isn't enough, then proceed to "level 2". Ad nauseum.
+
+###############################################################################
+## Primary subcommands
+
+$c['app']->command('dump', function($allTasks) {
+  dump([
+    'partitions' => uniq(...array_column($allTasks, 'partitions')),
+    'levels' => uniq(array_column($allTasks, 'level')),
+    'tasks' => $allTasks,
+  ]);
+});
+
+$c['app']->command('run [-N|--dry-run] [--threshold=]', function($dryRun, $threshold = 90, SymfonyStyle $io, $allTasks, $findTasks, $isPartitionFull, $cmdr) {
+  $exitCode = 0;
+
+  $allPartitions = uniq(...array_column($allTasks, 'partitions'));
+  $io->writeln("<comment>PARTITIONS</comment>: <info>" . implode("</info>, <info>", $allPartitions) . "</info> (" . count($allPartitions) . ")");
+  $io->writeln("<comment>THRESHOLD</comment>: <info>" . $threshold . "%</info>");
+
+  foreach ($allPartitions as $partition) {
+    $levels = uniq(array_column($allTasks, 'level'));
+    do {
+      if (empty($levels)) {
+        $io->writeln("<error>Cannot reduce space on partition ({$partition}) to {$threshold}%. No more levels found.</error>");
+        $exitCode = 1;
+        break;
+      }
+
+      $level = array_shift($levels);
+      $io->writeln("Clean up <info>{$partition}</info> at level <info>{$level}</info>.");
+      $tasks = $findTasks(['level' => $level, 'partition' => $partition]);
+      $cmds = uniq(array_column($tasks, 'cmd'));
+      foreach ($cmds as $cmd) {
+        if ($dryRun) {
+          $io->writeln("<comment>DRY-RUN</comment>: " . $cmd);
+        }
+        else {
+          $cmdr->run($cmd);
+        }
+      }
+    } while ($isPartitionFull($partition, $threshold));
+  }
+  return $exitCode;
+});
+
+###############################################################################
+## Task library
+
+class CleanupTask {
+
+  /**
+   * How early/late to try this cleanup task.
+   *
+   * Lower levels run first. If they don't succeed in creating sufficient
+   * free space, then higher levels run.
+   *
+   * @var int
+   */
+  public $level = 0;
+
+  /**
+   * A bash command which frees up some space.
+   *
+   * @var string|null
+   */
+  public $cmd = NULL;
+
+  /**
+   * List of paths from which files may be removed.
+   *
+   * @var string[]
+   */
+  public $paths = [];
+
+  /**
+   * List of partitions from which files may be removed.
+   * Usually computed from $paths.
+   *
+   * @var string[]
+   */
+  public $partitions = [];
+}
+
+/**
+ * Get a list of bknix profiles.
+ *
+ * @return string[]
+ */
+$c['allProfiles'] = function() {
+  return ['min', 'max', 'dfl', 'old', 'edge'];
+};
+
+/**
+ * @param string[] $allProfiles
+ * @param callable $createProfileTasks
+ * @return CleanupTask[]
+ */
+$c['allTasks'] = function($allProfiles, $createProfileTasks, $createTask, $cmdr) {
+  /** @var CleanupTask[] $tasks */
+  $tasks = [];
+
+  foreach ($allProfiles as $profile) {
+    $tasks = array_merge($tasks, $createProfileTasks($profile));
+  }
+
+  $TMP_CLEANUP = 'find /tmp -user "$USER" -mtime +{{DAYS|s}} -delete 2>&1 | grep -v "Permission denied"';
+  foreach ([45, 30, 15, 7, 1] as $level => $days) {
+    if (file_exists('/tmp')) {
+      $tasks[] = $createTask([
+        'level' => $level,
+        'cmd' => $cmdr->escape($TMP_CLEANUP, ['DAYS' => $days]),
+        'paths' => ['/tmp'],
+      ]);
+    }
+  }
+
+  usort($tasks, function($a, $b){
+    return $a->level - $b->level;
+  });
+
+  return $tasks;
+};
+
+/**
+ * Prepare a list of cleanup tasks for the given profile/environment.
+ *
+ * @param string $profile
+ *   Ex: 'min', 'max'
+ * @param callable $createTask
+ *   (injected)
+ * @return array
+ */
+$c['createProfileTasks()'] = function($profile, $createTask, Cmdr $cmdr, SymfonyStyle $io) {
+  $bldDir = getenv('HOME') . '/bknix-' . $profile . '/build';
+  if (!file_exists($bldDir)) {
+    $io->writeln("<comment>SKIP</comment>: No builds found for profile <info>{$profile}</info> (<info>{$bldDir}</info>)");
+    return [];
+  }
+
+  $PREFIX = 'eval $( use-bknix ' . $profile . ' -e ) ';
+  // $PREFIX = $cmdr->run('use-bknix {{PROFILE|s}} -e', ['PROFILE' => $profile]);
+  $CIVIBUILD_CLEANUP = 'find-stale-builds {{BLDDIR|s}} {{EXPIRE_AFTER|s}} {{REDUNDANT_AFTER|s}} | while read BLD ; do echo y | civibuild destroy $(basename $BLD) ; done';
+  $AMP_CLEANUP = '[ -d "$AMPHOME" -a -d "$AMPHOME/my.cnf.d" ] && find "$AMPHOME/my.cnf.d" -name \'my.cnf-*\' -ctime +{{DAYS|s}} -delete';
+
+  $tasks = [];
+
+  foreach ([5, 4, 3, 2, 1] as $level => $days) {
+    $tasks[] = $createTask([
+      'level' => $level,
+      'cmd' => $cmdr->escape($PREFIX . $CIVIBUILD_CLEANUP, [
+        'BLDDIR' => $bldDir,
+        'EXPIRE_AFTER' => $days * 24,
+        'REDUNDANT_AFTER' => 4,
+      ]),
+      'paths' => [$bldDir, getenv('HOME') . "/_bknix/ramdisk/{$profile}", getenv('HOME') . "/_bknix/amp/{$profile}"],
+    ]);
+    $tasks[] = $createTask([
+      'level' => $level + 1,
+      'cmd' => $cmdr->escape($PREFIX . $CIVIBUILD_CLEANUP, [
+        'BLDDIR' => $bldDir,
+        'EXPIRE_AFTER' => $days * 24,
+        'REDUNDANT_AFTER' => 1,
+      ]),
+      'paths' => [$bldDir, getenv('HOME') . "/_bknix/ramdisk/{$profile}", getenv('HOME') . "/_bknix/amp/{$profile}"],
+    ]);
+  }
+
+  foreach ([45, 30, 15, 7, 1] as $level => $days) {
+    if (file_exists(getenv('HOME') . "/_bknix/amp/{$profile}")) {
+      $tasks[] = $createTask([
+        'level' => $level,
+        'cmd' => $cmdr->escape($PREFIX . $AMP_CLEANUP, ['DAYS' => $days]),
+        'paths' => [getenv('HOME') . "/_bknix/amp/{$profile}"],
+      ]);
+    }
+  }
+
+  return $tasks;
+};
+
+/**
+ * @param array $params
+ * @param callable $getPartition
+ *   (injected)
+ * @param SymfonyStyle $io
+ *   (injected)
+ * @return \Clippy\CleanupTask
+ */
+$c['createTask()'] = function($params, $getPartition, $io) {
+  $task = new CleanupTask($params);
+
+  foreach ($params as $k => $v) {
+    $task->{$k} = $v;
+  }
+
+  $partitions = [];
+  foreach ($task->paths as $path) {
+    $part = $getPartition($path);
+    if ($part) {
+      $partitions[] = $part;
+    }
+    else {
+      $io->writeln("<comment>Warning</comment>: Path <info>{$path}</info> appears to be invalid.");
+    }
+  }
+  $task->partitions = uniq($partitions);
+
+  return $task;
+};
+
+/**
+ * @param array $criteria
+ *   partition: string
+ *   level: int
+ * @param CleanupTask[] $allTasks
+ *   (injected)
+ * @return array
+ *   List of tasks, filtered by $criteria.
+ */
+$c['findTasks()'] = function($criteria, $allTasks) {
+  return array_filter($allTasks, function($t) use ($criteria) {
+    /** @var CleanupTask $t */
+    if (isset($criteria['partition']) && !in_array($criteria['partition'], $t->partitions)) {
+      return FALSE;
+    }
+    if (isset($criteria['level']) && $t->level != $criteria['level']) {
+      return FALSE;
+    }
+    return TRUE;
+  });
+};
+
+###############################################################################
+## Partition helpers
+
+/**
+ * Determine the root mount-point for the partition which has $tgtPath.
+ *
+ * @param string $tgtPath
+ *   Ex: '/home/foo/.bashrc'
+ * @param Cmdr $cmdr
+ *   (injected)
+ * @return string
+ *   Ex: '/home'
+ */
+$c['getPartition()'] = function($tgtPath, Cmdr $cmdr) {
+  static $cache = [];
+  if (!isset($cache[$tgtPath])) {
+    $cache[$tgtPath] = trim($cmdr->run('df -P {{TGT|s}} | sed -n \'$s/[^%]*%[[:blank:]]*//p\'', [
+      'TGT' => $tgtPath,
+    ]));
+  }
+  return $cache[$tgtPath];
+};
+
+/**
+ * Determine if a partition's utilization is approaching it's capacity.
+ *
+ * @param string $tgtPath
+ * @param int $maxUsedPct
+ *  The threshold percentage. If more than $X percent used, then the disk needs work.
+ * @param \Clippy\Cmdr $cmdr
+ *   (injected)
+ * @return bool
+ * @throws \Exception
+ */
+$c['isPartitionFull()'] = function($tgtPath, $maxUsedPct, Cmdr $cmdr) {
+  $inodePct = trim($cmdr->run('df {{TGT|s}} --output=ipcent | tail -n1 | sed \'s/[^0-9]//g\'', ['TGT' => $tgtPath]));
+  $spacePct = trim($cmdr->run('df {{TGT|s}} --output=pcent | tail -n1 | sed \'s/[^0-9]//g\'', ['TGT' => $tgtPath]));
+  if (!is_numeric($inodePct) || !is_numeric($spacePct)) {
+    throw new \Exception("Received invalid percentages ($spacePct, $inodePct)");
+  }
+  return ($inodePct > $maxUsedPct || $spacePct > $maxUsedPct);
+};
+
+###############################################################################
+## Primitive utilities
+
+/**
+ * Combine the $arrays and return the uniq values.
+ *
+ * @param \array[] ...$arrays
+ * @return array
+ *   Unique values.
+ *   To avoid ambiguous behavior, these values are sorted (natsort).
+ */
+function uniq(array... $arrays) {
+  $v = [];
+  foreach ($arrays as $arr) {
+    $v = array_unique(array_merge($arr, $v));
+  }
+  $v = array_values($v);
+  natsort($v);
+  return $v;
+}
+
+###############################################################################
+$c['app']->run();

--- a/bin/find-stale-builds
+++ b/bin/find-stale-builds
@@ -1,7 +1,9 @@
 #!/usr/bin/env php
 <?php
 
-## Generate a list of old/stale builds which are either:
+## Generate a list of "stale" builds - either:
+## - The build is objectively old.
+## - The build is redundant because there's a newer build of the same PR.
 
 ###############################################################################
 ## Bootstrap


### PR DESCRIPTION
This script aims to degrade service more gracefully when the hardware capacity is inadequate to providing the nominal 5 days of support for each test build. It assimilates several cleanup steps from https://test.civicrm.org/job/CiviCRM-PR-Cleanup/ but introduces increasingly aggressive thresholds (for which builds to keep and which builds to destroy).

This script will start by deleting 5-day-old builds.  If the disk still looks too full, then it proceeds to 4-day-old builds.  Then 3-day (etc). It proceeds until the disk capacity reaches a target of (at most) 90% utilization (aka at least 10% free). Capacity is measured by both disk-bytes and disk-inodes.

Key commands:

```
## Show the list of cleanup rules
bknix-ci-cleanup dump

## Do a dry-run of the cleanup (aiming for the default 90% maximum utilization)
bknix-ci-cleanup run -N

## Do a dry-run of the cleanup (aiming for 20% maximum utilization)
bknix-ci-cleanup run -N --threshold=20

## Execute the cleanup rules (aiming for the default 90% maximum utilization)
bknix-ci-cleanup run
```

See also: https://lab.civicrm.org/infra/ops/-/issues/955