### PR TITLE
Enotice fix on d7

### DIFF
--- a/app/drupal.settings.d/pre.d/100-file_private_path-d8.php
+++ b/app/drupal.settings.d/pre.d/100-file_private_path-d8.php
@@ -2,6 +2,6 @@
 
 global $civibuild, $settings;
 // Example CMS_VERSIONs: '7', '7.23', '7.x', '8', '8.8', '8.x'. Note that the '8.x' case would mess up `version_compare()`.
-if (empty($settings['file_private_path']) && isset($civibuild['CMS_VERSION']) && $civibuild['CMS_VERSION'][0] === '8') {
+if (isset($civibuild['CMS_VERSION'][0]) && empty($settings['file_private_path']) && $civibuild['CMS_VERSION'][0] === '8') {
   $settings['file_private_path'] = $civibuild['PRIVATE_ROOT'] . DIRECTORY_SEPARATOR . $civibuild['DRUPAL_SITE_DIR'];
 }


### PR DESCRIPTION
Seeing an enotice fix on d7 on code clearly intended for D8
<img width="1079" alt="Screen Shot 2020-08-14 at 11 31 16 AM" src="https://user-images.githubusercontent.com/336308/90197209-16250280-de22-11ea-8155-c246b3ae742f.png">
