### PR TITLE
D8/D9 demo - turn on errors on screen

### DIFF
--- a/app/config/drupal8-demo/install.sh
+++ b/app/config/drupal8-demo/install.sh
@@ -43,6 +43,9 @@ pushd "${CMS_ROOT}/sites/${DRUPAL_SITE_DIR}" >> /dev/null
   civicrm_apply_demo_defaults
   cv ev 'return CRM_Utils_System::synchronizeUsers();'
 
+  ## Show errors on screen
+  drush8 -y config:set system.logging error_level verbose
+
   ## Setup theme
   #above# drush8 -y en garland
   export SITE_CONFIG_DIR

--- a/app/config/drupal9-demo/install.sh
+++ b/app/config/drupal9-demo/install.sh
@@ -37,11 +37,14 @@ pushd "${CMS_ROOT}/sites/${DRUPAL_SITE_DIR}" >> /dev/null
   ## make sure drush functions are loaded
   drush8 cc drush -y
 
-  ## Setup CiviCRM -- But not in 'clean' config!
+  ## Setup CiviCRM
   echo '{"enable_components":["CiviEvent","CiviContribute","CiviMember","CiviMail","CiviReport","CiviPledge","CiviCase","CiviCampaign"]}' \
     | drush8 cvapi setting.create --in=json
   civicrm_apply_demo_defaults
   cv ev 'return CRM_Utils_System::synchronizeUsers();'
+
+  ## Show errors on screen
+  drush8 -y config:set system.logging error_level verbose
 
   ## Setup demo user
   civicrm_apply_d8_perm_defaults


### PR DESCRIPTION
In drupal 8/9 error logging to screen is completely off by default.

I'd argue it should be on for the "clean" versions too but will probably lose that argument.

Besides making it visible for developers who might be used to drupal 7, when you ask someone to reproduce their problem on the public demo if they don't see an error they might think it's their own setup and waste time.