### PR TITLE
cividist - When fetching remotes, use a fixed list of repos

### DIFF
--- a/bin/cividist
+++ b/bin/cividist
@@ -36,7 +36,15 @@ HASH_SUFFIX=-0003
 ###############################################################################
 ## Fetch the latest code
 function cividist_update() {
-  git scan foreach -c "pwd; git fetch $GIT_REMOTE"
+  for SUBDIR in . packages backdrop drupal drupal-8 joomla WordPress ; do
+    if [ -d "$SUBDIR" ]; then
+      pushd "$SUBDIR"
+         git fetch "$GIT_REMOTE"
+      popd
+    else
+      echo "Skip update on non-existent subdir ($SUBDIR)."
+    fi
+  done
   if cividist_l10n_is_current ; then
     echo "[l10n] Appears recent (less than $L10N_TTL minutes old)" 1>&2
   else


### PR DESCRIPTION
For example: if you run `GIT_REMOTE=security cividist update`, and if
`vendor/pear/validate_finance_creditcard` is a git repo (*which it is*),
then it incorrectly tries to fetch the `security` remote on this repo.

Note that the previous call to `git scan` was fairly forgiving -- e.g. if the local source tree was fairly old, then it might not have (say) `drupal-8`. The behavior here is fairly close with/without the patch -- ie it updates the folder if present, and ignores it if missing.