### PR TITLE
Add PECL extension "inotify" (on Linux only)

### DIFF
--- a/nix/pkgs/php56/default.nix
+++ b/nix/pkgs/php56/default.nix
@@ -31,7 +31,7 @@ let
             extension=${phpPkgs.imagick}/lib/php/extensions/imagick.so
             extension=${phpExtras.timecop}/lib/php/extensions/timecop.so
             openssl.cafile=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt
-      '';
+      '' + stdenv.lib.optionalString stdenv.isLinux "extension=${phpExtras.inotify_0}/lib/php/extensions/inotify.so";
     }
     ''
       cat "${phpRuntime}/etc/php.ini" > $out
@@ -41,7 +41,8 @@ let
 
     phpOverride = stdenv.mkDerivation rec {
         name = "bknix-php56";
-        buildInputs = [phpRuntime phpPkgs.xdebug phpPkgs.redis phpPkgs.yaml phpPkgs.apcu phpPkgs.memcached phpPkgs.memcache phpPkgs.imagick phpExtras.timecop pkgs.makeWrapper pkgs.cacert];
+        buildInputs = [phpRuntime phpPkgs.xdebug phpPkgs.redis phpPkgs.yaml phpPkgs.apcu phpPkgs.memcached phpPkgs.memcache phpPkgs.imagick phpExtras.timecop pkgs.makeWrapper pkgs.cacert]
+             ++ stdenv.lib.optionals stdenv.isLinux [ phpExtras.inotify_0 ];
         buildCommand = ''
           makeWrapper ${phpRuntime}/bin/phar $out/bin/phar
           makeWrapper ${phpRuntime}/bin/php $out/bin/php --add-flags -c --add-flags "${phpIni}"

--- a/nix/pkgs/php70/default.nix
+++ b/nix/pkgs/php70/default.nix
@@ -30,7 +30,7 @@ let
             extension=${phpExtras.timecop}/lib/php/extensions/timecop.so
             extension=${phpExtras.runkit7_1}/lib/php/extensions/runkit.so
             openssl.cafile=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt
-      '';
+      '' + stdenv.lib.optionalString stdenv.isLinux "extension=${phpExtras.inotify}/lib/php/extensions/inotify.so";
     }
     ''
       cat "${phpRuntime}/etc/php.ini" > $out
@@ -40,7 +40,9 @@ let
 
     phpOverride = stdenv.mkDerivation rec {
         name = "bknix-php70";
-        buildInputs = [phpRuntime phpPkgs.xdebug phpPkgs.redis phpPkgs.yaml phpPkgs.memcached phpPkgs.imagick phpExtras.timecop phpExtras.runkit7_1 pkgs.makeWrapper pkgs.cacert];
+        buildInputs =
+          [phpRuntime phpPkgs.xdebug phpPkgs.redis phpPkgs.yaml phpPkgs.memcached phpPkgs.imagick phpExtras.timecop phpExtras.runkit7_1 pkgs.makeWrapper pkgs.cacert]
+          ++ stdenv.lib.optionals stdenv.isLinux [ phpExtras.inotify ];
         buildCommand = ''
           makeWrapper ${phpRuntime}/bin/phar $out/bin/phar
           makeWrapper ${phpRuntime}/bin/php $out/bin/php --add-flags -c --add-flags "${phpIni}"

--- a/nix/pkgs/php71/default.nix
+++ b/nix/pkgs/php71/default.nix
@@ -29,7 +29,7 @@ let
             extension=${phpPkgs.imagick}/lib/php/extensions/imagick.so
             extension=${phpExtras.timecop}/lib/php/extensions/timecop.so
             extension=${phpExtras.runkit7_3}/lib/php/extensions/runkit7.so
-      '';
+      '' + stdenv.lib.optionalString stdenv.isLinux "extension=${phpExtras.inotify}/lib/php/extensions/inotify.so";
     }
     ''
       cat "${phpRuntime}/etc/php.ini" > $out
@@ -39,7 +39,9 @@ let
 
     phpOverride = stdenv.mkDerivation rec {
         name = "bknix-php71";
-        buildInputs = [phpRuntime phpPkgs.xdebug phpPkgs.redis phpPkgs.yaml phpPkgs.memcached phpPkgs.imagick phpExtras.timecop phpExtras.runkit7_3 pkgs.makeWrapper];
+        buildInputs =
+             [phpRuntime phpPkgs.xdebug phpPkgs.redis phpPkgs.yaml phpPkgs.memcached phpPkgs.imagick phpExtras.timecop phpExtras.runkit7_3 pkgs.makeWrapper]
+             ++ stdenv.lib.optionals stdenv.isLinux [ phpExtras.inotify ];
         buildCommand = ''
           makeWrapper ${phpRuntime}/bin/phar $out/bin/phar
           makeWrapper ${phpRuntime}/bin/php $out/bin/php --add-flags -c --add-flags "${phpIni}"

--- a/nix/pkgs/php72/default.nix
+++ b/nix/pkgs/php72/default.nix
@@ -30,7 +30,7 @@ let
             extension=${phpExtras.timecop}/lib/php/extensions/timecop.so
             extension=${phpExtras.runkit7_3}/lib/php/extensions/runkit7.so
             openssl.cafile=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt
-      '';
+      '' + stdenv.lib.optionalString stdenv.isLinux "extension=${phpExtras.inotify}/lib/php/extensions/inotify.so";
     }
     ''
       cat "${phpRuntime}/etc/php.ini" > $out
@@ -40,7 +40,9 @@ let
 
     phpOverride = stdenv.mkDerivation rec {
         name = "bknix-php72";
-        buildInputs = [phpRuntime phpPkgs.xdebug phpPkgs.redis phpPkgs.yaml phpPkgs.memcached phpPkgs.imagick phpExtras.timecop phpExtras.runkit7_3 pkgs.makeWrapper pkgs.cacert];
+        buildInputs =
+		[phpRuntime phpPkgs.xdebug phpPkgs.redis phpPkgs.yaml phpPkgs.memcached phpPkgs.imagick phpExtras.timecop phpExtras.runkit7_3 pkgs.makeWrapper pkgs.cacert]
+		++ stdenv.lib.optionals stdenv.isLinux [ phpExtras.inotify ];
         buildCommand = ''
           makeWrapper ${phpRuntime}/bin/phar $out/bin/phar
           makeWrapper ${phpRuntime}/bin/php $out/bin/php --add-flags -c --add-flags "${phpIni}"

--- a/nix/pkgs/php73/default.nix
+++ b/nix/pkgs/php73/default.nix
@@ -25,6 +25,7 @@ let
             extension=${phpExtras.runkit7_3}/lib/php/extensions/runkit7.so
             openssl.cafile=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt
       ''
+       + stdenv.lib.optionalString stdenv.isLinux "extension=${phpExtras.inotify}/lib/php/extensions/inotify.so"
 
        ## Per https://bugs.php.net/bug.php?id=77260 -- in php73, pcre.jit uses MAP_JIT which is quirky on diff versions of macOS
        + (if stdenv.isDarwin then "pcre.jit=0\n" else "");
@@ -42,7 +43,9 @@ let
         name = "bknix-php73";
         ## TEST ME: Do we still need imagick? Can we get away with gd nowadays?
         # buildInputs = [phpRuntime phpPkgs.xdebug phpPkgs.redis phpPkgs.yaml phpPkgs.memcached phpPkgs.imagick phpExtras.timecop phpExtras.runkit7_3 pkgs.makeWrapper pkgs.cacert];
-        buildInputs = [phpRuntime phpPkgs.xdebug phpPkgs.redis phpPkgs.yaml phpPkgs.memcached phpExtras.timecop phpExtras.runkit7_3 pkgs.makeWrapper pkgs.cacert];
+        buildInputs =
+		[phpRuntime phpPkgs.xdebug phpPkgs.redis phpPkgs.yaml phpPkgs.memcached phpExtras.timecop phpExtras.runkit7_3 pkgs.makeWrapper pkgs.cacert]
+		++ stdenv.lib.optionals stdenv.isLinux [ phpExtras.inotify ];
         buildCommand = ''
           makeWrapper ${phpRuntime}/bin/phar $out/bin/phar
           makeWrapper ${phpRuntime}/bin/php $out/bin/php --add-flags -c --add-flags "${phpIni}"

--- a/nix/pkgs/php74/default.nix
+++ b/nix/pkgs/php74/default.nix
@@ -23,7 +23,7 @@ let
             extension=${phpPkgs.memcached}/lib/php/extensions/memcached.so
             extension=${phpExtras.timecop}/lib/php/extensions/timecop.so
             extension=${phpExtras.runkit7_3}/lib/php/extensions/runkit7.so
-      '';
+      '' + stdenv.lib.optionalString stdenv.isLinux "extension=${phpExtras.inotify}/lib/php/extensions/inotify.so";
        ## TEST ME: Do we still need imagick? Can we get away with gd nowadays?
        #    extension=${phpPkgs.imagick}/lib/php/extensions/imagick.so
     }
@@ -37,7 +37,9 @@ let
         name = "bknix-php74";
         ## TEST ME: Do we still need imagick? Can we get away with gd nowadays?
         # buildInputs = [phpRuntime phpPkgs.xdebug phpPkgs.redis phpPkgs.yaml phpPkgs.memcached phpPkgs.imagick phpExtras.timecop phpExtras.runkit7_3 pkgs.makeWrapper];
-        buildInputs = [phpRuntime phpPkgs.xdebug phpPkgs.redis phpPkgs.yaml phpPkgs.memcached phpExtras.timecop phpExtras.runkit7_3 pkgs.makeWrapper];
+        buildInputs =
+          [phpRuntime phpPkgs.xdebug phpPkgs.redis phpPkgs.yaml phpPkgs.memcached phpExtras.timecop phpExtras.runkit7_3 pkgs.makeWrapper]
+          ++ stdenv.lib.optionals stdenv.isLinux [ phpExtras.inotify ];
         buildCommand = ''
           makeWrapper ${phpRuntime}/bin/phar $out/bin/phar
           makeWrapper ${phpRuntime}/bin/php $out/bin/php --add-flags -c --add-flags "${phpIni}"

--- a/nix/pkgs/phpExtras/default.nix
+++ b/nix/pkgs/phpExtras/default.nix
@@ -55,4 +55,21 @@ in rec {
     buildInputs = [ ];
   };
 
+  inotify = buildPecl {
+    name = "inotify-2.0.0";
+    sha256 = "01si0jn4jzkxhcywzflnh1v0ksxm5b4v30pi6h7i3amv4sfshi6h";
+    configureFlags = [ ];
+    nativeBuildInputs = [ pkgs.pkgconfig ];
+    buildInputs = [ ];
+#    https://pecl.php.net/get/inotify-2.0.0.tgz
+  };
+
+  inotify_0 = buildPecl {
+    name = "inotify-0.1.6";
+    sha256 = "0kj9bcp9jj1yjjdhnc9z72l4cwzh8vgw1zqp4qldxc2fbni817wp";
+    configureFlags = [ ];
+    nativeBuildInputs = [ pkgs.pkgconfig ];
+    buildInputs = [ ];
+  };
+
 }


### PR DESCRIPTION
`inotify` helps monitor file changes - it should perform better than filesystem polling (especially on large trees). However, it's a Linux-specific API, so it should only build on Linux hosts.