### PR TITLE
civihydra - For D7 and Backdrop, recommend different install URL

### DIFF
--- a/bin/civihydra
+++ b/bin/civihydra
@@ -153,14 +153,14 @@ function hydra_show() {
       *-drupal)
         subsite_url=$(cvutil_mkurl "${HYDRA_PREFIX}drupal")
         login_url="$subsite_url/user/login"
-        install_url="$subsite_url/sites/all/modules/civicrm/install/index.php"
+        install_url="$subsite_url/admin/modules"
         install_blurb=""
         ;;
 
       *-backdrop)
         subsite_url=$(cvutil_mkurl "${HYDRA_PREFIX}backdrop")
         login_url="$subsite_url/user/login"
-        install_url="$subsite_url/modules/civicrm/install/index.php?civicrm_install_type=backdrop"
+        install_url="$subsite_url/admin/modules"
         install_blurb=""
         ;;
 


### PR DESCRIPTION
The `civihydra` script builds test sites with the tarballs - useful for manually testing the install process.  After building a test site, it shows hyperlinks where you can login and start installation.

The recommended link changes in 5.29, which is now the stable branch.