### PR TITLE
Enable org.civicrm.contactlayout on demo sites

### DIFF
--- a/app/config/drupal-demo/install.sh
+++ b/app/config/drupal-demo/install.sh
@@ -116,7 +116,7 @@ EOPERM
     add 'register to volunteer'
 EOPERM
 
-  cv en --ignore-missing civirules civisualize cividiscount org.civicrm.search
+  cv en --ignore-missing civirules civisualize cividiscount org.civicrm.search org.civicrm.contactlayout
 
   ## Demo sites always disable email and often disable cron
   drush cvapi StatusPreference.create ignore_severity=critical name=checkOutboundMail

--- a/app/config/drupal8-demo/install.sh
+++ b/app/config/drupal8-demo/install.sh
@@ -97,7 +97,7 @@ pushd "${CMS_ROOT}/sites/${DRUPAL_SITE_DIR}" >> /dev/null
   drush8 -y rap anonymous 'register to volunteer'
   drush8 -y rap authenticated 'register to volunteer'
 
-  cv en --ignore-missing civirules civisualize cividiscount org.civicrm.search
+  cv en --ignore-missing civirules civisualize cividiscount org.civicrm.search org.civicrm.contactlayout
 
   ## Demo sites always disable email and often disable cron
   drush8 cvapi StatusPreference.create ignore_severity=critical name=checkOutboundMail

--- a/app/config/drupal9-demo/install.sh
+++ b/app/config/drupal9-demo/install.sh
@@ -79,7 +79,7 @@ pushd "${CMS_ROOT}/sites/${DRUPAL_SITE_DIR}" >> /dev/null
   drush8 -y rap anonymous 'register to volunteer'
   drush8 -y rap authenticated 'register to volunteer'
 
-  cv en --ignore-missing civirules civisualize cividiscount org.civicrm.search
+  cv en --ignore-missing civirules civisualize cividiscount org.civicrm.search org.civicrm.contactlayout
 
   ## Demo sites always disable email and often disable cron
   drush8 cvapi StatusPreference.create ignore_severity=critical name=checkOutboundMail

--- a/app/config/wp-demo/install.sh
+++ b/app/config/wp-demo/install.sh
@@ -156,7 +156,7 @@ wp eval '$c=[civi_wp()->users->set_wp_user_capabilities()];if (is_callable($c)) 
 ## Force basepage
 wp eval '$c=[civi_wp()->basepage->create_wp_basepage()];if (is_callable($c)) $c();'
 
-cv en --ignore-missing angularprofiles volunteer org.civicrm.search
+cv en --ignore-missing angularprofiles volunteer org.civicrm.search org.civicrm.contactlayout
 
 wp cap add civicrm_admin \
   register to volunteer \


### PR DESCRIPTION
@totten @colemanw @seamuslee001 @MikeyMJCO  same as https://github.com/civicrm/civicrm-buildkit/pull/569 for contact layout editor.

we already enable civirules & civivolunteer so I would consider mosaico too - but not in scope on this