### PR TITLE
Fix backdrop builds by applying patch only if it hasn't already been …

### DIFF
--- a/src/civibuild.lib.sh
+++ b/src/civibuild.lib.sh
@@ -1031,7 +1031,9 @@ function backdrop_download() {
 
   # See: https://github.com/backdrop/backdrop/pull/3018
   pushd "$WEB_ROOT/web/core/includes/database/mysql"
-    patch database.inc < "$PRJDIR/app/drupal-patches/mysql8-drupal.patch"
+    if grep -q 'NO_AUTO_CREATE_USER' database.inc; then
+      patch database.inc < "$PRJDIR/app/drupal-patches/mysql8-drupal.patch"
+    fi
   popd
 }
 


### PR DESCRIPTION
…applied upstream

This fixes an issue building the bmaster demo site caused by https://github.com/backdrop/backdrop/pull/3018 being applied