### PR TITLE
install_cachix - Fix detection of single-user on macOS Catalina

### DIFF
--- a/nix/lib/common.sh
+++ b/nix/lib/common.sh
@@ -97,7 +97,7 @@ function install_cachix() {
   fi
   echo "Setup binary cache (cachix)"
   local SUDO
-  is_my_file /nix && SUDO='' || SUDO='sudo -i'
+  is_my_file /nix/store && SUDO='' || SUDO='sudo -i'
   $SUDO nix-env -iA cachix -f https://cachix.org/api/v1/install
   $SUDO cachix use bknix
 }


### PR DESCRIPTION
The idea here is to detect if nix has been on installed in single-user mode or multi-user mode -- the key difference being who has write-access to global nix data (ie `/nix`).

On Catalina, the `/nix` folder is a special volume.  So we have to go one level deeper (`/nix/store`) to check the writeable part. On other platforms, `/nix/store` is still going be just as representative as `/nix`.