### PR TITLE
Enable searchkit on drupal-clean

### DIFF
--- a/app/config/drupal-clean/install.sh
+++ b/app/config/drupal-clean/install.sh
@@ -67,4 +67,6 @@ pushd "${CMS_ROOT}/sites/${DRUPAL_SITE_DIR}" >> /dev/null
     drush -y role-add-perm civicrm_webtest_user "$perm"
   done
 
+  cv en --ignore-missing org.civicrm.search
+
 popd >> /dev/null


### PR DESCRIPTION
I have focussed on drupal clean as it is used on PR sites - however eventually this will be in
the main install script and enabled by default on all new sites. This is the next step on that
core-extension path

@totten @colemanw @seamuslee001 