### PR TITLE
Fix patching for MySQL 8 on Drupal 7 by patching for any CMS version …

### DIFF
--- a/src/civibuild.lib.sh
+++ b/src/civibuild.lib.sh
@@ -1045,12 +1045,15 @@ function drupal_download() {
   drush8 -y dl drupal-${CMS_VERSION} --destination="$WEB_ROOT" --drupal-project-rename
   mv "$WEB_ROOT/drupal" "$WEB_ROOT/web"
 
-  if [ ${CMS_VERSION} == "7.x" ]; then
-    # See: https://www.drupal.org/project/drupal/issues/2978575
-    pushd "$WEB_ROOT/web/includes/database/mysql"
-      patch database.inc < "$PRJDIR/app/drupal-patches/mysql8-drupal.patch"
-    popd
-  fi
+  case $CMS_VERSION in
+    7*)
+     # See: https://www.drupal.org/project/drupal/issues/2978575
+     pushd "$WEB_ROOT/web/includes/database/mysql"
+       if ! grep -q 'escapeAlias' database.inc; then
+         patch database.inc < "$PRJDIR/app/drupal-patches/mysql8-drupal.patch"
+       fi
+     popd
+  esac
 }
 
 ###############################################################################


### PR DESCRIPTION
…that starts with 7 and updating the grep based on the merged in patch

I tested this locally and it correctly doesn't apply the patch on the current d7 dev but does on 7.74 which is the most recent release of Drupal 7