### PR TITLE
NO_AUTO_CREATE_USER removed upstream

### DIFF
--- a/app/drupal-patches/mysql8-drupal.patch
+++ b/app/drupal-patches/mysql8-drupal.patch
@@ -2,15 +2,6 @@ diff --git a/includes/database/mysql/database.inc b/includes/database/mysql/data
 index 356e039f..c803207d 100644
 --- a/includes/database/mysql/database.inc
 +++ b/includes/database/mysql/database.inc
-@@ -87,7 +87,7 @@ class DatabaseConnection_mysql extends DatabaseConnection {
-       'init_commands' => array(),
-     );
-     $connection_options['init_commands'] += array(
--      'sql_mode' => "SET sql_mode = 'REAL_AS_FLOAT,PIPES_AS_CONCAT,ANSI_QUOTES,IGNORE_SPACE,STRICT_TRANS_TABLES,STRICT_ALL_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER'",
-+      'sql_mode' => "SET sql_mode = 'REAL_AS_FLOAT,PIPES_AS_CONCAT,ANSI_QUOTES,IGNORE_SPACE,STRICT_TRANS_TABLES,STRICT_ALL_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO'",
-     );
-     // Execute initial commands.
-     foreach ($connection_options['init_commands'] as $sql) {
 @@ -101,6 +101,14 @@ class DatabaseConnection_mysql extends DatabaseConnection {
      }
    }


### PR DESCRIPTION
Removing the NO_AUTO_CREATE_USER option for Mysql 8 has made it's way into the upstream drupal source https://api.drupal.org/api/drupal/includes!database!mysql!database.inc/7.x 🙌

As a result the first hunk of this patch is no longer needed (and throws an error when building currently)