### PR TITLE
Enable APC(u) for use with `E2E_Cache_APCcacheTest`

### DIFF
--- a/bin/civi-test-run
+++ b/bin/civi-test-run
@@ -314,7 +314,7 @@ for TESTTYPE in $SUITES ; do
     karma)  task_karma ;;
     upgrade)  CIVIVER=$(getCiviVer) ; task_upgrade 5.13.3-multilingual_af_bg_en* "@4.4.7..$CIVIVER:10" ;;
     upgrade@*)  task_upgrade $(echo $TESTTYPE | sed s'/^upgrade//' ) ;;
-    phpunit-e2e)  task_phpunit E2E_AllTests ;;
+    phpunit-e2e)  PHP_APC_CLI=on task_phpunit E2E_AllTests ;;
     phpunit-crm)  task_phpunit CRM_AllTests ;;
     # Handle legacy call for phpunit-api being equivilant to phpunit-api3
     phpunit-api)  task_phpunit api_v3_AllTests ;;

--- a/nix/pkgs/php71/default.nix
+++ b/nix/pkgs/php71/default.nix
@@ -29,6 +29,10 @@ let
             extension=${phpPkgs.imagick}/lib/php/extensions/imagick.so
             extension=${phpExtras.timecop}/lib/php/extensions/timecop.so
             extension=${phpExtras.runkit7_3}/lib/php/extensions/runkit7.so
+
+            extension=${phpPkgs.apcu}/lib/php/extensions/apcu.so
+            extension=${phpPkgs.apcu_bc}/lib/php/extensions/apc.so
+            apc.enable_cli = ''${PHP_APC_CLI}
       '';
     }
     ''
@@ -39,7 +43,7 @@ let
 
     phpOverride = stdenv.mkDerivation rec {
         name = "bknix-php71";
-        buildInputs = [phpRuntime phpPkgs.xdebug phpPkgs.redis phpPkgs.yaml phpPkgs.memcached phpPkgs.imagick phpExtras.timecop phpExtras.runkit7_3 pkgs.makeWrapper];
+        buildInputs = [phpRuntime phpPkgs.xdebug phpPkgs.redis phpPkgs.apcu phpPkgs.apcu_bc phpPkgs.yaml phpPkgs.memcached phpPkgs.imagick phpExtras.timecop phpExtras.runkit7_3 pkgs.makeWrapper];
         buildCommand = ''
           makeWrapper ${phpRuntime}/bin/phar $out/bin/phar
           makeWrapper ${phpRuntime}/bin/php $out/bin/php --add-flags -c --add-flags "${phpIni}"

--- a/nix/pkgs/php72/default.nix
+++ b/nix/pkgs/php72/default.nix
@@ -2,7 +2,7 @@
 # add all extensions needed as buildInputs and don't forget to load them in the php.ini above
 
 let
-    pkgs = import (import ../../pins/18.03.nix) {
+    pkgs = import (import ../../pins/19.09.nix) {
       config = {
         php = {
           mysqlnd = true;
@@ -29,6 +29,11 @@ let
             extension=${phpPkgs.imagick}/lib/php/extensions/imagick.so
             extension=${phpExtras.timecop}/lib/php/extensions/timecop.so
             extension=${phpExtras.runkit7_3}/lib/php/extensions/runkit7.so
+
+            extension=${phpPkgs.apcu}/lib/php/extensions/apcu.so
+            extension=${phpPkgs.apcu_bc}/lib/php/extensions/apc.so
+            apc.enable_cli = ''${PHP_APC_CLI}
+
             openssl.cafile=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt
       '';
     }
@@ -40,7 +45,7 @@ let
 
     phpOverride = stdenv.mkDerivation rec {
         name = "bknix-php72";
-        buildInputs = [phpRuntime phpPkgs.xdebug phpPkgs.redis phpPkgs.yaml phpPkgs.memcached phpPkgs.imagick phpExtras.timecop phpExtras.runkit7_3 pkgs.makeWrapper pkgs.cacert];
+        buildInputs = [phpRuntime phpPkgs.xdebug phpPkgs.redis phpPkgs.apcu phpPkgs.apcu_bc phpPkgs.yaml phpPkgs.memcached phpPkgs.imagick phpExtras.timecop phpExtras.runkit7_3 pkgs.makeWrapper pkgs.cacert];
         buildCommand = ''
           makeWrapper ${phpRuntime}/bin/phar $out/bin/phar
           makeWrapper ${phpRuntime}/bin/php $out/bin/php --add-flags -c --add-flags "${phpIni}"

--- a/nix/pkgs/php73/default.nix
+++ b/nix/pkgs/php73/default.nix
@@ -23,6 +23,11 @@ let
             extension=${phpPkgs.memcached}/lib/php/extensions/memcached.so
             extension=${phpExtras.timecop}/lib/php/extensions/timecop.so
             extension=${phpExtras.runkit7_3}/lib/php/extensions/runkit7.so
+
+            extension=${phpPkgs.apcu}/lib/php/extensions/apcu.so
+            extension=${phpPkgs.apcu_bc}/lib/php/extensions/apc.so
+            apc.enable_cli = ''${PHP_APC_CLI}
+
             openssl.cafile=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt
       ''
 
@@ -41,8 +46,8 @@ let
     phpOverride = stdenv.mkDerivation rec {
         name = "bknix-php73";
         ## TEST ME: Do we still need imagick? Can we get away with gd nowadays?
-        # buildInputs = [phpRuntime phpPkgs.xdebug phpPkgs.redis phpPkgs.yaml phpPkgs.memcached phpPkgs.imagick phpExtras.timecop phpExtras.runkit7_3 pkgs.makeWrapper pkgs.cacert];
-        buildInputs = [phpRuntime phpPkgs.xdebug phpPkgs.redis phpPkgs.yaml phpPkgs.memcached phpExtras.timecop phpExtras.runkit7_3 pkgs.makeWrapper pkgs.cacert];
+        # buildInputs = [phpRuntime phpPkgs.xdebug phpPkgs.redis phpPkgs.apcu phpPkgs.apcu_bc phpPkgs.yaml phpPkgs.memcached phpPkgs.imagick phpExtras.timecop phpExtras.runkit7_3 pkgs.makeWrapper pkgs.cacert];
+        buildInputs = [phpRuntime phpPkgs.xdebug phpPkgs.redis phpPkgs.apcu phpPkgs.apcu_bc phpPkgs.yaml phpPkgs.memcached phpExtras.timecop phpExtras.runkit7_3 pkgs.makeWrapper pkgs.cacert];
         buildCommand = ''
           makeWrapper ${phpRuntime}/bin/phar $out/bin/phar
           makeWrapper ${phpRuntime}/bin/php $out/bin/php --add-flags -c --add-flags "${phpIni}"

--- a/nix/pkgs/php74/default.nix
+++ b/nix/pkgs/php74/default.nix
@@ -23,6 +23,10 @@ let
             extension=${phpPkgs.memcached}/lib/php/extensions/memcached.so
             extension=${phpExtras.timecop}/lib/php/extensions/timecop.so
             extension=${phpExtras.runkit7_3}/lib/php/extensions/runkit7.so
+
+            extension=${phpPkgs.apcu}/lib/php/extensions/apcu.so
+            extension=${phpPkgs.apcu_bc}/lib/php/extensions/apc.so
+            apc.enable_cli = ''${PHP_APC_CLI}
       '';
        ## TEST ME: Do we still need imagick? Can we get away with gd nowadays?
        #    extension=${phpPkgs.imagick}/lib/php/extensions/imagick.so
@@ -36,8 +40,8 @@ let
     phpOverride = stdenv.mkDerivation rec {
         name = "bknix-php74";
         ## TEST ME: Do we still need imagick? Can we get away with gd nowadays?
-        # buildInputs = [phpRuntime phpPkgs.xdebug phpPkgs.redis phpPkgs.yaml phpPkgs.memcached phpPkgs.imagick phpExtras.timecop phpExtras.runkit7_3 pkgs.makeWrapper];
-        buildInputs = [phpRuntime phpPkgs.xdebug phpPkgs.redis phpPkgs.yaml phpPkgs.memcached phpExtras.timecop phpExtras.runkit7_3 pkgs.makeWrapper];
+        # buildInputs = [phpRuntime phpPkgs.xdebug phpPkgs.redis phpPkgs.apcu phpPkgs.apcu_bc phpPkgs.yaml phpPkgs.memcached phpPkgs.imagick phpExtras.timecop phpExtras.runkit7_3 pkgs.makeWrapper];
+        buildInputs = [phpRuntime phpPkgs.xdebug phpPkgs.redis phpPkgs.apcu phpPkgs.apcu_bc phpPkgs.yaml phpPkgs.memcached phpExtras.timecop phpExtras.runkit7_3 pkgs.makeWrapper];
         buildCommand = ''
           makeWrapper ${phpRuntime}/bin/phar $out/bin/phar
           makeWrapper ${phpRuntime}/bin/php $out/bin/php --add-flags -c --add-flags "${phpIni}"


### PR DESCRIPTION
The test `E2E_Cache_APCcacheTest` does not currently run in CI because APC(u) is not enabled.

## Background

APC(u) is a caching system based on shared-memory. The naming of "APC(u)" is a little confusing. For reference:

* `apc` was the original extension. It cached both data and PHP-opcodes in shared memory.
* `apcu` is a successor in PHP 5.6/7.x which provides only data-caching. (The opcode caching was rearranged circa 5.5/5.6.) It parallels `apc`, but all the methods are named differently (eg `apc_store(...)` vs `apcu_store(...)`).
* `apcu_bc` is a backward-compatibility extension. It wraps around `apcu` and supports the `apc_*` APIs.

A system with both  `apcu` and `apcu_bc` provides broadest API compatibility (e.g. supports both `apc_store(...)` and `apcu_store(...)`).

## Technical Details

This patch installs the `apcu` and `apcu_bc` extensions for use in CI.

There is some nuance around activation:

* By default, the APC(u) extensions only work for web-requests -- not CLI requests. The php.net docs suggest it's a waste of resources for most CLI uses. However, it *can be* useful for unit-testing (like `E2E_Cache_APCcacheTest`), and there is an extra option to enable it.
* With this patch, `apcu` is enabled for web-requests and for `civi-test-run phpunit-e2e` (but not for any other CLI requests).

