### PR TITLE
joomlatools-console - Switch from custom PHAR to extern

### DIFF
--- a/bin/civi-download-tools
+++ b/bin/civi-download-tools
@@ -19,6 +19,7 @@ PRJDIR=$(dirname "$BINDIR")
 LOCKFILE="$TMPDIR/civi-download-tools.lock"
 LOCKTIMEOUT=90
 HUB_VERSION="2.14.2"
+JOOMLATOOLS_CONSOLE_VERSION="v1.5.9"
 IS_QUIET=
 IS_FORCE=
 IS_FULL=
@@ -296,6 +297,50 @@ function get_hub_url() {
   esac
 
   echo https://github.com/github/hub/releases/download/v${VERSION}/hub-${PLATFORM}-${VERSION}.${FORMAT}
+}
+
+###############################################################################
+## Install the project 'joomlatools/console' in 'extern/joomlatools-console'
+## Note that this uses a separate folder becuase:
+##  1. Some of the dependencies don't agree with other top-level packages.
+##  2. The file structure allows writing data to funny places.
+##
+## usage: install_joomlatools_console <version-tag-branch>
+function install_joomlatools_console() {
+  local VERSION="$1"
+  local WRAPPER="$PRJDIR/bin/joomla"
+  local SRC="$PRJDIR/extern/joomlatools-console"
+  local MARKER="$PRJDIR/extern/joomlatools-console.txt"
+
+  ## Create/update wrapper script
+  ## Note: joomla was previously downloaded via other means (and gitignored). This "cp" ensures we overwrite without git conflicts.
+  if [ ! -f "$WRAPPER" -o "$PRJDIR/src/joomlatools-console.tmpl" -nt  "$WRAPPER" ]; then
+    echo "[[joomlatools-console ($WRAPPER): Generate wrapper]]"
+    cp "$PRJDIR/src/joomlatools-console.tmpl" "$WRAPPER"
+  fi
+
+  ## Do we need to download?
+  touch "$MARKER"
+  if [ -z "$IS_FORCE" -a -e "$SRC/bin/joomla" -a "$(cat $MARKER)" == "$VERSION" ]; then
+    echo_comment "[[joomla ($PRJDIR/extern/joomlatools-console) already exists. Skipping.]]"
+    return
+  fi
+  echo "[[Install joomlatools-console $VERSION]]"
+
+  ## Cleanup any previous downloads
+  [ -e "$SRC" ] && rm -rf "$SRC"
+
+  ## Download
+  git clone -b "$VERSION" --depth 1 https://github.com/joomlatools/joomlatools-console "$SRC"
+  pushd "$SRC" >> /dev/null
+    ## In 1.5.9, the lock file is pegged to libraries that aren't compatible with our env. Resolve dependencies anew.
+    rm -f composer.lock
+    composer update --prefer-lowest
+    composer install
+  popd >> /dev/null
+
+  ## Mark as downloaded
+  echo "$VERSION" > "$MARKER"
 }
 
 ###############################################################################
@@ -669,6 +714,9 @@ pushd $PRJDIR >> /dev/null
   make_link "$PRJDIR/bin" "../extern/phpunit5/phpunit5.phar" "phpunit5"
   make_link "$PRJDIR/bin" "../extern/phpunit6/phpunit6.phar" "phpunit6"
   make_link "$PRJDIR/bin" "../extern/phpunit7/phpunit7.phar" "phpunit7"
+
+  ## Download joomlatools-console
+  install_joomlatools_console "$JOOMLATOOLS_CONSOLE_VERSION"
 
   ## Download "hub"
   touch "$PRJDIR/extern/hub.txt"

--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,6 @@
       "drush8": {"version": "8.4.0", "url": "https://github.com/drush-ops/drush/releases/download/{$version}/drush.phar", "path": "extern/drush8.phar", "type": "phar"},
       "drush-backdrop": {"version": "1.0.0", "url": "https://github.com/backdrop-contrib/drush/archive/{$version}.zip", "path": "extern/drush-lib/backdrop"},
       "git-scan": {"version": "2020-07-16-5f15f6f5", "url": "https://download.civicrm.org/git-scan/git-scan.phar-{$version}", "path": "bin/git-scan", "type": "phar"},
-      "joomla": {"version": "2017-06-19-62ff6a9df", "url": "https://download.civicrm.org/joomlatools-console/joomla.phar-{$version}", "path": "bin/joomla", "type": "phar"},
       "phpunit4": {"version": "4.8.21", "url": "https://phar.phpunit.de/phpunit-{$version}.phar", "path": "extern/phpunit4/phpunit4.phar", "type": "phar"},
       "phpunit5": {"version": "5.x", "url": "https://phar.phpunit.de/phpunit-5.phar", "path": "extern/phpunit5/phpunit5.phar", "type": "phar"},
       "phpunit6": {"version": "6.x", "url": "https://phar.phpunit.de/phpunit-6.phar", "path": "extern/phpunit6/phpunit6.phar", "type": "phar"},

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8ec3e3c8cf63b0d0405ac8ba21b6e385",
+    "content-hash": "33f8e1bfd275c45f9e16b6b892a4b1b1",
     "packages": [
         {
             "name": "civicrm/composer-downloads-plugin",

--- a/src/joomlatools-console.tmpl
+++ b/src/joomlatools-console.tmpl
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+BINDIR=$(dirname $0)
+PRJDIR=$(dirname "$BINDIR")
+JTCDIR="$PRJDIR/extern/joomlatools-console"
+PATH="$JTCDIR/bin:$PATH"
+
+exec "joomla" "$@"


### PR DESCRIPTION
__Overview__: `joomlatools-console` provides a subcommand for installing Joomla.

__Before__: `civi-download-tools` downloads a PHAR build of `joomlatools-console`. However, this PHAR is based on a fork that is not maintained.

__After__: `civi-download-tools` creates a folder `extern/joomlatools-console` based on a git tag of `joomlatools-console`. This aligns better with upstream's distribution, and it avoids impedance mismatch between their composer.json and buildkit's composer.json.