### PR TITLE
Remove database.inc patch about NO_AUTO_CREATE_USER

### DIFF
--- a/app/drupal-patches/mysql8-drupal.patch
+++ b/app/drupal-patches/mysql8-drupal.patch
@@ -2,15 +2,6 @@ diff --git a/includes/database/mysql/database.inc b/includes/database/mysql/data
 index 356e039f..c803207d 100644
 --- a/includes/database/mysql/database.inc
 +++ b/includes/database/mysql/database.inc
-@@ -87,7 +87,7 @@ class DatabaseConnection_mysql extends DatabaseConnection {
-       'init_commands' => array(),
-     );
-     $connection_options['init_commands'] += array(
--      'sql_mode' => "SET sql_mode = 'REAL_AS_FLOAT,PIPES_AS_CONCAT,ANSI_QUOTES,IGNORE_SPACE,STRICT_TRANS_TABLES,STRICT_ALL_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER'",
-+      'sql_mode' => "SET sql_mode = 'REAL_AS_FLOAT,PIPES_AS_CONCAT,ANSI_QUOTES,IGNORE_SPACE,STRICT_TRANS_TABLES,STRICT_ALL_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO'",
-     );
-     // Execute initial commands.
-     foreach ($connection_options['init_commands'] as $sql) {
 @@ -101,6 +101,14 @@ class DatabaseConnection_mysql extends DatabaseConnection {
      }
    }


### PR DESCRIPTION
It looks like some php logic has been implemented such that the first part of this patch (I'm referring to a patch file saved in the project, not a commit) might not be necessary any longer.

Put another way: with buildkit as is, I couldn't get it to build because it failed trying to apply this patch. With this PR, I could get it to build.