### PR TITLE
find-stale-builds - Fix missing dependency 'symfony/finder'

### DIFF
--- a/bin/find-stale-builds
+++ b/bin/find-stale-builds
@@ -1,5 +1,8 @@
-#!/usr/bin/env php
+#!/usr/bin/env pogo
 <?php
+#!depdir '../extern/find-stale-builds'
+#!ttl 10 years
+#!require symfony/finder: ~2.6.1
 
 ## Generate a list of "stale" builds - either:
 ## - The build is objectively old.
@@ -9,21 +12,6 @@
 ## Bootstrap
 
 ini_set('display_errors', 1);
-$found = 0;
-$autoloaders = array(
-  dirname(__DIR__) . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'autoload.php',
-  dirname(dirname(dirname(__DIR__))) . DIRECTORY_SEPARATOR . 'autoload.php'
-);
-foreach ($autoloaders as $autoloader) {
-  if (file_exists($autoloader)) {
-    require_once $autoloader;
-    $found = 1;
-    break;
-  }
-}
-if (!$found) {
-  die("Failed to find autoloader");
-}
 
 ###############################################################################
 class MyFinder {


### PR DESCRIPTION
Background
----------

It appears that `find-stale-builds` was working, but for the wrong reason - and then broke. This should be a bit more robust.

* At some point in the past, `buildkit:composer.json` likely listed `symfony/finder`   or some package that uses `symfony/finder`.
* During this time, `buildkit:bin/find-stale-builds` started to use `symfony/finder`
* Eventually, the formal requirement for `symfony/finder` was removed from `composer.json`. But it remained as a ghost requirement `buildkit:composer.lock`.
* Eventually, during an unrelated update, `buildkit:composer.lock` was completely regenerated (eg `rm -f composer.lock` instead of composer `composer update ...`). This removed the ghost dependency.
* Then `find-stale-builds` broke.

Fix
---

This change allows `find-stale-builds` to declare its own dependencies, independent of the `buildkit:composer.lock` and `buildkit:composer.json`.