### PR TITLE
Use PHP7.4 for Max profile

### DIFF
--- a/nix/profiles/max/default.nix
+++ b/nix/profiles/max/default.nix
@@ -11,7 +11,7 @@ let
 
 in (import ../base/default.nix) ++ (import ../mgmt/default.nix) ++ [
 
-    bkpkgs.php73
+    bkpkgs.php74
     pkgs_1809.nodejs-8_x
     pkgs.apacheHttpd
     pkgs_1809.mailcatcher


### PR DESCRIPTION
@totten we now have a fully passing build on edge https://test.civicrm.org/job/CiviCRM-Core-Edge/CIVIVER=master,label=test-3/ this will be the next step IMO. ping @eileenmcnaughton 

I am thinking that we may want to hold back for another couple of release cycles at least until 5.37 becomes stable release.

I also started looking at PHP8 and it seems like there might have been some movements on 2 of the 3 pecl packages but not timecop