### PR TITLE
Disable 'update' module for wmff

### DIFF
--- a/app/config/wmff/install.sh
+++ b/app/config/wmff/install.sh
@@ -42,6 +42,7 @@ civicrm_install
 ###############################################################################
 ## Extra configuration
 pushd "$CMS_ROOT"
+drysh -u dis update
 drush -y en `cat sites/default/enabled_modules`
 
 drush -y updatedb


### PR DESCRIPTION
Try to shave some time off setups by not checking for new versions
on what may be locked down networks that make all requests time out.

Change-Id: Ib5630067a66d1cd2489c8d8838d0b083aad1c08d