### PR TITLE
WMFF: sync all drupal users to contacts

### DIFF
--- a/app/config/wmff/install.sh
+++ b/app/config/wmff/install.sh
@@ -60,6 +60,9 @@ drush php-eval -u "$ADMIN_USER" 'module_load_include("inc","block","block.admin"
 ## Setup demo user
 drush -y user-create --password="$DEMO_PASS" --mail="$DEMO_EMAIL" "$DEMO_USER"
 
+## Add a contact record for the admin user so we can do stuff with it before logging in
+drush -y civicrm-sync-users-contacts
+
 DEV_SETTINGS_FILE="${WEB_ROOT}/sites/default/wmf_settings_developer.json"
 if [ -e "$DEV_SETTINGS_FILE" ]; then
   drush --in=json cvapi Setting.create < "$DEV_SETTINGS_FILE"


### PR DESCRIPTION
So we can e.g. set the admin api key in later scripts without
having to log them in.