### PR TITLE
(REF) app/config/*-demo - Get list of demo exts from common env-var

### DIFF
--- a/app/config/backdrop-demo/install.sh
+++ b/app/config/backdrop-demo/install.sh
@@ -54,7 +54,8 @@ pushd "$CMS_ROOT" >> /dev/null
     #drush -y user-add-role civicrm_webtest_user "$DEMO_USER"
   fi
 
-  cv en --ignore-missing civirules civisualize cividiscount org.civicrm.search_kit org.civicrm.search org.civicrm.contactlayout org.civicrm.angularprofiles org.civicrm.volunteer
+  ## Setup demo extensions
+  cv en --ignore-missing $CIVI_DEMO_EXTS
 
   ## Demo sites always disable email and often disable cron
   drush cvapi StatusPreference.create ignore_severity=critical name=checkOutboundMail

--- a/app/config/drupal-demo/install.sh
+++ b/app/config/drupal-demo/install.sh
@@ -106,17 +106,15 @@ EOPERM
 EOPERM
   ## Note: If you enable CiviGrant, the grant 'access CiviGrant', 'edit grants', 'delete in CiviGrant'
 
-  ## Setup CiviVolunteer
-  drush -y cvapi extension.install key=org.civicrm.angularprofiles debug=1
-
-  drush -y cvapi extension.install key=org.civicrm.volunteer debug=1
-  drush scr "$PRJDIR/src/drush/perm.php" <<EOPERM
-    role 'anonymous user'
-    role 'authenticated user'
-    add 'register to volunteer'
+  ## Setup demo extensions
+  cv en --ignore-missing $CIVI_DEMO_EXTS
+  if [[ "$CIVI_DEMO_EXTS" =~ volunteer ]]; then
+    drush scr "$PRJDIR/src/drush/perm.php" <<EOPERM
+      role 'anonymous user'
+      role 'authenticated user'
+      add 'register to volunteer'
 EOPERM
-
-  cv en --ignore-missing civirules civisualize cividiscount org.civicrm.search_kit org.civicrm.contactlayout org.civicrm.search
+  fi
 
   ## Demo sites always disable email and often disable cron
   drush cvapi StatusPreference.create ignore_severity=critical name=checkOutboundMail

--- a/app/config/drupal8-demo/install.sh
+++ b/app/config/drupal8-demo/install.sh
@@ -88,14 +88,12 @@ pushd "${CMS_ROOT}/sites/${DRUPAL_SITE_DIR}" >> /dev/null
   fi
   cv api extension.refresh
 
-  ## Setup CiviVolunteer
-  drush8 -y cvapi extension.install key=org.civicrm.angularprofiles debug=1
-
-  drush8 -y cvapi extension.install key=org.civicrm.volunteer debug=1
-  drush8 -y rap anonymous 'register to volunteer'
-  drush8 -y rap authenticated 'register to volunteer'
-
-  cv en --ignore-missing civirules civisualize cividiscount org.civicrm.search_kit org.civicrm.search org.civicrm.contactlayout
+  ## Setup demo extensions
+  cv en --ignore-missing $CIVI_DEMO_EXTS
+  if [[ "$CIVI_DEMO_EXTS" =~ volunteer ]]; then
+    drush8 -y rap anonymous 'register to volunteer'
+    drush8 -y rap authenticated 'register to volunteer'
+  fi
 
   ## Demo sites always disable email and often disable cron
   drush8 cvapi StatusPreference.create ignore_severity=critical name=checkOutboundMail

--- a/app/config/drupal9-demo/install.sh
+++ b/app/config/drupal9-demo/install.sh
@@ -70,14 +70,12 @@ pushd "${CMS_ROOT}/sites/${DRUPAL_SITE_DIR}" >> /dev/null
   fi
   cv api extension.refresh
 
-  ## Setup CiviVolunteer
-  drush8 -y cvapi extension.install key=org.civicrm.angularprofiles debug=1
-
-  drush8 -y cvapi extension.install key=org.civicrm.volunteer debug=1
-  drush8 -y rap anonymous 'register to volunteer'
-  drush8 -y rap authenticated 'register to volunteer'
-
-  cv en --ignore-missing civirules civisualize cividiscount org.civicrm.search_kit org.civicrm.contactlayout org.civicrm.search
+  ## Setup demo extensions
+  cv en --ignore-missing $CIVI_DEMO_EXTS
+  if [[ "$CIVI_DEMO_EXTS" =~ volunteer ]]; then
+    drush8 -y rap anonymous 'register to volunteer'
+    drush8 -y rap authenticated 'register to volunteer'
+  fi
 
   ## Demo sites always disable email and often disable cron
   drush8 cvapi StatusPreference.create ignore_severity=critical name=checkOutboundMail

--- a/app/config/wp-demo/install.sh
+++ b/app/config/wp-demo/install.sh
@@ -156,14 +156,16 @@ wp eval '$c=[civi_wp()->users->set_wp_user_capabilities()];if (is_callable($c)) 
 ## Force basepage
 wp eval '$c=[civi_wp()->basepage->create_wp_basepage()];if (is_callable($c)) $c();'
 
-cv en --ignore-missing angularprofiles volunteer org.civicrm.search_kit org.civicrm.contactlayout org.civicrm.search
-
-wp cap add civicrm_admin \
-  register to volunteer \
-  log own hours \
-  create volunteer projects \
-  edit own volunteer projects \
-  delete own volunteer projects
+## Setup demo extensions
+cv en --ignore-missing $CIVI_DEMO_EXTS
+if [[ "$CIVI_DEMO_EXTS" =~ volunteer ]]; then
+  wp cap add civicrm_admin \
+    register to volunteer \
+    log own hours \
+    create volunteer projects \
+    edit own volunteer projects \
+    delete own volunteer projects
+fi
 
 ## Demo sites always disable email and often disable cron
 wp civicrm api StatusPreference.create ignore_severity=critical name=checkOutboundMail

--- a/src/civibuild.defaults.sh
+++ b/src/civibuild.defaults.sh
@@ -207,6 +207,9 @@ CIVI_EXT_DIR=
 ## URL of the web-managed extension folder (required iff CIVI_EXT_DIR is set)
 CIVI_EXT_URL=
 
+## List of extensions to enable on `*-demo` builds
+CIVI_DEMO_EXTS='civirules civisualize cividiscount org.civicrm.search_kit org.civicrm.search org.civicrm.contactlayout org.civicrm.angularprofiles org.civicrm.volunteer'
+
 ## DB credentials for Civi test DB
 ## (suggested: autogenerate via 'amp create -f --root="$WEB_ROOT" --name=civi --prefix=TEST_ --skip-url')
 TEST_DB_DSN=


### PR DESCRIPTION
This consolidates the list of extensions used on various `*-demo` builds.

The demo builds already use the same list of extensions, although the code
from each `install.sh` has some arbitrary differences.  (In particular, some
scripts use multiple calls to `drush cvapi` and `cv en`; other scripts use
a single `cv en`. This is just evolutionary happenstance.)

Two upshots:

1. When changing the `*-demo` cfg, you only have to change that part once.

2. If you want to override this list locally, you can edit `civibuild.conf` and set `CIVI_DEMO_EXTS`.