### PR TITLE
civibuild - Optionally read /etc/civibuild.conf

### DIFF
--- a/src/civibuild.parse.sh
+++ b/src/civibuild.parse.sh
@@ -116,6 +116,7 @@ declare -a ARGS=()
 function civibuild_parse() {
   source "$PRJDIR/src/civibuild.defaults.sh"
   [ -f "$PRJDIR/app/civibuild.conf" ] && source "$PRJDIR/app/civibuild.conf"
+  [ -f "/etc/civibuild.conf" ] && source "/etc/civibuild.conf"
   cvutil_mkdir "$TMPDIR" "$BLDDIR"
   [ -z "$CIVIBUILD_HOME" ] && cvutil_mkdir "$PRJDIR/app/private"
 


### PR DESCRIPTION
For certain environments, this makes it easier to customize constants defined in `civibuild.defaults.sh`.

__Before__: Constants may be customized in `./app/civibuild.conf`

__After__: Constants may be customized in `./app/civibuild.conf` or `/etc/civibuild.conf`