### PR TITLE
app/config/wp-clean - Add a profile intended for running basic tests

### DIFF
--- a/app/config/wp-clean/download.sh
+++ b/app/config/wp-clean/download.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+## download.sh -- Download WordPress and CiviCRM
+
+###############################################################################
+[ -z "$CMS_VERSION" ] && CMS_VERSION=latest
+
+echo "[[Download WordPress]]"
+mkdir "$WEB_ROOT" "$WEB_ROOT/web"
+pushd "$WEB_ROOT/web" >> /dev/null
+  "$PRJDIR/bin/wp" core download --version=$CMS_VERSION
+  if [ ! -e "wp-cli.yml" ]; then
+    cp -a "$SITE_CONFIG_DIR/wp-cli.yml" "wp-cli.yml"
+  fi
+popd >> /dev/null
+
+echo "[[Download CiviCRM]]"
+[ ! -d "$WEB_ROOT/web/wp-content/plugins" ] && mkdir -p "$WEB_ROOT/web/wp-content/plugins"
+pushd "$WEB_ROOT/web/wp-content/plugins" >> /dev/null
+
+  git clone ${CACHE_DIR}/civicrm/civicrm-wordpress.git                -b "$CIVI_VERSION" civicrm
+  git clone ${CACHE_DIR}/civicrm/civicrm-core.git                     -b "$CIVI_VERSION" civicrm/civicrm
+  git clone ${CACHE_DIR}/civicrm/civicrm-packages.git                 -b "$CIVI_VERSION" civicrm/civicrm/packages
+
+  cd civicrm
+  extract-url --cache-ttl 172800 civicrm=http://download.civicrm.org/civicrm-l10n-core/archives/civicrm-l10n-daily.tar.gz
+  cd -
+
+  git_set_hooks civicrm-wordpress   civicrm                    "../civicrm/tools/scripts/git"
+  git_set_hooks civicrm-core        civicrm/civicrm            "../tools/scripts/git"
+  git_set_hooks civicrm-packages    civicrm/civicrm/packages   "../../tools/scripts/git"
+
+popd >> /dev/null

--- a/app/config/wp-clean/install.sh
+++ b/app/config/wp-clean/install.sh
@@ -1,0 +1,150 @@
+#!/bin/bash
+
+## install.sh -- Create config files and databases; fill the databases
+
+## Transition: Old builds don't have "web/" folder. New builds do.
+## TODO: Simplify sometime after Dec 2019
+[ -d "$WEB_ROOT/web" ] && CMS_ROOT="$WEB_ROOT/web"
+
+###############################################################################
+## Create virtual-host and databases
+
+amp_install
+
+###############################################################################
+## Setup WordPress (config files, database tables)
+
+wp_install
+
+###############################################################################
+## Setup CiviCRM (config files, database tables)
+
+CIVI_DOMAIN_NAME="Demonstrators Anonymous"
+CIVI_DOMAIN_EMAIL="\"Demonstrators Anonymous\" <info@example.org>"
+CIVI_CORE="${CMS_ROOT}/wp-content/plugins/civicrm/civicrm"
+
+if [[ "$CIVI_VERSION" =~ ^4.[0123456](\.([0-9]|alpha|beta)+)?$ ]] ; then
+  CIVI_SETTINGS="${CMS_ROOT}/wp-content/plugins/civicrm/civicrm.settings.php"
+  CIVI_FILES="${CMS_ROOT}/wp-content/plugins/files/civicrm"
+  CIVI_EXT_DIR="${CMS_ROOT}/wp-content/plugins/files/civicrm/ext"
+  CIVI_EXT_URL="${CMS_URL}/wp-content/plugins/files/civicrm/ext"
+else
+  CIVI_SETTINGS="${CMS_ROOT}/wp-content/uploads/civicrm/civicrm.settings.php"
+  CIVI_FILES="${CMS_ROOT}/wp-content/uploads/civicrm"
+  ## civicrm-core v4.7+ sets default ext dir; for older versions, we'll set our own.
+fi
+CIVI_TEMPLATEC="${CIVI_FILES}/templates_c"
+CIVI_UF="WordPress"
+
+civicrm_install
+
+###############################################################################
+## Extra configuration
+
+pushd "$CMS_ROOT" >> /dev/null
+
+## Clear out default content. Load real content.
+TZ=$(php --info |grep 'Default timezone' |sed s/' => '/:/ |cut -d':' -f2)
+wp option set timezone_string $TZ
+wp rewrite structure '/%postname%/'
+wp rewrite flush --hard
+
+wp plugin activate civicrm
+wp eval '$c=[civi_wp(), "add_wpload_setting"]; if (is_callable($c)) $c();' ## Temporary workaround, init wpLoadPh
+
+cv ev 'if(is_callable(array("CRM_Core_BAO_CMSUser","synchronize"))){CRM_Core_BAO_CMSUser::synchronize(FALSE);}else{CRM_Utils_System::synchronizeUsers();}'
+
+wp role create civicrm_admin 'CiviCRM Administrator'
+wp cap add civicrm_admin \
+  read \
+  level_0
+wp cap add civicrm_admin \
+  access_ajax_api \
+  access_all_cases_and_activities \
+  access_all_custom_data \
+  access_civicontribute \
+  access_civicrm \
+  access_civievent \
+  access_civigrant \
+  access_civimail \
+  access_civimail_subscribe_unsubscribe_pages \
+  access_civimember \
+  access_civipledge \
+  access_civireport \
+  access_contact_dashboard \
+  access_contact_reference_fields \
+  access_deleted_contacts \
+  access_my_cases_and_activities \
+  access_report_criteria \
+  access_uploaded_files \
+  add_cases \
+  add_contacts \
+  administer_civicampaign \
+  administer_civicase \
+  administer_civicrm \
+  administer_dedupe_rules \
+  administer_reports \
+  administer_reserved_groups \
+  administer_reserved_reports \
+  administer_reserved_tags \
+  administer_tagsets \
+  create_manual_batch \
+  delete_activities \
+  delete_all_manual_batches \
+  delete_contacts \
+  delete_in_civicase \
+  delete_in_civicontribute \
+  delete_in_civievent \
+  delete_in_civigrant \
+  delete_in_civimail \
+  delete_in_civimember \
+  delete_in_civipledge \
+  delete_own_manual_batches \
+  edit_all_contacts \
+  edit_all_events \
+  edit_all_manual_batches \
+  edit_contributions \
+  edit_event_participants \
+  edit_grants \
+  edit_groups \
+  edit_memberships \
+  edit_own_manual_batches \
+  edit_pledges \
+  export_all_manual_batches \
+  export_own_manual_batches \
+  gotv_campaign_contacts \
+  import_contacts \
+  interview_campaign_contacts \
+  make_online_contributions \
+  manage_campaign \
+  merge_duplicate_contacts \
+  profile_create \
+  profile_edit \
+  profile_listings \
+  profile_listings_and_forms \
+  profile_view \
+  register_for_events \
+  release_campaign_contacts \
+  reserve_campaign_contacts \
+  sign_civicrm_petition \
+  translate_civicrm \
+  view_all_activities \
+  view_all_contacts \
+  view_all_manual_batches \
+  view_all_notes \
+  view_debug_output \
+  view_event_info \
+  view_event_participants \
+  view_own_manual_batches \
+  view_public_civimail_content
+
+wp user create "$DEMO_USER" "$DEMO_EMAIL" --role=civicrm_admin --user_pass="$DEMO_PASS"
+## Ceate anonymous user role
+wp eval '$c=[civi_wp()->users->set_wp_user_capabilities()];if (is_callable($c)) $c();'
+## Force basepage
+wp eval '$c=[civi_wp()->basepage->create_wp_basepage()];if (is_callable($c)) $c();'
+
+# Disable WP fatal error handler as it gets in the way of debugging.
+wp config set WP_DISABLE_FATAL_ERROR_HANDLER true --raw
+
+popd >> /dev/null

--- a/app/config/wp-clean/uninstall.sh
+++ b/app/config/wp-clean/uninstall.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+## uninstall.sh -- Delete config files and databases
+
+###############################################################################
+
+if [ -f "$CIVI_SETTINGS" ]; then
+  rm -f "$CIVI_SETTINGS"
+fi
+
+wp_uninstall
+amp_uninstall

--- a/app/config/wp-clean/wp-cli.yml
+++ b/app/config/wp-clean/wp-cli.yml
@@ -1,0 +1,1 @@
+apache_modules: [mod_rewrite]


### PR DESCRIPTION
This is basically `wp-demo`, with several elements removed.  It's intended
to parallel `drupal-clean` and (fingers-crossed) can be used for running
the full set of core-related test-suites.

