### PR TITLE
[WMFF] bring back harvey-dent

### DIFF
--- a/app/config/wmff/install.sh
+++ b/app/config/wmff/install.sh
@@ -39,7 +39,7 @@ CIVI_EXT_URL="${CMS_URL}/sites/default/civicrm/extensions"
 civicrm_install
 
 ## Comment out for now
-##"${WEB_ROOT}/sites/default/civicrm/extensions/rpow/bin/harvey-dent" --root "${WEB_ROOT}/drupal"
+"${WEB_ROOT}/drupal/sites/default/civicrm/extensions/rpow/bin/harvey-dent" --root "${WEB_ROOT}/drupal"
 echo "DROP DATABASE IF EXISTS fredge"| amp sql -N civi -a
 echo "CREATE DATABASE IF NOT EXISTS fredge"| amp sql -N civi -a
 eval mysql $CIVI_DB_ARGS <<EOSQL


### PR DESCRIPTION
This re-enables the line that installs harvey-dent. It was previously blocked on all that pre-create mysql stuff we recently got rid off breaking ci. This should now work with our CI - although we'll know once I merge it.

Note that harvey-dent is a script to set up the local dev database to similate the rpow extension - ie it creates 2 connections to the same database, one with only read permission

https://github.com/totten/rpow/