### PR TITLE
[WMFF] Move enabling of wmf-civicrm to buildkit

### DIFF
--- a/app/config/wmff/install.sh
+++ b/app/config/wmff/install.sh
@@ -49,9 +49,12 @@ EOSQL
 ###############################################################################
 ## Extra configuration
 pushd "$CMS_ROOT"
-drush -y en `cat sites/default/enabled_modules`
+drush -y en civicrm
+cv en --ignore-missing search search_kit wmf-civicrm
 
-drush -y updatedb
+drush -y en --debug `cat sites/default/enabled_modules`
+
+drush -y -v --debug updatedb
 
 ## Setup theme
 drush -y en tivy


### PR DESCRIPTION
This should work both before, and after, we remove it from wmf_civicrm (the module) install
but not until we merge the chain up until here

https: //gerrit.wikimedia.org/r/c/wikimedia/fundraising/crm/+/695709
