### PR TITLE
nix/profiles/edge - Bump NodeJS from v8 to v14

### DIFF
--- a/nix/profiles/edge/default.nix
+++ b/nix/profiles/edge/default.nix
@@ -7,12 +7,13 @@
 let
     pkgs = import (import ../../pins/19.09.nix) {};
     pkgs_1809 = import (import ../../pins/18.09.nix) {};
+    pkgs_2105 = import (import ../../pins/pre-21.05.nix) {};
     bkpkgs = import ../../pkgs;
 
 in (import ../base/default.nix) ++ (import ../mgmt/default.nix) ++ [
 
     bkpkgs.php80
-    pkgs_1809.nodejs-8_x
+    pkgs_2105.nodejs-14_x
     pkgs.apacheHttpd
     pkgs_1809.mailcatcher
     pkgs.memcached


### PR DESCRIPTION
If this works on `edge`, then we should bump up the {`max`,`dfl`} profiles as well.

See also: #633

CC @seamuslee001 