### PR TITLE
Dump stored procedures too when making snapshot

### DIFF
--- a/src/civibuild.lib.sh
+++ b/src/civibuild.lib.sh
@@ -419,7 +419,7 @@ function amp_snapshot_create() {
     echo "[[Save Civi DB ($CIVI_DB_NAME) to file ($CIVI_SQL)]]"
     cvutil_assertvars amp_snapshot_create CIVI_SQL CIVI_DB_ARGS CIVI_DB_NAME
     cvutil_makeparent "$CIVI_SQL"
-    cvutil_php_nodbg amp sql:dump --root="$CMS_ROOT" --passthru="--no-tablespaces" -Ncivi | gzip > "$CIVI_SQL"
+    cvutil_php_nodbg amp sql:dump --root="$CMS_ROOT" --passthru="--no-tablespaces --routines" -Ncivi | gzip > "$CIVI_SQL"
   fi
 }
 


### PR DESCRIPTION
Overview
----------
This is a bit speculative, but my theory is this is the cause of https://lab.civicrm.org/dev/core/-/issues/2692 and I can't think of a downside, and may help devs in a more general case.

BEFORE
---------
mysqldump will dump triggers by default but not stored procedures. Civi has civicrm_strip_non_numeric, so when reloading the snapshot, you lose the procedure.

AFTER
-------
Procedures are dumped and so also get reloaded if the db is restored.

Comments
------------
Another option would be for people's scripts to rebuild the triggers which recreates the stored procedure. But it seems more consistent to always dump what was already existing.