### PR TITLE
civicredits.php - Sorting for contributors should be case-insensitive

### DIFF
--- a/bin/civicredits.php
+++ b/bin/civicredits.php
@@ -36,7 +36,9 @@ $c['fmtNames()'] = function($ppl, $ids, $extras, SymfonyStyle $io) {
     $names[] = sprintf("%s - %s", $orgName, implode(', ', $orgPpl));
   }
 
-  sort($names);
+  usort($names, function($a,$b) {
+    return strnatcmp(mb_strtolower($a), mb_strtolower($b));
+  });
   return $names;
 };
 


### PR DESCRIPTION
It's common to have 1 or 2 usernames (lower-case) in a long list of titles
and full names (name-case).  The 1-2 look really odd if they're pushed to
the end.