### PR TITLE
nix - Enable `tidy` extension

### DIFF
--- a/nix/pkgs/php72/default.nix
+++ b/nix/pkgs/php72/default.nix
@@ -6,6 +6,7 @@ let
       config = {
         php = {
           mysqlnd = true;
+          tidy = true;
         };
       };
     };

--- a/nix/pkgs/php73/default.nix
+++ b/nix/pkgs/php73/default.nix
@@ -1,60 +1,23 @@
-# Make an own version of php with the new php.ini from above
-# add all extensions needed as buildInputs and don't forget to load them in the php.ini above
+# Make a version of php with extensions and php.ini options
 
 let
-    pkgs = import (import ../../pins/20.09.nix) {};
+    pkgs = import (import ../../pins/pre-21.05.nix) {};
     ## TEST ME: Do we need to set config.php.mysqlnd = true?
 
-    stdenv = pkgs.stdenv;
-
-    phpRuntime = pkgs.php73;
-    phpPkgs = pkgs.php73Extensions;
     phpExtras = import ../phpExtras/default.nix {
       pkgs = pkgs;
-      php = pkgs.php73; ## Hmm, a little bit loopy, but this effectively how other extensions resolve the loopines..
+      php = pkgs.php73; ## Compile PECL extensions with our preferred version of PHP
     };
 
-    phpIniSnippet = ../phpCommon/php.ini;
-    phpIni = pkgs.runCommand "php.ini"
-    { options = ''
-            zend_extension=${phpPkgs.xdebug}/lib/php/extensions/xdebug.so
-            extension=${phpPkgs.redis}/lib/php/extensions/redis.so
-            extension=${phpPkgs.yaml}/lib/php/extensions/yaml.so
-            extension=${phpPkgs.memcached}/lib/php/extensions/memcached.so
-            extension=${phpExtras.timecop}/lib/php/extensions/timecop.so
-            extension=${phpExtras.runkit7_3}/lib/php/extensions/runkit7.so
-
-            extension=${phpPkgs.apcu}/lib/php/extensions/apcu.so
-            extension=${phpPkgs.apcu_bc}/lib/php/extensions/apc.so
-            apc.enable_cli = ''${PHP_APC_CLI}
-
-            openssl.cafile=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt
-      ''
-
-       ## Per https://bugs.php.net/bug.php?id=77260 -- in php73, pcre.jit uses MAP_JIT which is quirky on diff versions of macOS
-       + (if stdenv.isDarwin then "pcre.jit=0\n" else "");
-
-       ## TEST ME: Do we still need imagick? Can we get away with gd nowadays?
-       #    extension=${phpPkgs.imagick}/lib/php/extensions/imagick.so
-    }
-    ''
-      cat "${phpRuntime}/etc/php.ini" > $out
-      echo "$options" >> $out
-      cat "${phpIniSnippet}" >> $out
+    phpIniSnippet1 = builtins.readFile ../phpCommon/php.ini;
+    phpIniSnippet2 = ''
+      apc.enable_cli = ''${PHP_APC_CLI}
     '';
 
-    phpOverride = stdenv.mkDerivation rec {
-        name = "bknix-php73";
-        ## TEST ME: Do we still need imagick? Can we get away with gd nowadays?
-        # buildInputs = [phpRuntime phpPkgs.xdebug phpPkgs.redis phpPkgs.apcu phpPkgs.apcu_bc phpPkgs.yaml phpPkgs.memcached phpPkgs.imagick phpExtras.timecop phpExtras.runkit7_3 pkgs.makeWrapper pkgs.cacert];
-        buildInputs = [phpRuntime phpPkgs.xdebug phpPkgs.redis phpPkgs.apcu phpPkgs.apcu_bc phpPkgs.yaml phpPkgs.memcached phpExtras.timecop phpExtras.runkit7_3 pkgs.makeWrapper pkgs.cacert];
-        buildCommand = ''
-          makeWrapper ${phpRuntime}/bin/phar $out/bin/phar
-          makeWrapper ${phpRuntime}/bin/php $out/bin/php --add-flags -c --add-flags "${phpIni}"
-          makeWrapper ${phpRuntime}/bin/php-cgi $out/bin/php-cgi --add-flags -c --add-flags "${phpIni}"
-          makeWrapper ${phpRuntime}/bin/php-fpm $out/bin/php-fpm --add-flags -c --add-flags "${phpIni}"
-          makeWrapper ${phpRuntime}/bin/phpdbg $out/bin/phpdbg --add-flags -c --add-flags "${phpIni}"
-        '';
-    };
+in pkgs.php73.buildEnv {
 
-in phpOverride
+  ## EVALUATE: apcu_bc
+  extensions = { all, enabled}: with all; enabled++ [ phpExtras.xdebug2 redis tidy apcu apcu_bc yaml memcached imagick opcache phpExtras.runkit7_3 phpExtras.timecop ];
+  extraConfig = phpIniSnippet1 + phpIniSnippet2;
+
+}

--- a/nix/pkgs/php74/default.nix
+++ b/nix/pkgs/php74/default.nix
@@ -17,7 +17,7 @@ let
 in pkgs.php74.buildEnv {
 
   ## EVALUATE: apcu_bc
-  extensions = { all, enabled}: with all; enabled++ [ xdebug redis apcu apcu_bc yaml memcached imagick opcache phpExtras.runkit7_3 phpExtras.timecop ];
+  extensions = { all, enabled}: with all; enabled++ [ xdebug redis tidy apcu apcu_bc yaml memcached imagick opcache phpExtras.runkit7_3 phpExtras.timecop ];
   extraConfig = phpIniSnippet1 + phpIniSnippet2;
 
 }

--- a/nix/pkgs/php80/default.nix
+++ b/nix/pkgs/php80/default.nix
@@ -17,7 +17,7 @@ let
 in pkgs.php80.buildEnv {
 
   ## EVALUATE: apcu_bc
-  extensions = { all, enabled}: with all; enabled++ [ xdebug redis apcu yaml memcached imagick opcache phpExtras.runkit7_4 ];
+  extensions = { all, enabled}: with all; enabled++ [ xdebug redis tidy apcu yaml memcached imagick opcache phpExtras.runkit7_4 ];
   extraConfig = phpIniSnippet1 + phpIniSnippet2;
 
 }

--- a/nix/pkgs/phpExtras/default.nix
+++ b/nix/pkgs/phpExtras/default.nix
@@ -70,4 +70,13 @@ in rec {
     buildInputs = [ ];
   };
 
+  xdebug2 = buildPecl {
+    version = "2.8.1";
+    pname = "xdebug";
+    sha256 = "080mwr7m72rf0jsig5074dgq2n86hhs7rdbfg6yvnm959sby72w3";
+    doCheck = true;
+    checkTarget = "test";
+    zendExtension = true;
+  };
+
 }


### PR DESCRIPTION
This enables the `tidy` extension for use in E2E unit-tests. Applies update to `php72` - `php80`.

```
totten@localhost:~/bknix/nix$ for PRF in min dfl max edge; do nix-shell -A $PRF --command 'php -r "var_export([PHP_VERSION, class_exists(\"tidy\")]);"' ; echo; echo ; done
array (
  0 => '7.2.23',
  1 => true,
)

array (
  0 => '7.3.28',
  1 => true,
)

array (
  0 => '7.4.18',
  1 => true,
)

Xdebug: [Step Debug] Could not connect to debugging client. Tried: localhost:9000 (through xdebug.client_host/xdebug.client_port) :-(
Xdebug: [Step Debug] Could not connect to debugging client. Tried: localhost:9000 (through xdebug.client_host/xdebug.client_port) :-(
array (
  0 => '8.0.5',
  1 => true,
)
```

Note: (1) The xdebug errors are pre-existing issues `php80`. (2) To see that `php73` builds, I locally edited the `dfl` profile to use `php73`.