### PR TITLE
nix/profiles - Update various packages to match v21.05

### DIFF
--- a/nix/pins/21.05.nix
+++ b/nix/pins/21.05.nix
@@ -1,0 +1,7 @@
+/**
+ * v21.05, with official backports circa Sep 24 2021
+ */
+fetchTarball {
+  url = "https://github.com/nixos/nixpkgs/archive/df409303ab906216e7fb04fd0cbfd73f03aff1f7.tar.gz";
+  sha256 = "09cr2lxnp8m406nb4ka1kja62cl5cxzh9dl1g57s2k86313sw37p";
+}

--- a/nix/pins/pre-21.05.nix
+++ b/nix/pins/pre-21.05.nix
@@ -1,9 +1,0 @@
-/**
- * PHP 8.0 pre-release of 21.05 nix 
- *
- * See: https://github.com/NixOS/nixpkgs/pull/104159
- */
-fetchTarball {
-  url = "https://github.com/nixos/nixpkgs/archive/594fbfe27905f2fd98d9431038814e497b4fcad1.tar.gz";
-  sha256 = "1lqcw9355ibydqj0zbxhzdqvawx980m6ahjny8ghhw4899nbmhys";
-}

--- a/nix/pkgs/php73/default.nix
+++ b/nix/pkgs/php73/default.nix
@@ -1,7 +1,7 @@
 # Make a version of php with extensions and php.ini options
 
 let
-    pkgs = import (import ../../pins/pre-21.05.nix) {};
+    pkgs = import (import ../../pins/21.05.nix) {};
     ## TEST ME: Do we need to set config.php.mysqlnd = true?
 
     phpExtras = import ../phpExtras/default.nix {

--- a/nix/pkgs/php74/default.nix
+++ b/nix/pkgs/php74/default.nix
@@ -1,7 +1,7 @@
 # Make a version of php with extensions and php.ini options
 
 let
-    pkgs = import (import ../../pins/pre-21.05.nix) {};
+    pkgs = import (import ../../pins/21.05.nix) {};
     ## TEST ME: Do we need to set config.php.mysqlnd = true?
 
     phpExtras = import ../phpExtras/default.nix {

--- a/nix/pkgs/php80/default.nix
+++ b/nix/pkgs/php80/default.nix
@@ -1,7 +1,7 @@
 # Make a version of php with extensions and php.ini options
 
 let
-    pkgs = import (import ../../pins/pre-21.05.nix) {};
+    pkgs = import (import ../../pins/21.05.nix) {};
     ## TEST ME: Do we need to set config.php.mysqlnd = true?
 
     phpExtras = import ../phpExtras/default.nix {

--- a/nix/profiles/dfl/default.nix
+++ b/nix/profiles/dfl/default.nix
@@ -7,7 +7,7 @@
 let
     pkgs = import (import ../../pins/19.09.nix) {};
     pkgs_1809 = import (import ../../pins/18.09.nix) {};
-    pkgs_2105 = import (import ../../pins/pre-21.05.nix) {};
+    pkgs_2105 = import (import ../../pins/21.05.nix) {};
     bkpkgs = import ../../pkgs;
 
 in (import ../base/default.nix) ++ (import ../mgmt/default.nix) ++ [

--- a/nix/profiles/dfl/default.nix
+++ b/nix/profiles/dfl/default.nix
@@ -14,7 +14,7 @@ in (import ../base/default.nix) ++ (import ../mgmt/default.nix) ++ [
 
     bkpkgs.php72
     pkgs_2105.nodejs-14_x
-    pkgs.apacheHttpd
+    pkgs_2105.apacheHttpd
     pkgs_1809.mailcatcher
     pkgs.memcached
     pkgs_1809.mysql57

--- a/nix/profiles/edge/default.nix
+++ b/nix/profiles/edge/default.nix
@@ -16,10 +16,10 @@ in (import ../base/default.nix) ++ (import ../mgmt/default.nix) ++ [
     pkgs_2105.nodejs-14_x
     pkgs_2105.apacheHttpd
     pkgs_1809.mailcatcher
-    pkgs.memcached
+    pkgs_2105.memcached
     /* pkgs.mariadb */
     bkpkgs.mysql80
-    pkgs.redis
+    pkgs_2105.redis
     bkpkgs.transifexClient
 
 ]

--- a/nix/profiles/edge/default.nix
+++ b/nix/profiles/edge/default.nix
@@ -7,7 +7,7 @@
 let
     pkgs = import (import ../../pins/19.09.nix) {};
     pkgs_1809 = import (import ../../pins/18.09.nix) {};
-    pkgs_2105 = import (import ../../pins/pre-21.05.nix) {};
+    pkgs_2105 = import (import ../../pins/21.05.nix) {};
     bkpkgs = import ../../pkgs;
 
 in (import ../base/default.nix) ++ (import ../mgmt/default.nix) ++ [

--- a/nix/profiles/edge/default.nix
+++ b/nix/profiles/edge/default.nix
@@ -14,7 +14,7 @@ in (import ../base/default.nix) ++ (import ../mgmt/default.nix) ++ [
 
     bkpkgs.php80
     pkgs_2105.nodejs-14_x
-    pkgs.apacheHttpd
+    pkgs_2105.apacheHttpd
     pkgs_1809.mailcatcher
     pkgs.memcached
     /* pkgs.mariadb */

--- a/nix/profiles/max/default.nix
+++ b/nix/profiles/max/default.nix
@@ -7,7 +7,7 @@
 let
     pkgs = import (import ../../pins/19.09.nix) {};
     pkgs_1809 = import (import ../../pins/18.09.nix) {};
-    pkgs_2105 = import (import ../../pins/pre-21.05.nix) {};
+    pkgs_2105 = import (import ../../pins/21.05.nix) {};
     bkpkgs = import ../../pkgs;
 
 in (import ../base/default.nix) ++ (import ../mgmt/default.nix) ++ [

--- a/nix/profiles/max/default.nix
+++ b/nix/profiles/max/default.nix
@@ -14,7 +14,7 @@ in (import ../base/default.nix) ++ (import ../mgmt/default.nix) ++ [
 
     bkpkgs.php74
     pkgs_2105.nodejs-14_x
-    pkgs.apacheHttpd
+    pkgs_2105.apacheHttpd
     pkgs_1809.mailcatcher
     pkgs.memcached
     pkgs.mysql57

--- a/nix/profiles/min/default.nix
+++ b/nix/profiles/min/default.nix
@@ -7,7 +7,7 @@
 let
     pkgs = import (import ../../pins/19.09.nix) {};
     pkgs_1809 = import (import ../../pins/18.09.nix) {};
-    pkgs_2105 = import (import ../../pins/pre-21.05.nix) {};
+    pkgs_2105 = import (import ../../pins/21.05.nix) {};
     bkpkgs = import ../../pkgs;
 
 in (import ../base/default.nix) ++ (import ../mgmt/default.nix) ++ [

--- a/nix/profiles/min/default.nix
+++ b/nix/profiles/min/default.nix
@@ -14,7 +14,7 @@ in (import ../base/default.nix) ++ (import ../mgmt/default.nix) ++ [
 
     bkpkgs.php72
     pkgs_2105.nodejs-14_x
-    pkgs.apacheHttpd
+    pkgs_2105.apacheHttpd
     pkgs_1809.mailcatcher
     pkgs.memcached
     bkpkgs.mysql56

--- a/nix/profiles/old/default.nix
+++ b/nix/profiles/old/default.nix
@@ -13,7 +13,7 @@ in (import ../base/default.nix) ++ (import ../mgmt/default.nix) ++ [
 
     bkpkgs.php71
     pkgs_2105.nodejs-14_x
-    pkgs.apacheHttpd
+    pkgs_2105.apacheHttpd
     pkgs_1809.mailcatcher
     pkgs.memcached
     bkpkgs.mysql55

--- a/nix/profiles/old/default.nix
+++ b/nix/profiles/old/default.nix
@@ -6,7 +6,7 @@
 let
     pkgs = import (import ../../pins/18.03.nix) {};
     pkgs_1809 = import (import ../../pins/18.09.nix) {};
-    pkgs_2105 = import (import ../../pins/pre-21.05.nix) {};
+    pkgs_2105 = import (import ../../pins/21.05.nix) {};
     bkpkgs = import ../../pkgs;
 
 in (import ../base/default.nix) ++ (import ../mgmt/default.nix) ++ [


### PR DESCRIPTION
# Before

Pin to a pre-release of nixpkgs-21.05 which affects:

* php73/php74/php80

# After

Pin to a post-release of nixpkgs-21.05 (ie 21.05 plus official backports) which affects:

* php73/php74/php80
* apacheHttpd
* redis and memcached (but only in the `edge` profile; there's no specific need, but it's good to test on newer version)