### PR TITLE
drush8 - Use pre-release based on 8.4.x branch.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
       "codecept-php5": {"version": "2.3.6", "url": "https://codeception.com/releases/{$version}/php54/codecept.phar", "path": "bin/_codecept-php5.phar", "type": "phar"},
       "codecept-php7": {"version": "2.3.6", "url": "https://codeception.com/releases/{$version}/codecept.phar", "path": "bin/_codecept-php7.phar", "type": "phar"},
       "cv": {"version": "2021-10-14-7b065b9c", "url": "https://download.civicrm.org/cv/cv.phar-{$version}", "path": "bin/cv", "type": "phar"},
-      "drush8": {"version": "8.4.0", "url": "https://github.com/drush-ops/drush/releases/download/{$version}/drush.phar", "path": "extern/drush8.phar", "type": "phar"},
+      "drush8": {"version": "8.4.9-dev0", "url": "https://storage.googleapis.com/civicrm/drush/drush.phar-{$version}", "path": "extern/drush8.phar", "type": "phar"},
       "drush-backdrop": {"version": "1.0.0", "url": "https://github.com/backdrop-contrib/drush/archive/{$version}.zip", "path": "extern/drush-lib/backdrop"},
       "git-scan": {"version": "2021-06-28-92b3e512", "url": "https://download.civicrm.org/git-scan/git-scan.phar-{$version}", "path": "bin/git-scan", "type": "phar"},
       "phpunit4": {"version": "4.8.21", "url": "https://phar.phpunit.de/phpunit-{$version}.phar", "path": "extern/phpunit4/phpunit4.phar", "type": "phar"},

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "33c82e59961b04def8a786f03e82b582",
+    "content-hash": "2eb043396b6575ca09689f46bd822589",
     "packages": [
         {
             "name": "civicrm/composer-downloads-plugin",
@@ -74,7 +74,6 @@
                 "reference": "318cb5d9cecd75b83bbceb999735fd62dfe2ae7a",
                 "shasum": ""
             },
-            "default-branch": true,
             "bin": [
                 "civicrm-upgrade-test"
             ],
@@ -91,9 +90,6 @@
             ],
             "description": "Collection of scripts and data-files for testing CiviCRM upgrades",
             "homepage": "https://github.com/civicrm/civicrm-upgrade-test",
-            "support": {
-                "source": "https://github.com/civicrm/civicrm-upgrade-test/tree/master"
-            },
             "time": "2021-06-03T02:50:54+00:00"
         },
         {
@@ -113,7 +109,6 @@
             "require-dev": {
                 "phpunit/phpunit": ">=3.7 <6"
             },
-            "default-branch": true,
             "type": "phpcodesniffer-standard",
             "autoload": {
                 "psr-0": {
@@ -419,7 +414,6 @@
             "require": {
                 "nikic/php-parser": "^1.4"
             },
-            "default-branch": true,
             "bin": [
                 "bin/php-symbol-diff",
                 "bin/git-php-symbol-diff"
@@ -441,11 +435,7 @@
                 }
             ],
             "description": "Identify changes in PHP code by symbol (class/method)",
-            "support": {
-                "issues": "https://github.com/totten/php-symbol-diff/issues",
-                "source": "https://github.com/totten/php-symbol-diff/tree/master"
-            },
-            "time": "2018-05-04T22:36:55+00:00"
+            "time": "2015-08-06T08:23:13+00:00"
         }
     ],
     "packages-dev": [],
@@ -465,5 +455,5 @@
     "platform-overrides": {
         "php": "7.1"
     },
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "1.1.0"
 }


### PR DESCRIPTION
@seamuslee001 sent a patch for drush8 to improve php80.  It was merged by upstream but has been waiting for a release.

Go ahead and use a pre-release build.