### PR TITLE
dev/core#2998 Towards CiviCRM Standalone support

### DIFF
--- a/app/config/standalone-clean/download.sh
+++ b/app/config/standalone-clean/download.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+## download.sh -- Download Standalone project and CiviCRM core
+
+###############################################################################
+
+# @todo Requires that we register with packagist?
+# mkdir "$WEB_ROOT"
+# composer create-project mlutfy/civicrm-standalone "$WEB_ROOT" --no-interaction
+git clone https://github.com/mlutfy/civicrm-standalone $WEB_ROOT
+cd $WEB_ROOT
+composer install

--- a/app/config/standalone-clean/install.sh
+++ b/app/config/standalone-clean/install.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+## install.sh -- Create config files and databases; fill the databases
+[ -d "$WEB_ROOT/web" ] && CMS_ROOT="$WEB_ROOT/web"
+
+###############################################################################
+## Create virtual-host and databases
+
+amp_install
+
+###############################################################################
+## Setup CiviCRM (config files, database tables)
+
+CIVI_DOMAIN_NAME="Demonstrators Anonymous"
+CIVI_DOMAIN_EMAIL="\"Demonstrators Anonymous\" <info@example.org>"
+CIVI_CORE="${WEB_ROOT}/vendor/civicrm/civicrm-core"
+CIVI_UF="Standalone"
+GENCODE_CONFIG_TEMPLATE="${CMS_ROOT}/civicrm.config.php.standalone"
+
+civicrm_install_cv
+
+###############################################################################
+## Extra configuration
+# @todo Setup demo user


### PR DESCRIPTION
It works up to the point where it call `cv`, which cannot detect the CMS.

I then proceeded to complete the install by:

* Fetching the DB credentials from `~/.amp/instances.yml`
* `chgrp -R www-data builds/mysite/data`
* `chmod -R g+w builds/mysite/data`
* Complete the setup using the web UI

There are some "todos":

- we cannot `composer create-project` yet (package should be registered with packagist?)
- there is no user management yet

cc @demeritcowboy @totten @homotechsual 