### PR TITLE
fix add_wpload_setting - to prevent fatal errors in E2E testing

### DIFF
--- a/app/config/wp-demo/install.sh
+++ b/app/config/wp-demo/install.sh
@@ -57,7 +57,7 @@ wp theme install twentythirteen --activate
 wp eval '$home = get_page_by_title("Welcome to CiviCRM with WordPress"); update_option("page_on_front", $home->ID); update_option("show_on_front", "page");'
 
 wp plugin activate civicrm
-wp eval '$c=[civi_wp(), "add_wpload_setting"]; if (is_callable($c)) $c();' ## Temporary workaround, init wpLoadPh
+wp eval '$c=[civi_wp()->admin, "add_wpload_setting"]; if (is_callable($c)) $c();'
 wp plugin activate civicrm-demo-wp
 wp plugin install civicrm-admin-utilities
 wp plugin install gutenberg


### PR DESCRIPTION
@christianwach pointed out that he saw  fatal errors on PR builds due to the way we call  `add_wpload_setting`   I've updated to the sysntax that is currently working for me locally.