### PR TITLE
dev/core#2773 Add a new user to the drupal demo install 'advisor'

### DIFF
--- a/app/config/drupal-demo/install-welcome.php
+++ b/app/config/drupal-demo/install-welcome.php
@@ -25,7 +25,7 @@ Just login with...
 ... and click the <a href="/civicrm"><strong>CiviCRM</strong></a> link (upper left-hand corner of your screen)
 
 <p><strong>Any data you enter on this demo site is "publicly available" due to the open login. Please do not enter real email addresses or other personal information.</strong> The demo database is reset periodically.</p>
-
+<p>There is also a user with the username advisor and the password advisor who has more limited access granted by Access Control</p>
 <h3>New to CiviCRM?</h3>
 <ul>
 <li>Learn about how you can use CiviCRM from our new <strong><a href="https://docs.civicrm.org/user/en/stable/" target="_blank" title="Opens Understanding CiviCRM book in a new window">online book</a></strong>.</li>

--- a/app/config/drupal-demo/install.sh
+++ b/app/config/drupal-demo/install.sh
@@ -79,6 +79,25 @@ pushd "${CMS_ROOT}/sites/${DRUPAL_SITE_DIR}" >> /dev/null
     remove "change own password"
 EOPERM
 
+ ## Setup advisor user
+  # This gives us a user with more limited permissions.
+  # specifically the user does not have 'edit all contacts'
+  # or 'view all contacts'. However, they will be able to view
+  # some by virtue of an acl
+  drush role-create advisor
+  drush scr "$PRJDIR/src/drush/perm.php" <<EOPERM
+    role "advisor"
+    add 'access toolbar'
+    add "access CiviCRM"
+    add "access CiviReport"
+    add 'view debug output'
+    add 'access CiviContribute'
+    add 'view report sql'
+    add 'merge duplicate contacts'
+EOPERM
+  drush -y user-create --password="advisor" --mail="jenny@example.com" "advisor"
+  drush -y user-add-role advisor "advisor"
+
   ## Setup demo user
   drush -y en civicrm_webtest
   drush -y user-create --password="$DEMO_PASS" --mail="$DEMO_EMAIL" "$DEMO_USER"


### PR DESCRIPTION
This creates a new user 'advisor' password 'advisor' with the email jenny@example.com.

In conjunction with https://github.com/civicrm/civicrm-core/pull/22377 this new login gets ACL limited
access to contacts rather than 'view all' - this makes testing easier

Note the key thing I was trying to set up is an ACL limited user. The user also only has access to view contributions - but this could morph over time if we find other configs more useful

![image](https://user-images.githubusercontent.com/336308/148153494-aa4c0c2e-1f4d-4cc6-8ad6-27238a3b6a09.png)
