### PR TITLE
Give demo user permission to close & edit own batches

### DIFF
--- a/app/config/drupal-demo/install.sh
+++ b/app/config/drupal-demo/install.sh
@@ -122,6 +122,8 @@ EOPERM
     add 'access CiviGrant'
     add 'edit grants'
     add 'delete in CiviGrant'
+    add 'close own manual batches'
+    add 'edit own manual batches'
 EOPERM
   ## Note: If you enable CiviGrant, the grant 'access CiviGrant', 'edit grants', 'delete in CiviGrant'
 


### PR DESCRIPTION
As an aside they already have this in d8 & still don't in wordpress. At some point
we should use a config file that they all read for users, roles & permissions
but it's a bit of a lift.

