### PR TITLE
app/config/drupal-clean - Use CV for installation

### DIFF
--- a/app/config/drupal-clean/download.sh
+++ b/app/config/drupal-clean/download.sh
@@ -20,6 +20,9 @@ pushd "$WEB_ROOT/web"
 
     extract-url --cache-ttl 172800 civicrm=http://download.civicrm.org/civicrm-l10n-core/archives/civicrm-l10n-daily.tar.gz
     ## or https://raw.github.com/civicrm/l10n/master/po/fr_CA/civicrm.mo => civicrm/l10n/fr_CA/LC_MESSAGES/
+    pushd civicrm
+      composer install
+    popd
   popd
 
 popd

--- a/app/config/drupal-clean/install.sh
+++ b/app/config/drupal-clean/install.sh
@@ -38,6 +38,11 @@ civicrm_install_cv
 
 ###############################################################################
 ## Extra configuration
+pushd "$CIVI_CORE" >> /dev/null
+  ## Generating `civicrm.config.php` is necessary for `extern/*.php` and its E2E tests
+  ./bin/setup.sh -g
+popd >> /dev/null
+
 pushd "${CMS_ROOT}/sites/${DRUPAL_SITE_DIR}" >> /dev/null
 
   drush -y updatedb

--- a/app/config/drupal-clean/install.sh
+++ b/app/config/drupal-clean/install.sh
@@ -34,18 +34,23 @@ if [[ "$CIVI_VERSION" =~ ^4.[0123456](\.([0-9]|alpha|beta)+)?$ ]] ; then
   CIVI_EXT_URL="${CMS_URL}/sites/${DRUPAL_SITE_DIR}/ext"
 fi
 
-civicrm_install
+civicrm_install_cv
 
 ###############################################################################
 ## Extra configuration
 pushd "${CMS_ROOT}/sites/${DRUPAL_SITE_DIR}" >> /dev/null
 
   drush -y updatedb
+  drush -y cc all
   drush -y en civicrm toolbar locale garland
   ## disable annoying/unneeded modules
   drush -y dis overlay
 
   cv ev 'if(is_callable(array("CRM_Core_BAO_CMSUser","synchronize"))){CRM_Core_BAO_CMSUser::synchronize(FALSE);}else{CRM_Utils_System::synchronizeUsers();}'
+
+  ## Setup CiviCRM
+  echo '{"enable_components":["CiviEvent","CiviContribute","CiviMember","CiviMail","CiviReport","CiviPledge","CiviCase","CiviCampaign","CiviGrant"]}' \
+    | drush cvapi setting.create --in=json
 
   ## Setup theme
   #above# drush -y en garland

--- a/app/config/drupal-clean/install.sh
+++ b/app/config/drupal-clean/install.sh
@@ -41,7 +41,6 @@ civicrm_install_cv
 pushd "${CMS_ROOT}/sites/${DRUPAL_SITE_DIR}" >> /dev/null
 
   drush -y updatedb
-  drush -y cc all
   drush -y en civicrm toolbar locale garland
   ## disable annoying/unneeded modules
   drush -y dis overlay


### PR DESCRIPTION
Rebased/reopened @seamuslee001's #661. 

@seamuslee001 I tried the changes out locally and found an issue.

```
civibuild create tmp --type drupal-clean
civi-test-run -b tmp -j /tmp/junit phpunit-e2e
```

This gave several errors in `tests/phpunit/E2E/Extern/*`, eg

```
E2E_Extern_LegacyRestTest::testAPICalls with data set #0 (array('Contact', 'get', 'pakK68PIjWzYIMG3', '1'), 1)

        (
            [entity] => Contact
            [action] => get
            [key] => pakK68PIjWzYIMG3
            [json] => 1
        )

    [response data] => ...(SNIP-HTML)...
Fatal error: require_once(): Failed opening required '../civicrm.config.php' (include_path='.:/nix/store/0jjkqmqgf80ww3gvch8jwcgmknmvfn8x-php-7.2.23/lib/php') in /home/totten/bknix/build/tmp/web/sites/all/modules/civicrm/extern/rest.php on line
...(SNIP-HTML)...
)
```

This makes sense - as we discussed on #661, it was skipping `setup.sh` completely. So I threw in a lighter call (`setup.sh -g`), and now it seems good with `civi-test-run ... phpunit-e2e`.

I'm having trouble, though, with `civi-test-run ... karma`. I think that's something with my workstation (55/81 tests fail - on both `master` and `drupal_clean_install-cv`), so it might help if you tried it too. 
