### PR TITLE
app/config/backdrop* - Remove/replace drush calls

### DIFF
--- a/app/config/backdrop-clean/install.sh
+++ b/app/config/backdrop-clean/install.sh
@@ -40,11 +40,8 @@ pushd "$CMS_ROOT" >> /dev/null
   fi
 
   ## Setup demo user
-  # drush -y en civicrm_webtest
-  drush -y user-create --password="$DEMO_PASS" --mail="$DEMO_EMAIL" "$DEMO_USER"
+  backdrop_user "$DEMO_USER" "$DEMO_EMAIL" "$DEMO_PASS"
   if [ $phpversioncheck ]; then
-    echo 'INSERT IGNORE INTO users_roles (uid,role) SELECT uid, "civicrm_webtest_user" FROM users WHERE name = @ENV[DEMO_USER];' \
-      | env DEMO_USER="$DEMO_USER" amp sql -Ncms -e
-    #drush -y user-add-role civicrm_webtest_user "$DEMO_USER"
+    backdrop_user_role "$DEMO_USER" "civicrm_webtest_user"
   fi
 popd >> /dev/null

--- a/app/config/backdrop-demo/install.sh
+++ b/app/config/backdrop-demo/install.sh
@@ -35,7 +35,7 @@ pushd "$CMS_ROOT" >> /dev/null
   php "$SITE_CONFIG_DIR/module-enable.php" civicrm
   ## Setup CiviCRM
   echo '{"enable_components":["CiviEvent","CiviContribute","CiviMember","CiviMail","CiviReport","CiviPledge","CiviCase","CiviCampaign","CiviGrant"]}' \
-    | drush cvapi setting.create --in=json
+    | cv api setting.create --in=json
   civicrm_apply_demo_defaults
   ver=$(civicrm_get_ver "$CIVI_CORE")
   phpversioncheck=$(php -r "echo version_compare('$ver', '5.19', '>=');")
@@ -44,7 +44,7 @@ pushd "$CMS_ROOT" >> /dev/null
   fi
 
   ## Setup welcome page
-  drush -y scr "$SITE_CONFIG_DIR/install-welcome.php"
+  cv scr "$SITE_CONFIG_DIR/install-welcome.php"
 
   ## Setup demo user
   backdrop_user "$DEMO_USER" "$DEMO_EMAIL" "$DEMO_PASS"
@@ -56,10 +56,10 @@ pushd "$CMS_ROOT" >> /dev/null
   cv en --ignore-missing $CIVI_DEMO_EXTS
 
   ## Demo sites always disable email and often disable cron
-  drush cvapi StatusPreference.create ignore_severity=critical name=checkOutboundMail
-  drush cvapi StatusPreference.create ignore_severity=critical name=checkLastCron
+  cv api StatusPreference.create ignore_severity=critical name=checkOutboundMail
+  cv api StatusPreference.create ignore_severity=critical name=checkLastCron
 
   ## Setup CiviCRM dashboards
-  INSTALL_DASHBOARD_USERS="$ADMIN_USER;$DEMO_USER" drush scr "$SITE_CONFIG_DIR/install-dashboard.php"
+  INSTALL_DASHBOARD_USERS="$ADMIN_USER;$DEMO_USER" cv scr "$SITE_CONFIG_DIR/install-dashboard.php"
 
 popd >> /dev/null

--- a/app/config/backdrop-demo/install.sh
+++ b/app/config/backdrop-demo/install.sh
@@ -47,11 +47,9 @@ pushd "$CMS_ROOT" >> /dev/null
   drush -y scr "$SITE_CONFIG_DIR/install-welcome.php"
 
   ## Setup demo user
-  drush -y user-create --password="$DEMO_PASS" --mail="$DEMO_EMAIL" "$DEMO_USER"
+  backdrop_user "$DEMO_USER" "$DEMO_EMAIL" "$DEMO_PASS"
   if [ $phpversioncheck ]; then
-    echo 'INSERT IGNORE INTO users_roles (uid,role) SELECT uid, "civicrm_webtest_user" FROM users WHERE name = @ENV[DEMO_USER];' \
-      | env DEMO_USER="$DEMO_USER" amp sql -Ncms -e
-    #drush -y user-add-role civicrm_webtest_user "$DEMO_USER"
+    backdrop_user_role "$DEMO_USER" "civicrm_webtest_user"
   fi
 
   ## Setup demo extensions

--- a/app/config/backdrop-empty/install.sh
+++ b/app/config/backdrop-empty/install.sh
@@ -20,5 +20,5 @@ backdrop_install
 ## Extra configuration
 
 pushd "$CMS_ROOT" >> /dev/null
-  drush -y user-create --password="$DEMO_PASS" --mail="$DEMO_EMAIL" "$DEMO_USER"
+  backdrop_user "$DEMO_USER" "$DEMO_EMAIL" "$DEMO_PASS"
 popd >> /dev/null

--- a/src/civibuild.lib.sh
+++ b/src/civibuild.lib.sh
@@ -706,7 +706,7 @@ function civicrm_apply_demo_defaults() {
   cv api MailSettings.create id=1 is_default=1 domain=example.org debug=1
   cv en --ignore-missing 'civigrant'
   if [ -z "$NO_SAMPLE_DATA" ]; then
-    cv -vv ev 'eval(file_get_contents("php://stdin"));' <<EOPHP
+    cv -v ev 'eval(file_get_contents("php://stdin"));' <<EOPHP
       \$cid = civicrm_api3('Domain', 'getvalue', array(
         'id' => 1,
         'return' => 'contact_id'

--- a/src/civibuild.lib.sh
+++ b/src/civibuild.lib.sh
@@ -1033,6 +1033,22 @@ function backdrop_uninstall() {
 }
 
 ###############################################################################
+## Backdrop - Create a user
+## usage: backdrop_user USERNAME EMAIL PASSWORD
+function backdrop_user() {
+  env NEW_USER="$1" NEW_EMAIL="$2" NEW_PASS="$3" \
+    cv ev --user=admin '$ps=["name"=>getenv("NEW_USER"), "mail"=>getenv("NEW_EMAIL"), "pass"=>getenv("NEW_PASS")]; $u=entity_create("user", $ps); $u->save();'
+}
+
+###############################################################################
+## Add a role to a user
+## usage: backdrop_user_role USERNAME ROLENAME
+function backdrop_user_role() {
+  echo 'INSERT IGNORE INTO users_roles (uid,role) SELECT uid, @ENV[THE_ROLE] FROM users WHERE name = @ENV[THE_USER];' \
+    | env THE_USER="$1" THE_ROLE="$2" amp sql -Ncms -e
+}
+
+###############################################################################
 ## Backdrop - Download to WEB_ROOT/web. Apply core patches (eg for MySQL 8) as required.
 function backdrop_download() {
   cvutil_assertvars backdrop_download WEB_ROOT CMS_VERSION PRJDIR CACHE_DIR


### PR DESCRIPTION
The `backdrop-drush` integration has an open issue with php8 (eg https://github.com/backdrop-contrib/backdrop-drush-extension/pull/251), which is fairly problematic since we're using php8 for a lot of test environments. This has been obfuscating test-runs for Civi-BD.

With this change, the Backdrop builds no longer need to use `backdrop-drush` for installation. (`backdrop-drush` is still bundled, of course; so in any use-cases where it uses `backdrop-drush`, and where that's currently working, it should continue as before.)