### PR TITLE
drupal*-demo - Fix permission error when building on 5.45/5.46

### DIFF
--- a/app/config/drupal-demo/install.sh
+++ b/app/config/drupal-demo/install.sh
@@ -47,8 +47,13 @@ pushd "${CMS_ROOT}/sites/${DRUPAL_SITE_DIR}" >> /dev/null
   drush -y dis overlay
 
   ## Setup CiviCRM
-  echo '{"enable_components":["CiviEvent","CiviContribute","CiviMember","CiviMail","CiviReport","CiviPledge","CiviCase","CiviCampaign"]}' \
-    | drush cvapi setting.create --in=json
+  if cv ev 'exit(version_compare(CRM_Utils_System::version(), "5.47.alpha", "<") ?0:1);' ; then
+    echo '{"enable_components":["CiviEvent","CiviContribute","CiviMember","CiviMail","CiviReport","CiviPledge","CiviCase","CiviCampaign","CiviGrant"]}' \
+      | drush cvapi setting.create --in=json
+  else
+    echo '{"enable_components":["CiviEvent","CiviContribute","CiviMember","CiviMail","CiviReport","CiviPledge","CiviCase","CiviCampaign"]}' \
+      | drush cvapi setting.create --in=json
+  fi
   ## Note: CiviGrant disabled by default. If you enable, update the permissions as well.
   civicrm_apply_demo_defaults
   cv ev 'if(is_callable(array("CRM_Core_BAO_CMSUser","synchronize"))){CRM_Core_BAO_CMSUser::synchronize(FALSE);}else{CRM_Utils_System::synchronizeUsers();}'

--- a/app/config/drupal8-demo/install.sh
+++ b/app/config/drupal8-demo/install.sh
@@ -38,8 +38,13 @@ pushd "${CMS_ROOT}/sites/${DRUPAL_SITE_DIR}" >> /dev/null
   drush8 cc drush -y
 
   ## Setup CiviCRM
-  echo '{"enable_components":["CiviEvent","CiviContribute","CiviMember","CiviMail","CiviReport","CiviPledge","CiviCase","CiviCampaign"]}' \
-    | drush8 cvapi setting.create --in=json
+  if cv ev 'exit(version_compare(CRM_Utils_System::version(), "5.47.alpha", "<") ?0:1);' ; then
+    echo '{"enable_components":["CiviEvent","CiviContribute","CiviMember","CiviMail","CiviReport","CiviPledge","CiviCase","CiviCampaign","CiviGrant"]}' \
+      | drush8 cvapi setting.create --in=json
+  else 
+    echo '{"enable_components":["CiviEvent","CiviContribute","CiviMember","CiviMail","CiviReport","CiviPledge","CiviCase","CiviCampaign"]}' \
+      | drush8 cvapi setting.create --in=json
+  fi
   civicrm_apply_demo_defaults
   cv ev 'return CRM_Utils_System::synchronizeUsers();'
 

--- a/app/config/drupal9-demo/install.sh
+++ b/app/config/drupal9-demo/install.sh
@@ -38,8 +38,13 @@ pushd "${CMS_ROOT}/sites/${DRUPAL_SITE_DIR}" >> /dev/null
   drush8 cc drush -y
 
   ## Setup CiviCRM
-  echo '{"enable_components":["CiviEvent","CiviContribute","CiviMember","CiviMail","CiviReport","CiviPledge","CiviCase","CiviCampaign"]}' \
-    | drush8 cvapi setting.create --in=json
+  if cv ev 'exit(version_compare(CRM_Utils_System::version(), "5.47.alpha", "<") ?0:1);' ; then
+    echo '{"enable_components":["CiviEvent","CiviContribute","CiviMember","CiviMail","CiviReport","CiviPledge","CiviCase","CiviCampaign","CiviGrant"]}' \
+      | drush8 cvapi setting.create --in=json
+  else
+    echo '{"enable_components":["CiviEvent","CiviContribute","CiviMember","CiviMail","CiviReport","CiviPledge","CiviCase","CiviCampaign"]}' \
+      | drush8 cvapi setting.create --in=json
+  if
   civicrm_apply_demo_defaults
   cv ev 'return CRM_Utils_System::synchronizeUsers();'
 


### PR DESCRIPTION
The `drupal*-demo` builds assign permissions like `edit grants`. This requires that CiviGrant is enabled -- otherwise it fails to assign permissions (and raises an error).

v5.45/v5.46 and v5.47 require different steps for enabling CiviGrant (eg toggle `enable_components` vs `cv en`).  The 5.45 steps were recently removed to support 5.47. This allows both to work.

Tested locally with `drupal-demo` for 5.45 and 5.47.