### PR TITLE
civibuild restore - Add option to skip the test DB

### DIFF
--- a/src/civibuild.parse.sh
+++ b/src/civibuild.parse.sh
@@ -236,6 +236,10 @@ function civibuild_parse() {
         CMS_SQL_SKIP=1
         ;;
 
+      --no-test)
+        TEST_SQL_SKIP=1
+        ;;
+
       --patch)
         PATCHES="$PATCHES|$1"
         shift

--- a/src/help/restore.hlp
+++ b/src/help/restore.hlp
@@ -11,6 +11,7 @@
 [32m  --no-cms[0m               Skip resetting the CMS DB [Optional]
 [32m  --civi-sql <sql-file>[0m  The path to a SQL backup of the CiviCRM DB [Optional]
 [32m  --no-civi[0m              Skip resetting the CiviCRM DB [Optional]
+[32m  --no-test[0m              Skip resetting the Test DB [Optional]
 
 
 [33mNB:[0m For more civibuild documentation see https://docs.civicrm.org/dev/en/latest/tools/civibuild/


### PR DESCRIPTION
Before:

* `civibuild restore` defaults to restoring all 3x DBs (`cms`, `civi`, `test`).
* You can opt-out of `cms` or `civi`.

After:

* `civibuild restore` defaults to restoring all 3x DBs (`cms`, `civi`, `test`).
* You can opt-out of `cms`, `civi`, or `test`