### PR TITLE
mysqld - When launching via nix/loco, ignore /etc/my.cnf

### DIFF
--- a/.loco/bin/loco-mysql-init
+++ b/.loco/bin/loco-mysql-init
@@ -1,20 +1,32 @@
 #!/bin/bash
+set -x
 
-## TODO: Detect MySQL version and tweak accordingly
+mysql_version=$(mysql --no-defaults --version)
 
 mkdir "$LOCO_SVC_VAR"/{log,tmp,run}
 
 php "$LOCO_CFG/mysql-common/my.cnf.php" > "$LOCO_SVC_VAR"/conf/common-my.cnf
 
 ## MySQL v5.7
-if mysql --version | grep 'Distrib 5.7' -q; then
-  mysqld --initialize-insecure --explicit_defaults_for_timestamp --datadir="$LOCO_SVC_VAR/data"
+if echo "$mysql_version" | grep 'Distrib 5.7' -q; then
+  mysqld --defaults-file="$LOCO_SVC_VAR/conf/my.cnf" --initialize-insecure --explicit_defaults_for_timestamp --datadir="$LOCO_SVC_VAR/data"
 
-elif mysql --version | grep 'Ver 8.0' -q; then
-  mysqld --initialize-insecure --explicit_defaults_for_timestamp --datadir="$LOCO_SVC_VAR/data"
+elif echo "$mysql_version" | grep 'Ver 8.0' -q; then
+  #mysqld --no-defaults --initialize-insecure --explicit_defaults_for_timestamp --datadir="$LOCO_SVC_VAR/data"
+  mysqld --defaults-file="$LOCO_SVC_VAR/conf/my.cnf" --initialize-insecure --explicit_defaults_for_timestamp --datadir="$LOCO_SVC_VAR/data"
 
-## MariaDB v10.2
-elif true; then
+## MariaDB
+elif echo "$mysql_version" | grep 'MariaDB' -q; then
+  mysql_bin=$(dirname $(which mysqld))
+  mysql_base=$(dirname "$mysql_bin")
+  pushd "$mysql_base"
+    set -ex
+      mysql_install_db --datadir="$LOCO_SVC_VAR/data" --defaults-file="$LOCO_SVC_VAR/conf/my.cnf" --skip-name-resolve --auth-root-authentication-method=normal
+    set +ex
+  popd
+
+## Older MySQL?
+else
   mysql_bin=$(dirname $(which mysqld))
   mysql_base=$(dirname "$mysql_bin")
   pushd "$mysql_base"

--- a/.loco/config/mysql-common/my.cnf.php
+++ b/.loco/config/mysql-common/my.cnf.php
@@ -2,7 +2,7 @@
 function ver() {
   static $ver = NULL;
   if ($ver === NULL) {
-    $ver = getenv('FORCE_MY_CNF_VERSION') ?: `mysqld --version`;
+    $ver = getenv('FORCE_MY_CNF_VERSION') ?: `mysqld --no-defaults --version`;
   }
   return $ver;
 }

--- a/.loco/loco.yml
+++ b/.loco/loco.yml
@@ -89,7 +89,7 @@ services:
     enabled: true
     init:
       - 'loco-mysql-init'
-    run: 'mysqld --datadir="$LOCO_SVC_VAR/data"'
+    run: 'mysqld --defaults-file="$LOCO_SVC_VAR/conf/my.cnf" --datadir="$LOCO_SVC_VAR/data"'
     pid_file: '$LOCO_SVC_VAR/run/mysql.pid'
     message: |-
       MySQL is running on "<comment>$LOCALHOST:$MYSQLD_PORT</comment>". The default credentials are user="<comment>root</comment>" and password="".


### PR DESCRIPTION
Overview
--------

This resolves a compatibility issue when running bknix on Arch.

Both nix and Arch build `mysqld` binaries which will (by default) read `/etc/my.cnf`.  This can lead to conflicts where bknix inappropriately read configuration data defined by Arch's mysqld.

The patch prevents bknix from reading `/etc/my.cnf`.

ping @colemanw 

Technical details
-----------------

I don't have Arch, but I reproduced the problem on Debian by creating a poisonous variant of `/etc/my.cnf` -- it's just this content:

```
inv[al_id
```

If any command in bknix reads this file, then it fails. For example, this command fails:

```
nix-shell -A "$PROFILE" --command 'loco run -f mysql'
```

Then I wanted to test with several different MySQL binaries. So I hacked my `nix/profiles/*/default.nix` to load these versions:

```
[[min]] mysql  Ver 14.14 Distrib 5.6.47, for Linux (x86_64) using  EditLine wrapper
[[dfl]] mysql  Ver 14.14 Distrib 5.7.23, for Linux (x86_64) using  EditLine wrapper
[[max]] mysql  Ver 15.1 Distrib 10.6.5-MariaDB, for Linux (x86_64) using readline 5.1
[[edge]] mysql  Ver 8.0.26 for Linux on x86_64 (Source distribution)
```

With this patch, it now works with all binaries listed above -- because it no longer reads the poisoned `/etc/my.cnf` file.

Comment
-------

IIRC, `/etc/my.cnf` is actually `mysql.com`'s official default, but I suspect it's been asymptomatic because several distros (incl Debian/Ubuntu) have changed this to match their own FHS.  (Ex: Debian `/etc/mysql/my.cnf`)

Testing also revealed a compatibility issue with the current version of MariaDB (eg 10.6).  This is also resolved.