### PR TITLE
WMFF config: fix prometheus output dir

### DIFF
--- a/app/config/wmff/install.sh
+++ b/app/config/wmff/install.sh
@@ -128,4 +128,5 @@ for processor in adyen amazon astropay ingenico; do
   drush vset ${processor}_audit_working_log_dir "${CMS_ROOT}/sites/default/files/wmf_audit/$processor/logs"
   drush vset ${processor}_audit_log_search_past_days 7
 done;
-mkdir /var/spool/prometheus/
+mkdir ${CMS_ROOT}/sites/default/files/prometheus/
+drush vset metrics_reporting_prometheus_path "${CMS_ROOT}/sites/default/files/prometheus/"


### PR DESCRIPTION
Oops, the install script generally doesn't have permissions to
create the /var/spool/prometheus directory. Instead, create a
directory under CiviCRM's files dir and update the setting used
by the stats writer.