### PR TITLE
bin/civi-test-run - Run headless+e2e groups for all core exts

### DIFF
--- a/bin/civi-test-run
+++ b/bin/civi-test-run
@@ -87,29 +87,21 @@ function task_phpunit() {
   $GUARD phpunit-xml-cleanup "$JUNITDIR"/*.xml
 }
 
-## usage: task_phpunit_core_extension <extension-dir> <junit-file> [<phpunit-group>]
+## usage: task_phpunit_core_extension <extension-dirname> <junit-name>
 function task_phpunit_core_extension() {
+  EXTENSION="$1"
+  JUNIT_NAME=${2:-$EXTENSION}
 
- EXTENSION="$1"
- if [ ! -z "$2" ]; then
-   FILENAME="junit-$2.xml"
- else
-   FILENAME="junit-$EXTENSION.xml"
- fi
- if [ -z "$3" ]; then
-   GROUP=""
- else
-   GROUP="--group $3"
- fi
+  pushd "$CIVI_CORE/ext/$EXTENSION"
+    for GROUP in headless e2e ; do
+      if ! $GUARD $(getPhpunitVer) --printer='Civi\Test\TAP' --log-junit="$JUNITDIR/junit-${JUNIT_NAME}-${GROUP}.xml" --group "$GROUP" ; then
+       EXITCODES="$EXITCODES $EXTENSION-$GROUP"
+     fi
+     echo "Found EXITCODES=\"$EXITCODES\""
+   done
+  popd
 
- pushd "$CIVI_CORE/ext/$EXTENSION"
- if ! $GUARD $(getPhpunitVer) --printer='Civi\Test\TAP' --log-junit="$JUNITDIR/$FILENAME" $GROUP; then
-   EXITCODES="$EXITCODES $EXTENSION"
- fi
- echo "Found EXITCODES=\"$EXITCODES\""
-
- $GUARD phpunit-xml-cleanup "$JUNITDIR"/*.xml
-
+  $GUARD phpunit-xml-cleanup "$JUNITDIR"/*.xml
 }
 
 function task_mixin() {
@@ -143,8 +135,7 @@ function test_afform_extensions() {
   $GUARD civibuild restore "$BLDNAME"
   cv en afform
   cv en --ignore-missing authx
-  task_phpunit_core_extension "$(basename $DIR)/mock" "afform-mock-e2e" e2e
-  task_phpunit_core_extension "$(basename $DIR)/mock" "afform-mock-headless" headless
+  task_phpunit_core_extension "$(basename $DIR)/mock" "afform-mock"
   $GUARD civibuild restore "$BLDNAME"
 }
 


### PR DESCRIPTION
Overview
----------

Civi tests are generally organized into two groups (`@group e2e` and `@group headless`). This PR makes it easier to include both types in core-ext's (`authx`, `search_kit`, etc).

Before
-------

Notwithstanding an exception (`afform`), most core-exts run tests without specifying a group. This works if you have exactly one group (`e2e` XOR `headless`). If you were to use a mix (both types), then there would be initialization conflicts.

After
-----

When running core-ext tests, it explicitly runs each group separately, ie

```
cd $MY_EXT
phpunit8 --group headless
phpunit8 --group e2e
```

This should allow for core-ext's with any of these situations:

* Headless-only. (The E2E group outputs a well-formed but empty result.)
* E2E-only. (The headless group outputs a well-formed but empty result.)
* Both headless and E2E groups.

Comments
-----------

Grepping in `civicrm-core:ext/`, it appears to me that all phpunit tests declare the expected `@group headless` or `@group e2e`.

This is a pre-req to expanding the mix of tests (eg adding headless tests in authx; adding e2e tests in search_kit).