### PR TITLE
app/config - Twiddle D7 `CMS_VERSION`

### DIFF
--- a/app/config/drupal-case/download.sh
+++ b/app/config/drupal-case/download.sh
@@ -8,7 +8,7 @@ git_cache_setup "https://github.com/civicrm/org.civicrm.shoreditch.git" "$CACHE_
 git_cache_setup "https://github.com/civicrm/org.civicrm.styleguide.git" "$CACHE_DIR/civicrm/org.civicrm.styleguide.git"
 git_cache_setup "https://github.com/civicrm/org.civicrm.civicase.git" "$CACHE_DIR/civicrm/org.civicrm.civicase.git"
 
-[ -z "$CMS_VERSION" ] && CMS_VERSION=7.x
+[ -z "$CMS_VERSION" ] && CMS_VERSION=7
 
 MAKEFILE="${TMPDIR}/${SITE_TYPE}/${SITE_NAME}/${SITE_ID}.make"
 cvutil_makeparent "$MAKEFILE"

--- a/app/config/drupal-clean/download.sh
+++ b/app/config/drupal-clean/download.sh
@@ -4,7 +4,7 @@
 
 ###############################################################################
 
-[ -z "$CMS_VERSION" ] && CMS_VERSION=7.x
+[ -z "$CMS_VERSION" ] && CMS_VERSION=7
 
 drupal_download
 

--- a/app/config/drupal-clean42/download.sh
+++ b/app/config/drupal-clean42/download.sh
@@ -10,7 +10,7 @@ git_cache_setup "https://github.com/CiviCRM42/civicrm42-packages.git" "$CACHE_DI
 
 ## Force version 4.2
 CIVI_VERSION=4.2
-[ -z "$CMS_VERSION" ] && CMS_VERSION=7.x
+[ -z "$CMS_VERSION" ] && CMS_VERSION=7
 MAKEFILE="${TMPDIR}/${SITE_TYPE}/${SITE_NAME}/${SITE_ID}.make"
 cvutil_makeparent "$MAKEFILE"
 cat "$SITE_CONFIG_DIR/drush.make.tmpl" \

--- a/app/config/drupal-demo/download.sh
+++ b/app/config/drupal-demo/download.sh
@@ -4,7 +4,7 @@
 
 ###############################################################################
 
-[ -z "$CMS_VERSION" ] && CMS_VERSION=7.x
+[ -z "$CMS_VERSION" ] && CMS_VERSION=7
 [ -z "$VOL_VERSION" ] && VOL_VERSION='master'
 [ -z "$NG_PRFL_VERSION" ] && NG_PRFL_VERSION='master'
 [ -z "$RULES_VERSION" ] && RULES_VERSION='master'

--- a/app/config/drupal-empty/download.sh
+++ b/app/config/drupal-empty/download.sh
@@ -4,7 +4,7 @@
 
 ###############################################################################
 
-[ -z "$CMS_VERSION" ] && CMS_VERSION=7.x
+[ -z "$CMS_VERSION" ] && CMS_VERSION=7
 
 drupal_download
 


### PR DESCRIPTION
In both CI and my local, drush is now reporting failures on this step:

```
drush8 -y dl drupal-7.x --destination=/home/jenkins/bknix-dfl/build/tmp-0-0 --drupal-project-rename
```

The exact error depends on the PHP version:

```
-- php74
copy(): Filename cannot be empty drush.inc:768

-- php80
Error: Uncaught ValueError: Path cannot be empty in phar:///Users/totten/bknix/extern/drush8.phar/includes/drush.inc:768
```

Switching the version expression to `drupal-7` or `drupal-7.89` appears to fix it.

Perhaps the backend feed (which drush uses to resolve versions) changed in some subtle way? But TBH `7` sounds just as good as `7.x` for our purposes...