### PR TITLE
phpunit-xml-cleanup - Fix karma XML bug. Move primary code to separat…

### DIFF
--- a/bin/phpunit-xml-cleanup
+++ b/bin/phpunit-xml-cleanup
@@ -1,44 +1,11 @@
-#!/usr/bin/env php
-<?php
-## When outputting JUnit XML files with backtraces, phpunit sometimes
-## generates invalid markup.  This is an ugly work-around to fix the
-## scenario wherein Civi's value-separator (\0001) is part of the backtrace.
+#!/usr/bin/env bash
 
-$sep = "";
-
-$files = $argv;
-array_shift($files);
-
-foreach ($files as $file) {
-  $content = file_get_contents($file);
-  #$content = str_replace($sep, '&#x0001;', $content);
-  $content = str_replace($sep, '', $content);
-  $content = preg_replace('/(<testsuite.*) fullPackage="[^"]+" /', '$1 ', $content);
-  $content = preg_replace('/(<testsuite.*) subpackage="[^"]+" /', '$1 ', $content);
-  $content = preg_replace('/(<testsuite.*) namespace="[^"]+" /', '$1 ', $content);
-  $content = preg_replace('/(<testsuite.*) warnings="[^"]+" /', '$1 ', $content);
-  if (isXmlEmpty($content)) {
-    $content = verbosePlaceholder();
-  }
-  file_put_contents($file, $content);
+function absdirname() {
+  pushd $(dirname $0) >> /dev/null
+    pwd
+  popd >> /dev/null
 }
+BINDIR=$(absdirname "$0")
+PRJDIR=$(dirname "$BINDIR")
 
-function isXmlEmpty($content) {
-  $xml = new SimpleXMLElement($content);
-  foreach ($xml->testsuite as $testsuite) {
-    return FALSE;
-  }
-  return TRUE;
-}
-
-function verbosePlaceholder() {
-  // Jenkins is quite persnickity.
-  $lines = [
-    '<?xml version="1.0" encoding="UTF-8"?>',
-    '<testsuites>',
-    '  <testsuite name="Placeholder" tests="0" assertions="0" errors="0" warnings="0" failures="0" skipped="0" time="0">',
-    '  </testsuite>',
-    '</testsuites>',
-  ];
-  return implode("\n", $lines);
-}
+exec php "$PRJDIR/extern/phpunit-xml-cleanup.php" "$@"

--- a/composer.json
+++ b/composer.json
@@ -57,6 +57,7 @@
       "phpunit7": {"version": "7.5.15", "url": "https://phar.phpunit.de/phpunit-7.5.15.phar", "path": "extern/phpunit7/phpunit7.phar", "type": "phar"},
       "phpunit8": {"version": "8.5.15", "url": "https://phar.phpunit.de/phpunit-8.5.15.phar", "path": "extern/phpunit8/phpunit8.phar", "type": "phar"},
       "phpunit9": {"version": "9.5.4", "url": "https://phar.phpunit.de/phpunit-9.5.4.phar", "path": "extern/phpunit9/phpunit9.phar", "type": "phar"},
+      "phpunit-xml-cleanup": {"version": "0.2", "url": "https://raw.githubusercontent.com/civicrm/phpunit-xml-cleanup/v{$version}/bin/phpunit-xml-cleanup", "path": "extern/phpunit-xml-cleanup.php", "type": "file"},
       "pogo": {"version": "0.2.4", "url": "https://github.com/totten/pogo/releases/download/v{$version}/pogo-{$version}.phar", "path": "bin/pogo", "type": "phar"},
       "wp": {"version": "2.5.0", "url": "https://github.com/wp-cli/wp-cli/releases/download/v{$version}/wp-cli-{$version}.phar", "path": "bin/wp", "type": "phar"}
     }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7669cd1a5eaeddcbbef2a21cb481b1e0",
+    "content-hash": "6fd49931288249a8233d9a3665e066b8",
     "packages": [
         {
             "name": "civicrm/composer-downloads-plugin",


### PR DESCRIPTION
…e repo.

This revision does two things:

1. It downloads `phpunit-xml-cleanup` from a new/separate repo, https://github.com/civicrm/phpunit-xml-cleanup.
   This repo includes examples/tests to ensure that the cleanup script does what's expected.

2. The newer version has a number (v0.2) and fixes a bug in processing karma XML files.