### PR TITLE
(civibuild.lib.sh) backdrop_user - Don't need to Civi to add CMS user

### DIFF
--- a/src/civibuild.lib.sh
+++ b/src/civibuild.lib.sh
@@ -1045,7 +1045,7 @@ function backdrop_uninstall() {
 ## usage: backdrop_user USERNAME EMAIL PASSWORD
 function backdrop_user() {
   env NEW_USER="$1" NEW_EMAIL="$2" NEW_PASS="$3" \
-    cv ev --user=admin '$ps=["name"=>getenv("NEW_USER"), "mail"=>getenv("NEW_EMAIL"), "pass"=>getenv("NEW_PASS")]; $u=entity_create("user", $ps); $u->save();'
+    cv ev --level=cms-only --user=admin '$ps=["name"=>getenv("NEW_USER"), "mail"=>getenv("NEW_EMAIL"), "pass"=>getenv("NEW_PASS")]; $u=entity_create("user", $ps); $u->save();'
 }
 
 ###############################################################################


### PR DESCRIPTION
Before: `backdrop-empty` build-type stopped working, because it needs to create
a backdrop user (`backdrop_user ...`), but the implementation (`cv ev`) relies
on booting Civi-first.

After: The implementation is basically the same, but it does need to boot
Civi (ie when adding a CMS user, it only boots CMS).