### PR TITLE
Bump up MySQL version for `old`, `min`, and `max` profiles

### DIFF
--- a/nix/profiles/max/default.nix
+++ b/nix/profiles/max/default.nix
@@ -13,7 +13,7 @@ in (import ../base/default.nix) ++ (import ../mgmt/default.nix) ++ [
     dists.v2111.apacheHttpd
     dists.v1809.mailcatcher
     dists.default.memcached
-    dists.default.mysql57
+    dists.default.mysql80
     dists.default.redis
     dists.bkit.transifexClient
 

--- a/nix/profiles/min/default.nix
+++ b/nix/profiles/min/default.nix
@@ -13,7 +13,7 @@ in (import ../base/default.nix) ++ (import ../mgmt/default.nix) ++ [
     dists.v2111.apacheHttpd
     dists.v1809.mailcatcher
     dists.default.memcached
-    dists.bkit.mysql56
+    dists.bkit.mysql57
     dists.default.redis
     dists.bkit.transifexClient
 

--- a/nix/profiles/old/default.nix
+++ b/nix/profiles/old/default.nix
@@ -13,7 +13,7 @@ in (import ../base/default.nix) ++ (import ../mgmt/default.nix) ++ [
     dists.v2111.apacheHttpd
     dists.v1809.mailcatcher
     dists.v1803.memcached
-    dists.bkit.mysql55
+    dists.bkit.mysql56
     dists.v1803.redis
     dists.bkit.transifexClient
 


### PR DESCRIPTION
| ... | old | min | dfl | max | edge |
| --| --| --| --| --| --|
| Was | mysql55 | mysql56 | mysql57 | mysql57 | mysql80 |
| Now | __mysql56__ | __mysql57__ | mysql57 | ~~mysql57~~ __mysql80__ (*edited*) | mysql80 |

Aside @seamuslee001 - Shouldn't we also bump up `max=>mysql80`? I know `edge` has been failing for a while, but I thought that was mostly about php81? I use `mysql80` day-to-day -- you'd agree it's in good shape, right?