### PR TITLE
Type drupal9-demo installs an unsupported version by default

### DIFF
--- a/app/config/drupal9-clean/download.sh
+++ b/app/config/drupal9-clean/download.sh
@@ -5,7 +5,7 @@
 ###############################################################################
 
 #[ -z "$CMS_VERSION" ] && CMS_VERSION=8.7.x
-[ -z "$CMS_VERSION" ] && CMS_VERSION=9.1.x
+[ -z "$CMS_VERSION" ] && CMS_VERSION='^9'
 
 mkdir "$WEB_ROOT"
 composer create-project drupal/recommended-project:"$CMS_VERSION" "$WEB_ROOT" --no-interaction

--- a/app/config/drupal9-demo/download.sh
+++ b/app/config/drupal9-demo/download.sh
@@ -5,7 +5,7 @@
 ###############################################################################
 
 #[ -z "$CMS_VERSION" ] && CMS_VERSION=8.7.x
-[ -z "$CMS_VERSION" ] && CMS_VERSION=9.1.x
+[ -z "$CMS_VERSION" ] && CMS_VERSION='^9'
 [ -z "$VOL_VERSION" ] && VOL_VERSION='master'
 [ -z "$NG_PRFL_VERSION" ] && NG_PRFL_VERSION='master'
 [ -z "$RULES_VERSION" ] && RULES_VERSION='master'

--- a/src/civibuild.lib.sh
+++ b/src/civibuild.lib.sh
@@ -602,6 +602,7 @@ function civicrm_download_composer_d8() {
     9.2*) echo 'No Extra Patch required' ; ;;
     9.1*) echo 'No Extra Patch required' ; ;;
     9*) echo 'No Extra Patch required' ; ;;
+    ^9) echo 'No Extra Patch required' ; ;;
     8.9*) echo 'No Extra Patch required' ; ;;
     *) EXTRA_COMPOSER+=( 'pear/pear_exception:1.0.1 as 1.0.0') ## weird conflict in drupal-composer/drupal-project
   esac 


### PR DESCRIPTION
So use a non-fixed default.

Also for newer versions don't do the pear-exception thing since otherwise it fails.