### PR TITLE
D8+ - Fix configuration of file_private_path

### DIFF
--- a/app/drupal.settings.d/pre.d/100-file_private_path-d8.php
+++ b/app/drupal.settings.d/pre.d/100-file_private_path-d8.php
@@ -1,7 +1,8 @@
 <?php
 
 global $civibuild, $settings;
-// Example CMS_VERSIONs: '7', '7.23', '7.x', '8', '8.8', '8.x'. Note that the '8.x' case would mess up `version_compare()`.
-if (isset($civibuild['CMS_VERSION'][0]) && empty($settings['file_private_path']) && $civibuild['CMS_VERSION'][0] === '8') {
+// Example CMS_VERSIONs: '7', '7.23', '7.x', '8', '8.3.4', '8.x', '^9'. Note that the '8.x' and `^9' case would mess up `version_compare()`.
+$cmsMajorVer = ltrim(explode('.', $civibuild['CMS_VERSION'] ?? '')[0], '^~><=');
+if ($cmsMajorVer && empty($settings['file_private_path']) && $cmsMajorVer >= 8) {
   $settings['file_private_path'] = $civibuild['PRIVATE_ROOT'] . DIRECTORY_SEPARATOR . $civibuild['DRUPAL_SITE_DIR'];
 }


### PR DESCRIPTION
Overview
----------

1. Enable `file_private_path` on D9/D10 (same way as D8)
2. Ignore composer version-constraint chars

(Off-shoot from reviewing from @demeritcowboy's #700.)

Before
-------

On Drupal 9:

```
$ drush ev 'echo Drupal\Core\Site\Settings::get("file_private_path");'
(blank - no value)
```

After
-----

On Drupal 9:

```
$ drush ev 'echo Drupal\Core\Site\Settings::get("file_private_path");'
/Users/totten/bknix/build/drupal9-clean/.civibuild/private/default
```

Comment
----------

D7 and D8 configurations use different techniques (`drush vset` vs `$settings`) for setting `file_private_path`. This is because `drush vset` stopped working in D8 (*at least, drush8 + d8/d9 doesn't support it -- and`$settings` is the documented way to configure on D8+*).

```
$ drush vset file_private_path /Users/totten/bknix/build/drupal9-clean/.civibuild/private/default
Command variable-set requires Drupal core version 6 or 7 to run.                                                                                                                           [error]
The drush command 'vset file_private_path /Users/totten/bknix/build/drupal9-clean/.civibuild/private/default' could not be executed.                                                       [error]
```