### PR TITLE
my.cnf - Bump up max_allowed_packet (1m => 16m)

### DIFF
--- a/.loco/config/mysql-common/my.cnf
+++ b/.loco/config/mysql-common/my.cnf
@@ -1,7 +1,7 @@
 [mysqld]
 skip-external-locking
 key_buffer_size = 256M
-max_allowed_packet = 1M
+max_allowed_packet = 16M
 table_open_cache = 256
 sort_buffer_size = 1M
 read_buffer_size = 1M

--- a/.loco/config/mysql-common/my.cnf.php
+++ b/.loco/config/mysql-common/my.cnf.php
@@ -11,7 +11,7 @@ function matchVer($pat) {return (bool) preg_match($pat, ver());}
 [mysqld]
 skip-external-locking
 key_buffer_size = 256M
-max_allowed_packet = 1M
+max_allowed_packet = 16M
 table_open_cache = 256
 sort_buffer_size = 1M
 read_buffer_size = 1M


### PR DESCRIPTION
The old limit (1m) is fairly low. The default max_allowed_packet is 64m.

https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_max_allowed_packet

I'm not sure why it was so low, but I don't think it was representative (since
the mysqld default is so much higher), and the low value caused problems
when using D9+CiviCRM+civicrm_entity.