### PR TITLE
fetch-universe - Use subdirectories ('core', 'ext', 'tools', etc)

### DIFF
--- a/bin/fetch-universe
+++ b/bin/fetch-universe
@@ -27,6 +27,10 @@ function errprintf() {
   fwrite(STDERR, $str);
 }
 
+function errdump(...$args) {
+  fwrite(STDERR, var_dump($args, 1));
+}
+
 ########################################################################################
 ## Feeds
 
@@ -39,7 +43,7 @@ function feed_extdir() {
   $extdirUrl = 'https://civicrm.org/extdir/git-urls';
   errprintf("Fetch URL (%s)\n", $extdirUrl);
   $json = json_decode(file_get_contents($extdirUrl), 1);
-  return feed_normalize($json);
+  return feed_normalize($json, ['type' => 'ext']);
 }
 
 /**
@@ -77,7 +81,7 @@ function feed_labdir() {
     $page++;
   } while ($validProjectsInPage > 0);
 
-  return feed_normalize($labdir);
+  return feed_normalize($labdir, ['type' => 'ext']);
 }
 
 /**
@@ -88,89 +92,134 @@ function feed_static() {
   $core = array(
     'civicrm-core' => array(
       'git_url' => 'https://github.com/civicrm/civicrm-core',
+      'type' => 'core',
     ),
     'civicrm-backdrop-1.x' => array(
       'git_url' => 'https://github.com/civicrm/civicrm-backdrop',
       'git_branch' => '1.x-master',
+      'type' => 'core',
     ),
     'civicrm-buildkit' => array(
       'git_url' => 'https://github.com/civicrm/civicrm-buildkit',
+      'type' => 'tools',
     ),
     'civicrm-drupal-6.x' => array(
       'git_url' => 'https://github.com/civicrm/civicrm-drupal',
       'git_branch' => '6.x-master',
+      'type' => 'core',
     ),
     'civicrm-drupal-7.x' => array(
       'git_url' => 'https://github.com/civicrm/civicrm-drupal',
       'git_branch' => '7.x-master',
+      'type' => 'core',
     ),
     'civicrm-drupal-8.x' => array(
       'git_url' => 'https://github.com/civicrm/civicrm-drupal-8',
+      'type' => 'core',
     ),
     'civicrm-joomla' => array(
       'git_url' => 'https://github.com/civicrm/civicrm-joomla',
+      'type' => 'core',
     ),
     'civicrm-packages' => array(
       'git_url' => 'https://github.com/civicrm/civicrm-packages',
+      'type' => 'core',
     ),
     'civicrm-setup' => array(
       'git_url' => 'https://github.com/civicrm/civicrm-setup',
+      'type' => 'lib',
     ),
     'civicrm-wordpress' => array(
       'git_url' => 'https://github.com/civicrm/civicrm-wordpress',
+      'type' => 'core',
     ),
     'civihr' => array(
       'git_url' => 'https://github.com/civicrm/civihr',
       'git_branch' => 'staging',
+      'type' => 'ext',
     ),
     'com.webaccessglobal.module.civimobile' => array(
       'git_url' => 'https://github.com/webaccess/com.webaccessglobal.module.civimobile',
+      'type' => 'ext',
     ),
     'civix' => array(
       'git_url' => 'https://github.com/totten/civix',
+      'type' => 'tools',
+    ),
+    'coworker' => array(
+      'git_url' => 'https://lab.civicrm.org/dev/coworker',
+      'type' => 'tools',
     ),
     'cf-civicrm' => array(
       'git_url' => 'https://github.com/mecachisenros/cf-civicrm',
+      'type' => 'wp-plugin',
+    ),
+    'civicrm_entity' => array(
+      'git_url' => 'https://git.drupalcode.org/project/civicrm_entity',
+      'type' => 'drupal-module',
     ),
     'webform_civicrm' => array(
       'git_url' => 'https://github.com/colemanw/webform_civicrm',
+      'type' => 'drupal-module',
     ),
   );
 
   // These repos all have basic names and use default branch.
   $subRepos = array(
-    'apachesolr_civiAttachments',
-    'civicon',
-    'civicrm-ac',
-    'civicrm-botdylan',
-    'civicrm-community-messages',
-    'civicrm-cxn-rpc',
-    'civicrm-demo-wp',
-    'civicrm-docs',
-    'civicrm-extdir-example',
-    'civicrm-l10n-extensions',
-    'civicrm-org-platform',
-    'civicrm-pingback',
-    'civicrm-statistics',
-    'civicrm-upgrade-test',
-    'coder',
-    'cv-nodejs',
-    'cxnapp',
-    'pr-report',
-    'zetacomponents-mail',
-    'cv',
-    'civistrings',
-    'civicrm-sysadmin-guide',
-    'civicrm-user-guide',
-    'civicrm-dev-docs',
-    'civicrm-infra',
-    'civicrm-dist-manager',
-    'release-management',
-    'l10n',
+    'l10n' => 'core',
+    'civicrm-upgrade-test' => 'core',
+
+    'civicrm-dev-docs' => 'docs',
+    'civicrm-infra' => 'docs',
+    'civicrm-sysadmin-guide' => 'docs',
+    'civicrm-user-guide' => 'docs',
+    'release-management' => 'docs',
+
+    'apachesolr_civiAttachments' => 'drupal-module',
+
+    'civicrm-l10n-extensions' => 'ext',
+    'org.civicrm.doctorwhen' => 'ext',
+    'org.civicrm.module.cividiscount' => 'ext',
+    'org.civicrm.shoreditch' => 'ext',
+    'org.civicrm.sms.twilio' => 'ext',
+    'org.civicrm.styleguide' => 'ext',
+    'org.civicrm.volunteer ' => 'ext',
+
+    'civicrm-cxn-rpc' => 'lib',
+    'composer-compile-lib ' => 'lib',
+    'composer-compile-plugin ' => 'lib',
+    'composer-downloads-plugin ' => 'lib',
+    'jquery' => 'lib',
+    'jqueryui' => 'lib',
+    'mosaico' => 'lib',
+    'zetacomponents-mail' => 'lib',
+
+    'civicon' => 'misc',
+    'civicrm-ac' => 'misc',
+    'civicrm-botdylan' => 'misc',
+    'civicrm-community-messages' => 'misc',
+    'civicrm-dist-manager' => 'misc',
+    'civicrm-docs' => 'misc',
+    'civicrm-extdir-example' => 'misc',
+    'civicrm-org-platform' => 'misc',
+    'civicrm-pingback' => 'misc',
+    'civicrm-statistics'=> 'misc',
+    'cxnapp' => 'misc',
+    'pr-report' => 'misc',
+    'probot-civicrm' => 'misc',
+
+    'civistrings' => 'tools',
+    'coder' => 'tools',
+    'cv' => 'tools',
+    'cv-nodejs' => 'tools',
+    'phpunit-xml-cleanup ' => 'tools',
+
+    'civicrm-demo-wp' => 'wp-plugin',
   );
-  foreach ($subRepos as $subRepo) {
+  foreach ($subRepos as $subRepo => $type) {
     $core[$subRepo] = array(
       'git_url' => 'https://github.com/civicrm/' . $subRepo,
+      'type' => $type,
     );
   }
 
@@ -183,7 +232,7 @@ function feed_static() {
  * @param array $feed
  * @return array
  */
-function feed_normalize($feed) {
+function feed_normalize($feed, $defaults = []) {
   $new = [];
   foreach ($feed as $key => $repo) {
     $repo['key'] = $key;
@@ -197,7 +246,7 @@ function feed_normalize($feed) {
       $repo['git_url'] = sprintf('https://%s/%s.git', $m[1], $userRepo);
     }
 
-    $new[$key] = $repo;
+    $new[$key] = array_merge($defaults, $repo);
   }
   ksort($new);
   return $new;
@@ -260,7 +309,18 @@ $deprecated = array('civicrm-drupal', 'civicrm-org-site', 'api4', 'civicrm-setup
 $repos = feed_merge([feed_extdir(), feed_static(), feed_labdir()]);
 
 foreach ($repos as $key => $ext) {
-  $dir = "$basedir/$key";
+  $dir = "$basedir/" . $ext['type'] . "/$key";
+  $oldDir = "$basedir/$key";
+
+  if (!is_dir(dirname($dir))) {
+    mkdir(dirname($dir));
+  }
+
+  if (is_dir($oldDir) && !is_dir($dir)) {
+    errprintf("Move %s => %s\n", $oldDir, $dir);
+    rename($oldDir, $dir);
+  }
+
   if (empty($ext['git_url'])) {
     errprintf("$key does not have git_url\n");
     $statuses[$key] = 1;


### PR DESCRIPTION
What: Reorganize the `universe` into subdirs

Why: Better targeting. The subdirs make it easier for `grep` queries to include/exclude big parts of the universe (and still allow full universe searching, when desired). I often want to do a grep on either (a) all extensions xor (b) all core repos. Searches against tools, third-party libraries, misc-sites, etc can sometimes useful - but they're less common, and they often duplicate hits (eg the `civicrm.org` backend incorporates some core repos and ext repos). In the past, there was a trick of searching on dotted-names or non-dotted-names (extensions vs everything-else), but that trick is no longer useful. The subdirs work better.

Tangentially: Also add some more packages