### PR TITLE
civircrm-upgrade-test - Update to v0.5

### DIFF
--- a/bin/civi-test-run
+++ b/bin/civi-test-run
@@ -87,6 +87,31 @@ function task_phpunit() {
   $GUARD phpunit-xml-cleanup "$JUNITDIR"/*.xml
 }
 
+## Run a PHPUnit test suite (based on a flexible expression).
+##
+## In the future, it will get progressively harder to run tests based on class-name.
+## File-names, paths, and groups will work better.
+##
+## usage: task_phpunit_expr <logical-suite-name> <pwd> [...phpunit file/filter options...]
+## example: task_phpunit_expr Foo.xml "$CIVI_CORE" tests/phpunit/Foo/
+function task_phpunit_expr() {
+  local PHPUNIT=$(getPhpunitVer)
+  local SUITE_NAME="$1"
+  local WORK_DIR="$2"
+  shift 2
+
+  [ ! -d "$JUNITDIR" ] && mkdir -p "$JUNITDIR"
+
+  pushd "$WORK_DIR"
+    if ! $GUARD $PHPUNIT $EXCLUDE_GROUP --log-junit "$JUNITDIR/$SUITE_NAME.xml" "$@" ; then
+      EXITCODES="$EXITCODES phpunit"
+    fi
+    echo "Found EXITCODES=\"$EXITCODES\""
+  popd
+
+  $GUARD phpunit-xml-cleanup "$JUNITDIR/$SUITE_NAME.xml"
+}
+
 ## usage: task_phpunit_core_extension <extension-dirname> <junit-name>
 function task_phpunit_core_extension() {
   EXTENSION="$1"
@@ -156,9 +181,31 @@ function task_karma() {
   $GUARD popd
 }
 
-## Execute the upgrade test suite
-## ex: task_upgrade @4.3..4.6.30
+## Execute the upgrade test suite (via 'phpunit' or 'civicrm-upgrade-test' or whatever is available).
+##
+## Usage: task_upgrade [<version-filter>]
+## Ex: task_upgrade @4.3..4.6.30
 function task_upgrade() {
+  if [ -e "$CIVI_CORE/tests/phpunit/Upgrade/" -a "$(ls $CIVI_CORE/tests/phpunit/Upgrade/*.php)"  ]; then
+    export UPGRADE_TEST_FILTER="$@"
+    task_phpunit_expr UpgradeTest "$CIVI_CORE" tests/phpunit/Upgrade/
+  else
+    if [ -z "$1" ]; then
+      CIVIVER=$(getCiviVer)
+      task_upgrade_legacy 5.13.3-multilingual_af_bg_en* "@4.6.12..$CIVIVER:10"
+    else
+      task_upgrade_legacy "$@"
+    fi
+  fi
+
+  $GUARD civibuild restore "$BLDNAME"
+}
+
+## Execute the upgrade test suite (via 'civicrm-upgrade-test' bash script).
+##
+## Usage: task_upgrade <version-filter>
+## Ex: task_upgrade @4.3..4.6.30
+function task_upgrade_legacy() {
   ## Run the tests -- DB upgrade tests
   if  ! $GUARD civibuild upgrade-test $BLDNAME $@ ; then
     EXITCODES="$EXITCODES upgrade-test"
@@ -169,7 +216,6 @@ function task_upgrade() {
   else
     $GUARD cp "$PRJDIR/app/debug/$BLDNAME/civicrm-upgrade-test.xml" "$JUNITDIR/"
   fi
-  $GUARD civibuild restore "$BLDNAME"
 }
 
 #################################################
@@ -338,8 +384,8 @@ for TESTTYPE in $SUITES ; do
   case "$TESTTYPE" in
     karma)  task_karma ;;
     mixin) task_mixin ;;
-    upgrade)  CIVIVER=$(getCiviVer) ; task_upgrade 5.13.3-multilingual_af_bg_en* "@4.6.12..$CIVIVER:10" ;;
-    upgrade@*)  task_upgrade $(echo $TESTTYPE | sed s'/^upgrade//' ) ;;
+    upgrade) task_upgrade ;;
+    upgrade@*) task_upgrade $(echo $TESTTYPE | sed s'/^upgrade//' ) ;;
     phpunit-e2e)  PHP_APC_CLI=on task_phpunit E2E_AllTests ;;
     phpunit-crm)  task_phpunit CRM_AllTests ;;
     # Handle legacy call for phpunit-api being equivilant to phpunit-api3

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
   "require": {
     "php": ">=5.6",
     "totten/php-symbol-diff": "dev-master#54f869ca68a3cd75f3386f8490870369733d2c23",
-    "civicrm/upgrade-test": "dev-master#7ad93f58a26791e41ae04ed97ee01d17368ed343",
+    "civicrm/upgrade-test": "0.5",
     "drupal/coder": "dev-8.x-2.x-civi#5fa299b7790535b9f5098417f848a173cb6ce4d4",
     "civicrm/composer-downloads-plugin": "^3.0",
     "squizlabs/php_codesniffer": ">=2.7 <4.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d9b595a024e54bc8c128ea10bc93cf1a",
+    "content-hash": "a2388fd793da953611891df6b3797f21",
     "packages": [
         {
             "name": "civicrm/composer-downloads-plugin",
@@ -62,23 +62,28 @@
         },
         {
             "name": "civicrm/upgrade-test",
-            "version": "dev-master",
+            "version": "0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/civicrm/civicrm-upgrade-test.git",
-                "reference": "7ad93f58a26791e41ae04ed97ee01d17368ed343"
+                "reference": "61f7b607f86c555489b5d4a59fa59207af0526f6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/civicrm/civicrm-upgrade-test/zipball/7ad93f58a26791e41ae04ed97ee01d17368ed343",
-                "reference": "7ad93f58a26791e41ae04ed97ee01d17368ed343",
+                "url": "https://api.github.com/repos/civicrm/civicrm-upgrade-test/zipball/61f7b607f86c555489b5d4a59fa59207af0526f6",
+                "reference": "61f7b607f86c555489b5d4a59fa59207af0526f6",
                 "shasum": ""
             },
-            "default-branch": true,
             "bin": [
-                "civicrm-upgrade-test"
+                "bin/civicrm-upgrade-examples",
+                "bin/civicrm-upgrade-test"
             ],
             "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Civi\\UpgradeTest\\": "src/"
+                }
+            },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "AGPL-3.0"
@@ -92,9 +97,9 @@
             "description": "Collection of scripts and data-files for testing CiviCRM upgrades",
             "homepage": "https://github.com/civicrm/civicrm-upgrade-test",
             "support": {
-                "source": "https://github.com/civicrm/civicrm-upgrade-test/tree/master"
+                "source": "https://github.com/civicrm/civicrm-upgrade-test/tree/0.5"
             },
-            "time": "2022-02-24T02:35:01+00:00"
+            "time": "2022-07-21T10:16:39+00:00"
         },
         {
             "name": "drupal/coder",
@@ -453,7 +458,6 @@
     "minimum-stability": "stable",
     "stability-flags": {
         "totten/php-symbol-diff": 20,
-        "civicrm/upgrade-test": 20,
         "drupal/coder": 20
     },
     "prefer-stable": false,
@@ -465,5 +469,5 @@
     "platform-overrides": {
         "php": "7.1"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/src/command/upgrade-test.run.sh
+++ b/src/command/upgrade-test.run.sh
@@ -4,7 +4,7 @@ if grep -q drupal "$CMS_ROOT/index.php" || grep -q backdrop "$CMS_ROOT/index.php
   cvutil_mkdir "$UPGRADE_LOG_DIR"
   pushd "$PRJDIR/vendor/civicrm/upgrade-test/databases" > /dev/null
     ## Note $ARGS is list of non-option parameters. The first two were action+buildname.
-    ../civicrm-upgrade-test --db "$CIVI_DB_NAME" --db-args "$CIVI_DB_ARGS" --web "$CMS_ROOT" --out "$UPGRADE_LOG_DIR" --junit-xml "$UPGRADE_LOG_DIR/civicrm-upgrade-test.xml" "${ARGS[@]:2}"
+    ../bin/civicrm-upgrade-test --db "$CIVI_DB_NAME" --db-args "$CIVI_DB_ARGS" --web "$CMS_ROOT" --out "$UPGRADE_LOG_DIR" --junit-xml "$UPGRADE_LOG_DIR/civicrm-upgrade-test.xml" "${ARGS[@]:2}"
   popd > /dev/null
 else
   echo "Skipped. civicrm-upgrade-test currently requires Drupal 7 or Backdrop and Drush."


### PR DESCRIPTION
`civircrm-upgrade-test` is actually a couple things:

1. _Archive_: It's a collection of example databases, taken from different versions of Civi.
2. _Runner_: It's a bash script which loads examples, runs `cv upgrade:db` (*or previously `drush cvupdb`*), and writes an XML file.

The general aim of the update is to decouple Archive+Runner -- moving the Runner out. (The "Archive" is  the heavy/unusual thing, and it doesn't change as much. It can stay here.)

With the update, the test-run can be driven by a PHPUnit suite (eg `civicrm-core:tests/phpunit/Upgrade`). This suite will be able to:

* Use more permutations
    * Low-hanging fruit: `cv` vs `drush` vs `wp-cli`
    * Further down: `civicrm/upgrade` browser-based runner
    * Further down: *various permutations of extensions*
* With more conditionals (eg *skip `drush` test on Backdrop+PHP8*)..
* And more assertions. (*It's kind of annoying to twiddle assertions and generate corresponding JUnit XML from bash.*)

In the decoupled model, `civicrm-upgrade-test` provides:

* Archive lookups via bash
    ```
    $ civicrm-upgrade-examples @5.30.0..5.50.0
    /Users/me/bknix/vendor/civicrm/upgrade-test/databases/5.33.2-setupsh.mysql.bz2
    /Users/me/bknix/vendor/civicrm/upgrade-test/databases/5.39.1-setupsh.mysql.bz2
    /Users/me/bknix/vendor/civicrm/upgrade-test/databases/5.45.3-setupsh.mysql.bz2
    /Users/me/bknix/vendor/civicrm/upgrade-test/databases/5.47.2-tz.mysql.bz2
    ```
* Archive lookups via PHP
    ```php
    $exampleFiles = \Civi\UpgradeTest\UpgradeExamples::find('@5.0.0..5.50.0')
    ```
* Legacy runner script (for continuity/compatibility)
    ```
    civicrm-upgrade-test [...connection-options...] @5.0.0..5.50.0
    ```
