### PR TITLE
Update buildkit to our supported php version

### DIFF
--- a/bin/civi-download-tools
+++ b/bin/civi-download-tools
@@ -800,9 +800,6 @@ check_php_ext imap recommended
 check_php_ext intl recommended
 check_php_ext mbstring recommended
 
-if php -r 'exit(version_compare(PHP_VERSION, 7.0, "<") ? 0 : 1);' ; then
-  check_php_ext mysql recommended  ## In case you try to install older Civi versions (<= 4.7.11)
-fi
 check_php_ext mysqli recommended   ## >= 4.7.12
 check_php_ext openssl recommended
 check_php_ext session recommended

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
   },
   "config": {
     "platform": {
-      "php": "7.1"
+      "php": "7.2"
     },
     "bin-dir": "bin",
     "allow-plugins": {
@@ -21,7 +21,7 @@
     }
   },
   "require": {
-    "php": ">=5.6",
+    "php": ">=7.2",
     "totten/php-symbol-diff": "dev-master#54f869ca68a3cd75f3386f8490870369733d2c23",
     "civicrm/upgrade-test": "dev-master#7ad93f58a26791e41ae04ed97ee01d17368ed343",
     "drupal/coder": "dev-8.x-2.x-civi#5fa299b7790535b9f5098417f848a173cb6ce4d4",


### PR DESCRIPTION
People (if any) who want buildkit to support a php version earlier than the one we are considering dropping should just grab an earlier buildkit