### PR TITLE
fix extensions not installing on wp-demo.  Update universe

### DIFF
--- a/app/config/wp-demo/download.sh
+++ b/app/config/wp-demo/download.sh
@@ -28,7 +28,10 @@ pushd "$WEB_ROOT/web/wp-content/plugins" >> /dev/null
   git clone ${CACHE_DIR}/civicrm/civicrm-demo-wp.git                  -b master          civicrm-demo-wp
   git clone ${CACHE_DIR}/civicrm/civivolunteer.git                    -b "$VOL_VERSION"  civicrm/civicrm/tools/extensions/civivolunteer
   git clone ${CACHE_DIR}/ginkgostreet/org.civicrm.angularprofiles.git -b "$NG_PRFL_VERSION" civicrm/civicrm/tools/extensions/org.civicrm.angularprofiles
-  git clone "${CACHE_DIR}/civicrm/org.civicrm.contactlayout.git"      -b "master"        civicrm/tools/extensions/org.civicrm.contactlayout
+  git clone "${CACHE_DIR}/civicrm/org.civicoop.civirules.git"              -b "master"  civicrm/civicrm/tools/extensions/org.civicoop.civirules
+  git clone "${CACHE_DIR}/TechToThePeople/civisualize.git"                 -b "master"  civicrm/civicrm/tools/extensions/civisualize
+  git clone "${CACHE_DIR}/civicrm/org.civicrm.module.cividiscount.git"     -b "master"  civicrm/civicrm/tools/extensions/cividiscount
+  git clone "${CACHE_DIR}/civicrm/org.civicrm.contactlayout.git"           -b "master"  civicrm/civicrm/tools/extensions/org.civicrm.contactlayout
 
 
   cd civicrm

--- a/src/universe.php
+++ b/src/universe.php
@@ -65,7 +65,11 @@ return function() {
       'type' => 'tools',
     ),
     'cf-civicrm' => array(
-      'git_url' => 'https://github.com/mecachisenros/cf-civicrm',
+      'git_url' => 'https://github.com/WPCV/cf-civicrm',
+      'type' => 'wp-plugin',
+    ),
+    'wpcv-woo-civi-integration' => array(
+      'git_url' => 'https://github.com/WPCV/wpcv-woo-civi-integration',
       'type' => 'wp-plugin',
     ),
     'civicrm_entity' => array(


### PR DESCRIPTION
 add URLs for cf-civicrm and woo-civicrm

Before:

Extension failures on wp-demo buildkit and universe pointing to an out of data repo.

After:

Extensions install properly on wp-demo  and universe updated.

