### PR TITLE
await-bknix - Add helper for running jobs with on-demand nodes

### DIFF
--- a/nix/bin/await-bknix
+++ b/nix/bin/await-bknix
@@ -52,9 +52,21 @@ function is_profile_online() {
   return $result
 }
 
+function usage() {
+  local prog=$(basename "$0")
+  echo "usage: $prog <user> <profile>"
+  echo "example: $prog $USER min"
+}
+
 ## usage: main <user> <profile>
 function main() {
   local slept=0
+
+  if [ -z "$1" -o -z "$2" ]; then
+    usage
+    exit 3
+  fi
+
   while true; do
     if is_profile_online "$1" "$2" ; then
       echo OK

--- a/nix/bin/await-bknix
+++ b/nix/bin/await-bknix
@@ -6,7 +6,7 @@
 ######################################################################
 
 SLEEP=5
-MAX_SLEEP=900
+MAX_SLEEP=600
 
 ######################################################################
 
@@ -25,6 +25,15 @@ function is_profile_online() {
   local svcs=$(get_profile_svcs "$1" "$2")
   local found=""
   local missing=""
+  local tgt_user="$1"
+  local tgt_profile="$2"
+
+  if [ -e "/nix/var/nix/profiles/bknix-${tgt_profile}/bin/php" -o -e "/nix/var/nix/profiles/per-user/${tgt_user}/bknix-${tgt_profile}/bin/php" ]; then
+    echo "Found profile binaries"
+  else
+    echo "Missing profile binaries"
+    result=1
+  fi
 
   if [ -z "$svcs" ]; then
     echo "Failed to identify services for \"$1 $2\""
@@ -56,7 +65,6 @@ function main() {
       echo "Waiting..."
       sleep "$SLEEP"
       slept=$(($SLEEP + $slept ))
-      echo "Slept total=$slept"
     else
       echo "Services did not come online after $slept seconds. Giving up."
       exit 2

--- a/nix/bin/await-bknix
+++ b/nix/bin/await-bknix
@@ -5,12 +5,18 @@
 
 ######################################################################
 
+## Polling interval
 SLEEP=5
+
+## Maximum amount of time to spend polling. After MAX_SLEEP, give up
 MAX_SLEEP=600
 
 ######################################################################
 
+## Find systemd services for the given user/profile
+##
 ## usage: get_profile_svcs <user> <profile>
+## return: Displays space-delimited list of service names
 function get_profile_svcs() {
   for svc in bknix-${1}-${2}{,-apache-vdr,-buildkit,-mailcatcher,-mysql,-mysqld,-php-fpm,-redis} ; do
     if [ -f "/etc/systemd/system/$svc.service" ]; then
@@ -19,7 +25,10 @@ function get_profile_svcs() {
   done
 }
 
+## Check if the user/profile is online
+##
 ## usage: check_profile <user> <profile>
+## return: Exit code indicates online/offline setatus
 function is_profile_online() {
   local result=0
   local svcs=$(get_profile_svcs "$1" "$2")
@@ -58,7 +67,10 @@ function usage() {
   echo "example: $prog $USER min"
 }
 
+## Check if the user/profile is online. Wait until it is.
+##
 ## usage: main <user> <profile>
+## return: n/a
 function main() {
   local slept=0
 

--- a/nix/bin/await-bknix
+++ b/nix/bin/await-bknix
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+## Usage: await-bknix <profile>
+## Purpose: Check to see if "profile" is online. Sleep+poll until it comes online.
+
+######################################################################
+
+SLEEP=5
+MAX_SLEEP=900
+
+######################################################################
+
+## usage: get_profile_svcs <user> <profile>
+function get_profile_svcs() {
+  for svc in bknix-${1}-${2}{,-apache-vdr,-buildkit,-mailcatcher,-mysql,-mysqld,-php-fpm,-redis} ; do
+    if [ -f "/etc/systemd/system/$svc.service" ]; then
+      echo -n " $svc"
+    fi
+  done
+}
+
+## usage: check_profile <user> <profile>
+function is_profile_online() {
+  local result=0
+  local svcs=$(get_profile_svcs "$1" "$2")
+  local found=""
+  local missing=""
+
+  if [ -z "$svcs" ]; then
+    echo "Failed to identify services for \"$1 $2\""
+    exit 1
+  fi
+  for svc in $svcs ; do
+    if systemctl is-active --quiet "$svc" ; then
+      found="$found $svc"
+    else
+      missing="$missing $svc"
+      result=1
+    fi
+  done
+  [ -n "$found" ] && echo "Found services:${found}"
+  [ -n "$missing" ] && echo "Missing services:${missing}"
+  return $result
+}
+
+## usage: main <user> <profile>
+function main() {
+  local slept=0
+  while true; do
+    if is_profile_online "$1" "$2" ; then
+      echo OK
+      break
+    fi
+
+    if [ $slept -lt $MAX_SLEEP ]; then
+      echo "Waiting..."
+      sleep "$SLEEP"
+      slept=$(($SLEEP + $slept ))
+      echo "Slept total=$slept"
+    else
+      echo "Services did not come online after $slept seconds. Giving up."
+      exit 2
+    fi
+  done
+}
+
+######################################################################
+main "$1" "$2"

--- a/nix/bin/install-ci.sh
+++ b/nix/bin/install-ci.sh
@@ -56,5 +56,6 @@ check_reqs
 install_cachix
 init_folder "$BKNIXSRC/examples/$BKNIX_CI_TEMPLATE" /etc/bknix-ci
 install_bin "$BINDIR"/use-bknix /usr/local/bin/use-bknix
+install_bin "$BINDIR"/await-bknix /usr/local/bin/await-bknix
 install_all_jenkins
 install_all_publisher


### PR DESCRIPTION
In some arrangements of running jobs with on-demand nodes, the job may be sent to the node before required services (eg `mysqld`) are fully available. This adds a utility will assert/wait for the services to come online. It can be sprinkled into a job like:

```bash
set -e
await-bknix "$USER" dfl
use-bknix -s dfl
```
