### PR TITLE
bknix-edge - Add PHP 8.2 and XDebug 3.2

### DIFF
--- a/nix/pins/22.05-php82.nix
+++ b/nix/pins/22.05-php82.nix
@@ -2,6 +2,6 @@
  * v22.05 with unofficial php82 backport (`totten/nixpkgs @ php82-v2205`)
  */
 fetchTarball {
-  url = "https://github.com/totten/nixpkgs/archive/3673729e7edc160135299a87e781981351fb8c2d.tar.gz";
-  sha256 = "1cclziiggh4s680kfz2290qzpwvn7fr0p8qlhwz9adyilsj225q7";
+  url = "https://github.com/totten/nixpkgs/archive/8a7a88cc553b68e982d4cb5c687d81e69daaa537.tar.gz";
+  sha256 = "1yx84hjif5c75jzyrafpi8r00hgm99dd47n3xpaarp3p0nbp2d6g";
 }

--- a/nix/pins/22.05-php82.nix
+++ b/nix/pins/22.05-php82.nix
@@ -1,0 +1,7 @@
+/**
+ * v22.05 with unofficial php82 backport (`totten/nixpkgs @ php82-v2205`)
+ */
+fetchTarball {
+  url = "https://github.com/totten/nixpkgs/archive/3673729e7edc160135299a87e781981351fb8c2d.tar.gz";
+  sha256 = "1cclziiggh4s680kfz2290qzpwvn7fr0p8qlhwz9adyilsj225q7";
+}

--- a/nix/pins/22.05-php82.nix
+++ b/nix/pins/22.05-php82.nix
@@ -2,6 +2,6 @@
  * v22.05 with unofficial php82 backport (`totten/nixpkgs @ php82-v2205`)
  */
 fetchTarball {
-  url = "https://github.com/totten/nixpkgs/archive/8a7a88cc553b68e982d4cb5c687d81e69daaa537.tar.gz";
-  sha256 = "1yx84hjif5c75jzyrafpi8r00hgm99dd47n3xpaarp3p0nbp2d6g";
+  url = "https://github.com/totten/nixpkgs/archive/d66b84e4b96bd996179b634517e24cbefdbb3f52.tar.gz";
+  sha256 = "0966j5qb801s49magl29pkxckx146xgn214w1gdawisifs5q9f14";
 }

--- a/nix/pins/default.nix
+++ b/nix/pins/default.nix
@@ -8,6 +8,7 @@ rec {
   v2105 = import (import  ./21.05.nix) {};
   v2111 = import (import  ./21.11.nix) {};
   v2205 = import (import  ./22.05.nix) {};
+  v2205php82 = import (import  ./22.05-php82.nix) {};
 
   bkit = import ../pkgs;
   default = v2205;

--- a/nix/pkgs/default.nix
+++ b/nix/pkgs/default.nix
@@ -25,6 +25,7 @@ in rec {
    php74 = import ./php74/default.nix;
    php80 = import ./php80/default.nix;
    php81 = import ./php81/default.nix;
+   php82 = import ./php82/default.nix;
    transifexClient = import ./transifexClient/default.nix;
    ramdisk = callPackage (fetchTarball https://github.com/totten/ramdisk/archive/v0.1.1.tar.gz) {};
 

--- a/nix/pkgs/php82/default.nix
+++ b/nix/pkgs/php82/default.nix
@@ -15,8 +15,8 @@ let
 
 in pkgs.php82.buildEnv {
 
-  ## TODO: apcu_bc tidy phpExtras.runkit7_4
-  extensions = { all, enabled }: with all; enabled++ [ apcu imagick memcached opcache redis yaml phpExtras.xdebug32 ];
+  ## TODO: apcu_bc tidy
+  extensions = { all, enabled }: with all; enabled++ [ apcu imagick memcached opcache redis yaml phpExtras.xdebug32 phpExtras.runkit7_4 ];
   extraConfig = phpIniSnippet1 + phpIniSnippet2;
 
 }

--- a/nix/pkgs/php82/default.nix
+++ b/nix/pkgs/php82/default.nix
@@ -16,7 +16,7 @@ let
 in pkgs.php82.buildEnv {
 
   ## TODO: apcu_bc apcu tidy phpExtras.runkit7_4
-  extensions = { all, enabled}: with all; enabled++ [ imagick memcached opcache redis yaml phpExtras.xdebug32rc ];
+  extensions = { all, enabled}: with all; enabled++ [ imagick memcached opcache redis yaml phpExtras.xdebug32 ];
   extraConfig = phpIniSnippet1 + phpIniSnippet2;
 
 }

--- a/nix/pkgs/php82/default.nix
+++ b/nix/pkgs/php82/default.nix
@@ -15,8 +15,8 @@ let
 
 in pkgs.php82.buildEnv {
 
-  ## TODO: apcu_bc apcu tidy phpExtras.runkit7_4
-  extensions = { all, enabled}: with all; enabled++ [ imagick memcached opcache redis yaml phpExtras.xdebug32 ];
+  ## TODO: apcu_bc tidy phpExtras.runkit7_4
+  extensions = { all, enabled }: with all; enabled++ [ apcu imagick memcached opcache redis yaml phpExtras.xdebug32 ];
   extraConfig = phpIniSnippet1 + phpIniSnippet2;
 
 }

--- a/nix/pkgs/php82/default.nix
+++ b/nix/pkgs/php82/default.nix
@@ -15,8 +15,8 @@ let
 
 in pkgs.php82.buildEnv {
 
-  ## TODO: apcu_bc tidy
-  extensions = { all, enabled }: with all; enabled++ [ apcu imagick memcached opcache redis yaml phpExtras.xdebug32 phpExtras.runkit7_4 ];
+  ## TODO: apcu_bc
+  extensions = { all, enabled }: with all; enabled++ [ apcu imagick memcached opcache redis tidy yaml phpExtras.xdebug32 phpExtras.runkit7_4 ];
   extraConfig = phpIniSnippet1 + phpIniSnippet2;
 
 }

--- a/nix/pkgs/php82/default.nix
+++ b/nix/pkgs/php82/default.nix
@@ -10,13 +10,13 @@ let
 
     phpIniSnippet1 = builtins.readFile ../phpCommon/php.ini;
     phpIniSnippet2 = ''
+      apc.enable_cli = ''${PHP_APC_CLI}
     '';
-    ## TODO(phpIniSnippet2):  apc.enable_cli = ''${PHP_APC_CLI}
 
 in pkgs.php82.buildEnv {
 
-  ## TODO: apcu_bc
-  extensions = { all, enabled }: with all; enabled++ [ apcu imagick memcached opcache redis tidy yaml phpExtras.xdebug32 phpExtras.runkit7_4 ];
+  ## EVALUATE: apcu_bc
+  extensions = { all, enabled }: with all; enabled++ [ phpExtras.xdebug32 redis tidy apcu yaml memcached imagick opcache phpExtras.runkit7_4 ];
   extraConfig = phpIniSnippet1 + phpIniSnippet2;
 
 }

--- a/nix/pkgs/php82/default.nix
+++ b/nix/pkgs/php82/default.nix
@@ -1,0 +1,22 @@
+# Make a version of php with extensions and php.ini options
+
+let
+    dists = import ../../pins;
+    pkgs = dists.v2205php82;
+    phpExtras = import ../phpExtras/default.nix {
+      pkgs = pkgs;
+      php = pkgs.php82; ## Compile PECL extensions with our preferred version of PHP
+    };
+
+    phpIniSnippet1 = builtins.readFile ../phpCommon/php.ini;
+    phpIniSnippet2 = ''
+    '';
+    ## TODO(phpIniSnippet2):  apc.enable_cli = ''${PHP_APC_CLI}
+
+in pkgs.php82.buildEnv {
+
+  ## TODO: apcu_bc apcu tidy phpExtras.runkit7_4
+  extensions = { all, enabled}: with all; enabled++ [ imagick memcached opcache redis yaml phpExtras.xdebug32rc ];
+  extraConfig = phpIniSnippet1 + phpIniSnippet2;
+
+}

--- a/nix/pkgs/phpExtras/default.nix
+++ b/nix/pkgs/phpExtras/default.nix
@@ -88,4 +88,14 @@ in rec {
     zendExtension = true;
   };
 
+  ## XDebug 3.2 adds support for PHP 8.2. It's currently in RC. Once it goes stable, consider making it default.
+  xdebug32rc = buildPecl {
+    version = "3.2.0RC1";
+    pname = "xdebug";
+    sha256 = "691kSkrlzgWUX8kxvGFM+OSFBabintHBPbzNb7CKzkQ=";
+    doCheck = true;
+    checkTarget = "test";
+    zendExtension = true;
+  };
+
 }

--- a/nix/pkgs/phpExtras/default.nix
+++ b/nix/pkgs/phpExtras/default.nix
@@ -27,8 +27,8 @@ in rec {
   ## runkit7 v4.x: Only series to support PHP 8
   runkit7_4 = buildPecl {
     pname = "runkit7";
-    version = "4.0.0a3";
-    sha256 = "029c3kn64v2qfl9m0g3nag6awp920grfdplmwj6848l90k9czpis";
+    version = "4.0.0a6";
+    sha256 = "28ldfLgy4WBMyr85VjT2GG1DGDJ19j8OgmNVL2kdDNg=";
     configureFlags = [ ];
     nativeBuildInputs = [ pkgs.pkg-config ];
     buildInputs = [ ];

--- a/nix/pkgs/phpExtras/default.nix
+++ b/nix/pkgs/phpExtras/default.nix
@@ -80,6 +80,7 @@ in rec {
   };
 
   xdebug3 = buildPecl {
+    ## XDebug 3.1 supports php72, php73, php74, php80, php81 (https://xdebug.org/docs/compat)
     version = "3.1.4";
     pname = "xdebug";
     sha256 = "QZWSb59sToAv90m7LKhaxQY2cZpy5TieNy4171I1Bfk=";
@@ -88,11 +89,11 @@ in rec {
     zendExtension = true;
   };
 
-  ## XDebug 3.2 adds support for PHP 8.2. It's currently in RC. Once it goes stable, consider making it default.
-  xdebug32rc = buildPecl {
-    version = "3.2.0RC1";
+  xdebug32 = buildPecl {
+    ## XDebug 3.2 supports php80, php81, php82 (https://xdebug.org/docs/compat)
+    version = "3.2.0";
     pname = "xdebug";
-    sha256 = "691kSkrlzgWUX8kxvGFM+OSFBabintHBPbzNb7CKzkQ=";
+    sha256 = "d2myDuza31++n1glEsELOU+1dbb3qMOjqC22iD4AMrc=";
     doCheck = true;
     checkTarget = "test";
     zendExtension = true;

--- a/nix/profiles/edge/default.nix
+++ b/nix/profiles/edge/default.nix
@@ -8,7 +8,7 @@ let
 
 in (import ../base/default.nix) ++ (import ../mgmt/default.nix) ++ [
 
-    dists.bkit.php81
+    dists.bkit.php82
     dists.default.nodejs-14_x
     dists.default.apacheHttpd
     dists.default.mailhog


### PR DESCRIPTION
Upstream `nixpkgs` doesn't officially have PHP 8.2 yet. That seems fair -- given that it's still only in RC.

But it wasn't [too hard to get a preview build](https://github.com/totten/nixpkgs/commit/3673729e7edc160135299a87e781981351fb8c2d). I based it on nixpkgs 22.05 (so it should mostly use the same low-level dependencies as the other PHP builds).

There's still some PECL extensions that need to shake-out. For the moment, I backported XDebug 3.2.0rc1 (which adds support for PHP 8.2), and temporarily skipped some less-used PECLs (`apcu`, `tidy`, `runkit7_4`).