### PR TITLE
drupal-clean, drupal-demo - Switch to civicrm_install_cv

### DIFF
--- a/app/config/drupal-clean/download.sh
+++ b/app/config/drupal-clean/download.sh
@@ -21,6 +21,9 @@ pushd "$WEB_ROOT/web"
 
     extract-url --cache-ttl 172800 civicrm=http://download.civicrm.org/civicrm-l10n-core/archives/civicrm-l10n-daily.tar.gz
     ## or https://raw.github.com/civicrm/l10n/master/po/fr_CA/civicrm.mo => civicrm/l10n/fr_CA/LC_MESSAGES/
+    pushd civicrm
+      composer install
+    popd
   popd
 
 popd

--- a/app/config/drupal-clean/install.sh
+++ b/app/config/drupal-clean/install.sh
@@ -38,6 +38,11 @@ civicrm_install_cv
 
 ###############################################################################
 ## Extra configuration
+pushd "$CIVI_CORE" >> /dev/null
+  ## Generating `civicrm.config.php` is necessary for `extern/*.php` and its E2E tests
+  ./bin/setup.sh -g
+popd >> /dev/null
+
 pushd "${CMS_ROOT}/sites/${DRUPAL_SITE_DIR}" >> /dev/null
 
   drush -y updatedb

--- a/app/config/drupal-clean/install.sh
+++ b/app/config/drupal-clean/install.sh
@@ -34,13 +34,13 @@ if [[ "$CIVI_VERSION" =~ ^4.[0123456](\.([0-9]|alpha|beta)+)?$ ]] ; then
   CIVI_EXT_URL="${CMS_URL}/sites/${DRUPAL_SITE_DIR}/ext"
 fi
 
-pushd "$CIVI_CORE" >> /dev/null
-  ## (1) Generating `civicrm.config.php` is necessary for `extern/*.php` and its E2E tests
-  ## (2) If you've switched branches and triggered `reinstall`, then you need to refresh composer deps/autoloader before installing
-  ./bin/setup.sh -Dg
-popd >> /dev/null
+# If you've switched branches and triggered `reinstall`, then you need to refresh composer deps/autoloader before installing
+(cd "$CIVI_CORE" && composer install)
 
 civicrm_install_cv
+
+## Generating `civicrm.config.php` is necessary for `extern/*.php` and its E2E tests
+(cd "$CIVI_CORE" && ./bin/setup.sh -g)
 
 ###############################################################################
 ## Extra configuration

--- a/app/config/drupal-clean/install.sh
+++ b/app/config/drupal-clean/install.sh
@@ -34,14 +34,16 @@ if [[ "$CIVI_VERSION" =~ ^4.[0123456](\.([0-9]|alpha|beta)+)?$ ]] ; then
   CIVI_EXT_URL="${CMS_URL}/sites/${DRUPAL_SITE_DIR}/ext"
 fi
 
+pushd "$CIVI_CORE" >> /dev/null
+  ## (1) Generating `civicrm.config.php` is necessary for `extern/*.php` and its E2E tests
+  ## (2) If you've switched branches and triggered `reinstall`, then you need to refresh composer deps/autoloader before installing
+  ./bin/setup.sh -Dg
+popd >> /dev/null
+
 civicrm_install_cv
 
 ###############################################################################
 ## Extra configuration
-pushd "$CIVI_CORE" >> /dev/null
-  ## Generating `civicrm.config.php` is necessary for `extern/*.php` and its E2E tests
-  ./bin/setup.sh -g
-popd >> /dev/null
 
 pushd "${CMS_ROOT}/sites/${DRUPAL_SITE_DIR}" >> /dev/null
 

--- a/app/config/drupal-clean/install.sh
+++ b/app/config/drupal-clean/install.sh
@@ -34,19 +34,24 @@ if [[ "$CIVI_VERSION" =~ ^4.[0123456](\.([0-9]|alpha|beta)+)?$ ]] ; then
   CIVI_EXT_URL="${CMS_URL}/sites/${DRUPAL_SITE_DIR}/ext"
 fi
 
-civicrm_install
+civicrm_install_cv
 
 ###############################################################################
 ## Extra configuration
 pushd "${CMS_ROOT}/sites/${DRUPAL_SITE_DIR}" >> /dev/null
 
   drush -y updatedb
+  drush -y cc all
   drush -y en civicrm toolbar locale garland
   ## disable annoying/unneeded modules
   drush -y dis overlay
   drupal7_po_import
 
   cv ev 'if(is_callable(array("CRM_Core_BAO_CMSUser","synchronize"))){CRM_Core_BAO_CMSUser::synchronize(FALSE);}else{CRM_Utils_System::synchronizeUsers();}'
+
+  ## Setup CiviCRM
+  echo '{"enable_components":["CiviEvent","CiviContribute","CiviMember","CiviMail","CiviReport","CiviPledge","CiviCase","CiviCampaign","CiviGrant"]}' \
+    | drush cvapi setting.create --in=json
 
   ## Setup theme
   #above# drush -y en garland

--- a/app/config/drupal-clean/install.sh
+++ b/app/config/drupal-clean/install.sh
@@ -41,7 +41,6 @@ civicrm_install_cv
 pushd "${CMS_ROOT}/sites/${DRUPAL_SITE_DIR}" >> /dev/null
 
   drush -y updatedb
-  drush -y cc all
   drush -y en civicrm toolbar locale garland
   ## disable annoying/unneeded modules
   drush -y dis overlay

--- a/app/config/drupal-clean/install.sh
+++ b/app/config/drupal-clean/install.sh
@@ -54,8 +54,7 @@ pushd "${CMS_ROOT}/sites/${DRUPAL_SITE_DIR}" >> /dev/null
   cv ev 'if(is_callable(array("CRM_Core_BAO_CMSUser","synchronize"))){CRM_Core_BAO_CMSUser::synchronize(FALSE);}else{CRM_Utils_System::synchronizeUsers();}'
 
   ## Setup CiviCRM
-  echo '{"enable_components":["CiviEvent","CiviContribute","CiviMember","CiviMail","CiviReport","CiviPledge","CiviCase","CiviCampaign","CiviGrant"]}' \
-    | drush cvapi setting.create --in=json
+  cv vset '{"enable_components":["CiviEvent","CiviContribute","CiviMember","CiviMail","CiviReport","CiviPledge","CiviCase","CiviCampaign"]}'
 
   ## Setup theme
   #above# drush -y en garland

--- a/app/config/drupal-demo/download.sh
+++ b/app/config/drupal-demo/download.sh
@@ -30,6 +30,9 @@ pushd "$WEB_ROOT/web"
     git clone "${CACHE_DIR}/civicrm/org.civicrm.contactlayout.git"           -b "master"             civicrm/tools/extensions/org.civicrm.contactlayout
     extract-url --cache-ttl 172800 civicrm=http://download.civicrm.org/civicrm-l10n-core/archives/civicrm-l10n-daily.tar.gz
     ## or https://raw.github.com/civicrm/l10n/master/po/fr_CA/civicrm.mo => civicrm/l10n/fr_CA/LC_MESSAGES/
+    pushd civicrm
+      composer install
+    popd
   popd
 
 popd

--- a/app/config/drupal-demo/install.sh
+++ b/app/config/drupal-demo/install.sh
@@ -35,13 +35,14 @@ if [[ "$CIVI_VERSION" =~ ^4.[0123456](\.([0-9]|alpha|beta)+)?$ ]] ; then
   CIVI_EXT_URL="${CMS_URL}/sites/${DRUPAL_SITE_DIR}/ext"
 fi
 
-pushd "$CIVI_CORE" >> /dev/null
-  ## (1) Generating `civicrm.config.php` is necessary for `extern/*.php` and its E2E tests
-  ## (2) If you've switched branches and triggered `reinstall`, then you need to refresh composer deps/autoloader before installing
-  ./bin/setup.sh -Dg
-popd >> /dev/null
+
+# If you've switched branches and triggered `reinstall`, then you need to refresh composer deps/autoloader before installing
+(cd "$CIVI_CORE" && composer install)
 
 civicrm_install_cv
+
+## Generating `civicrm.config.php` is necessary for `extern/*.php` and its E2E tests
+(cd "$CIVI_CORE" && ./bin/setup.sh -g)
 
 ###############################################################################
 ## Extra configuration

--- a/app/config/drupal-demo/install.sh
+++ b/app/config/drupal-demo/install.sh
@@ -35,14 +35,16 @@ if [[ "$CIVI_VERSION" =~ ^4.[0123456](\.([0-9]|alpha|beta)+)?$ ]] ; then
   CIVI_EXT_URL="${CMS_URL}/sites/${DRUPAL_SITE_DIR}/ext"
 fi
 
+pushd "$CIVI_CORE" >> /dev/null
+  ## (1) Generating `civicrm.config.php` is necessary for `extern/*.php` and its E2E tests
+  ## (2) If you've switched branches and triggered `reinstall`, then you need to refresh composer deps/autoloader before installing
+  ./bin/setup.sh -Dg
+popd >> /dev/null
+
 civicrm_install_cv
 
 ###############################################################################
 ## Extra configuration
-pushd "$CIVI_CORE" >> /dev/null
-  ## Generating `civicrm.config.php` is necessary for `extern/*.php` and its E2E tests
-  ./bin/setup.sh -g
-popd >> /dev/null
 
 pushd "${CMS_ROOT}/sites/${DRUPAL_SITE_DIR}" >> /dev/null
 

--- a/app/config/drupal-demo/install.sh
+++ b/app/config/drupal-demo/install.sh
@@ -35,10 +35,15 @@ if [[ "$CIVI_VERSION" =~ ^4.[0123456](\.([0-9]|alpha|beta)+)?$ ]] ; then
   CIVI_EXT_URL="${CMS_URL}/sites/${DRUPAL_SITE_DIR}/ext"
 fi
 
-civicrm_install
+civicrm_install_cv
 
 ###############################################################################
 ## Extra configuration
+pushd "$CIVI_CORE" >> /dev/null
+  ## Generating `civicrm.config.php` is necessary for `extern/*.php` and its E2E tests
+  ./bin/setup.sh -g
+popd >> /dev/null
+
 pushd "${CMS_ROOT}/sites/${DRUPAL_SITE_DIR}" >> /dev/null
 
   drush -y updatedb
@@ -49,11 +54,9 @@ pushd "${CMS_ROOT}/sites/${DRUPAL_SITE_DIR}" >> /dev/null
 
   ## Setup CiviCRM
   if cv ev 'exit(version_compare(CRM_Utils_System::version(), "5.47.alpha", "<") ?0:1);' ; then
-    echo '{"enable_components":["CiviEvent","CiviContribute","CiviMember","CiviMail","CiviReport","CiviPledge","CiviCase","CiviCampaign","CiviGrant"]}' \
-      | drush cvapi setting.create --in=json
+    cv vset '{"enable_components":["CiviEvent","CiviContribute","CiviMember","CiviMail","CiviReport","CiviPledge","CiviCase","CiviCampaign","CiviGrant"]}'
   else
-    echo '{"enable_components":["CiviEvent","CiviContribute","CiviMember","CiviMail","CiviReport","CiviPledge","CiviCase","CiviCampaign"]}' \
-      | drush cvapi setting.create --in=json
+    cv vset '{"enable_components":["CiviEvent","CiviContribute","CiviMember","CiviMail","CiviReport","CiviPledge","CiviCase","CiviCampaign"]}'
   fi
   ## Note: CiviGrant disabled by default. If you enable, update the permissions as well.
   civicrm_apply_demo_defaults

--- a/bin/civi-test-run
+++ b/bin/civi-test-run
@@ -83,6 +83,7 @@ function task_phpunit() {
 
   if [ $SUITE = 'E2E_AllTests' ]; then
       $GUARD civibuild restore "$BLDNAME"
+      $GUARD cv flush --cwd="$CIVI_CORE" ## This is smelly. It begs the question of "what is leaking between tests".
   fi
 
   $GUARD phpunit-xml-cleanup "$JUNITDIR"/*.xml
@@ -151,6 +152,7 @@ function test_core_extenions() {
     elif [ -f "$DIR/phpunit.xml.dist" ]; then
       task_phpunit_core_extension "$(basename $DIR)"
       $GUARD civibuild restore "$BLDNAME"
+      $GUARD cv flush --cwd="$CIVI_CORE" ## This is smelly. It begs the question of "what is leaking between tests".
     fi
   done
 }
@@ -160,10 +162,12 @@ function test_afform_extensions() {
   pushd "$DIR"
     task_phpunit_core_extension "$(basename $DIR)/core" "afform-core"
     $GUARD civibuild restore "$BLDNAME"
+    $GUARD cv flush --cwd="$CIVI_CORE" ## This is smelly. It begs the question of "what is leaking between tests".
     cv en afform
     cv en --ignore-missing authx
     task_phpunit_core_extension "$(basename $DIR)/mock" "afform-mock"
     $GUARD civibuild restore "$BLDNAME"
+    $GUARD cv flush --cwd="$CIVI_CORE" ## This is smelly. It begs the question of "what is leaking between tests".
   popd
 }
 
@@ -200,6 +204,7 @@ function task_upgrade() {
   fi
 
   $GUARD civibuild restore "$BLDNAME"
+  $GUARD cv flush --cwd="$CIVI_CORE" ## This is smelly. It begs the question of "what is leaking between tests".
 }
 
 ## Execute the upgrade test suite (via 'civicrm-upgrade-test' bash script).


### PR DESCRIPTION
Resubmission of #673 / #661.

I've started a local run of `civi-test-run all` on a `drupal-clean` site to make sure it still runs the full suite.