### PR TITLE
php73 - Fix PHAR loading issue. Update php73 to 7.3.33.

### DIFF
--- a/nix/pins/21.05.nix
+++ b/nix/pins/21.05.nix
@@ -1,7 +1,9 @@
 /**
- * v21.05, with official backports circa Dec 3 2021
+ * v21.05, with official backports circa Dec 3 2021, and unofficial php73 update/fix.
  */
 fetchTarball {
-  url = "https://github.com/nixos/nixpkgs/archive/7e9b0dff974c89e070da1ad85713ff3c20b0ca97.tar.gz";
-  sha256 = "1ckzhh24mgz6jd1xhfgx0i9mijk6xjqxwsshnvq789xsavrmsc36";
+  #url = "https://github.com/totten/nixpkgs/archive/f3bd1e68655f131d36dc26a9a744fdbd40234324.tar.gz";
+  #sha256 = "0xf7f2r0bpxx8vqi25yl876zg9zh3qpcsn5mnbza43hz35kizmrl";
+  url = "https://github.com/totten/nixpkgs/archive/c6d0611f21c15e2c0e8b02239a6b84bb8835078a.tar.gz";
+  sha256 = "1kj5cxwmgp0qwp5wfybbm48xzip3g1s4wyyk83i4jzwyl8s5585j";
 }


### PR DESCRIPTION
The existing build of php73 does not run some PHARs (notably, the current `composer.phar`).  Why?  PHARs can be signed with different hashing algorithms, and this one was signed with SHA-512.  Apparently, the PHAR signature-checking rejects SHA-512 if the `hash` library is dynamically linked.

With this PR, the `hash` will be built into PHP (which fixes PHAR signature-checking).  For good measure, it also updates to PHP 7.3.33.