### PR TITLE
bknix-min - Update to PHP 7.3

### DIFF
--- a/nix/profiles/min/default.nix
+++ b/nix/profiles/min/default.nix
@@ -11,7 +11,7 @@ let
 
 in (import ../base/default.nix) ++ (import ../mgmt/default.nix) ++ [
 
-    (if isAppleM1 then dists.bkit.php74 else dists.bkit.php72)
+    (if isAppleM1 then dists.bkit.php74 else dists.bkit.php73)
     dists.default.nodejs-14_x
     dists.default.apacheHttpd
     dists.default.mailhog


### PR DESCRIPTION
Implements #741. I've pushed a couple builds up to binary-cache (for linux-x86 and darwin-arm64).

There's a bit of backlog in terms of test-matrix failures. I'd like to get more of these cleaned up before we apply a major change to the environment.

Should be merged in tandem with #734.
