### PR TITLE
bknix-min - Use php73. Disable timecop.

### DIFF
--- a/nix/pkgs/php73/default.nix
+++ b/nix/pkgs/php73/default.nix
@@ -16,7 +16,8 @@ let
 in pkgs.php73.buildEnv {
 
   ## EVALUATE: apcu_bc
-  extensions = { all, enabled}: with all; enabled++ [ phpExtras.xdebug3 redis tidy apcu apcu_bc yaml memcached imagick opcache phpExtras.runkit7_3 phpExtras.timecop ];
+  ## DISABLED: With current versions, `php73` + `phpExtras.timecop` is unstable. In web-browsing, 10-30% of page-loads cause segfaults in php-fpm.
+  extensions = { all, enabled}: with all; enabled++ [ phpExtras.xdebug3 redis tidy apcu apcu_bc yaml memcached imagick opcache phpExtras.runkit7_3 ];
   extraConfig = phpIniSnippet1 + phpIniSnippet2;
 
 }

--- a/nix/profiles/min/default.nix
+++ b/nix/profiles/min/default.nix
@@ -11,7 +11,7 @@ let
 
 in (import ../base/default.nix) ++ (import ../mgmt/default.nix) ++ [
 
-    (if isAppleM1 then dists.bkit.php74 else dists.bkit.php72)
+    (if isAppleM1 then dists.bkit.php74 else dists.bkit.php73)
     dists.default.nodejs-14_x
     dists.default.apacheHttpd
     dists.default.mailhog


### PR DESCRIPTION
After the first trial run with php73, I found php-fpm  became flaky (i.e. 10-30% of page-views would have a segfault or a  PHP syntax-error). So I bisected the list of PECLs and found that `timecop` correlates to the problem.

As it's not essential for core test-runs, I'll simply disable it. Note that it's still enabled with php72 and php74.