### PR TITLE
drupal-* - Use 'civicrm_install_transitional'

### DIFF
--- a/app/config/drupal-case/install.sh
+++ b/app/config/drupal-case/install.sh
@@ -28,7 +28,7 @@ CIVI_FILES="${CMS_ROOT}/sites/${DRUPAL_SITE_DIR}/files/civicrm"
 CIVI_TEMPLATEC="${CIVI_FILES}/templates_c"
 CIVI_UF="Drupal"
 
-civicrm_install
+civicrm_install_transitional
 
 ###############################################################################
 ## Extra configuration

--- a/app/config/drupal-clean/install.sh
+++ b/app/config/drupal-clean/install.sh
@@ -34,13 +34,7 @@ if [[ "$CIVI_VERSION" =~ ^4.[0123456](\.([0-9]|alpha|beta)+)?$ ]] ; then
   CIVI_EXT_URL="${CMS_URL}/sites/${DRUPAL_SITE_DIR}/ext"
 fi
 
-# If you've switched branches and triggered `reinstall`, then you need to refresh composer deps/autoloader before installing
-(cd "$CIVI_CORE" && composer install)
-
-civicrm_install_cv
-
-## Generating `civicrm.config.php` is necessary for `extern/*.php` and its E2E tests
-(cd "$CIVI_CORE" && ./bin/setup.sh -g)
+civicrm_install_transitional
 
 ###############################################################################
 ## Extra configuration

--- a/app/config/drupal-demo/install.sh
+++ b/app/config/drupal-demo/install.sh
@@ -35,14 +35,7 @@ if [[ "$CIVI_VERSION" =~ ^4.[0123456](\.([0-9]|alpha|beta)+)?$ ]] ; then
   CIVI_EXT_URL="${CMS_URL}/sites/${DRUPAL_SITE_DIR}/ext"
 fi
 
-
-# If you've switched branches and triggered `reinstall`, then you need to refresh composer deps/autoloader before installing
-(cd "$CIVI_CORE" && composer install)
-
-civicrm_install_cv
-
-## Generating `civicrm.config.php` is necessary for `extern/*.php` and its E2E tests
-(cd "$CIVI_CORE" && ./bin/setup.sh -g)
+civicrm_install_transitional
 
 ###############################################################################
 ## Extra configuration

--- a/app/config/drupal-sym1/install.sh
+++ b/app/config/drupal-sym1/install.sh
@@ -34,7 +34,7 @@ if [[ "$CIVI_VERSION" =~ ^4.[0123456](\.([0-9]|alpha|beta)+)?$ ]] ; then
   CIVI_EXT_URL="${CMS_URL}/sites/${DRUPAL_SITE_DIR}/ext"
 fi
 
-civicrm_install
+civicrm_install_transitional
 
 ###############################################################################
 ## Extra configuration

--- a/app/config/drupal-sym2/install.sh
+++ b/app/config/drupal-sym2/install.sh
@@ -34,7 +34,7 @@ if [[ "$CIVI_VERSION" =~ ^4.[0123456](\.([0-9]|alpha|beta)+)?$ ]] ; then
   CIVI_EXT_URL="${CMS_URL}/sites/${DRUPAL_SITE_DIR}/ext"
 fi
 
-civicrm_install
+civicrm_install_transitional
 
 ###############################################################################
 ## Extra configuration


### PR DESCRIPTION
In #735, the build scripts for `drupal-clean` and `drupal-demo` switched:

* From: `civicrm_install` (ie `setup.sh`)
* To: `civicrm_install_cv` (ie `cv core:install`)

I drafted this as a possible work-around for the failures in 5.51 on https://test.civicrm.org/job/CiviCRM-Civix-Matrix/ -- but still checking to see if it actually helps.

(The PR also goes a bit further, and extends the use of `civicrm_install_cv` to a few more build-types.)