### PR TITLE
civibuild - When using "restore", the "-f" option will flush (forcibly resetting caches)

### DIFF
--- a/src/civibuild.parse.sh
+++ b/src/civibuild.parse.sh
@@ -127,7 +127,7 @@ function civibuild_parse() {
     shift
 
     case "$OPTION" in
-      -h|--help|-?)
+      -h|--help|-\?)
         civibuild_app_usage
         ;;
 
@@ -196,7 +196,7 @@ function civibuild_parse() {
         shift
         ;;
 
-      --force)
+      -f|--force)
         FORCE_DOWNLOAD=1
         FORCE_INSTALL=1
         ;;

--- a/src/command/restore.run.sh
+++ b/src/command/restore.run.sh
@@ -1,2 +1,5 @@
 amp_snapshot_restore
+if [ -n "$FORCE_INSTALL" ]; then
+  (cd "$CMS_ROOT" && cv flush)
+fi
 cvutil_save "${BLDDIR}/${SITE_NAME}.sh" $PERSISTENT_VARS

--- a/src/help/create.hlp
+++ b/src/help/create.hlp
@@ -26,8 +26,8 @@
 [32m  --demo-email[0m         Email of the CMS's demo user
 [32m  --no-sample-data[0m     Instead of loading the sample dataset, load a minimal dataset
 
-[32m  --force[0m             If necessary, destroy pre-existing files/directories/DBs
-                      (For "reinstall", "--force" is implicit.)
+[32m  -f, --force[0m          If necessary, destroy pre-existing files/directories/DBs
+                       (For "reinstall", "--force" is implicit.)
 
 [33mNB:[0m Before running the "create" command you must first run "amp config" (see https://docs.civicrm.org/dev/en/latest/tools/buildkit/#amp-config). For more civibuild documentation see https://docs.civicrm.org/dev/en/latest/tools/civibuild/
 

--- a/src/help/restore.hlp
+++ b/src/help/restore.hlp
@@ -12,7 +12,7 @@
 [32m  --civi-sql <sql-file>[0m  The path to a SQL backup of the CiviCRM DB [Optional]
 [32m  --no-civi[0m              Skip resetting the CiviCRM DB [Optional]
 [32m  --no-test[0m              Skip resetting the Test DB [Optional]
-
+[32m  -f, --force[0m            Force an extra flush after restoring [Optional]
 
 [33mNB:[0m For more civibuild documentation see https://docs.civicrm.org/dev/en/latest/tools/civibuild/
 


### PR DESCRIPTION
Anecdotally, when improvising test routines to isolate problems, I will often choose between:

* `civibuild restore dmaster` (which preserves caches from the snapshot)
* `civibuild restore dmaster && cv flush` (which resets caches)

(Both seem useful to me, and I don't think there's a quick rule for when to choose each.)

This PR adds a shorthand for the latter (`civibuild restore dmaster -f`). 

@eileenmcnaughton You could use this to mitigate https://lab.civicrm.org/dev/core/-/issues/4054 -- i.e. when using Redis, just include the `-f` flag.