### PR TITLE
Check for empty langs in drupal PO download

### DIFF
--- a/src/civibuild.lib.sh
+++ b/src/civibuild.lib.sh
@@ -1400,6 +1400,9 @@ function _drupalx_po_import() {
   ## Find any files named '*.XX.po` (eg `webform-4.x.fr.po`). The `XX` locale should be active.
   local NEW_LOCALES=$(find "${SPOOL}" -name '*.po' | sed 's;\(.*\)\.\(\w\w\)\.po;\2;' | sort -u)
   drush en -y locale
+  if [ -z "$NEW_LOCALES" ]; then
+    return
+  fi
   drush language-add $NEW_LOCALES
 
   for NEW_LOCALE in $NEW_LOCALES ; do


### PR DESCRIPTION
Adds the same early return in _drupalx_po_import as we are already using in _drupalx_po_download.

BEFORE: install fails when no new languages need to be added

NOW: install completes when no new languages need to be added

Fixes: #751