### PR TITLE
loco - Improve support for transactional test-runs

### DIFF
--- a/.loco/plugin/portnum.php
+++ b/.loco/plugin/portnum.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Loco;
+
+Loco::dispatcher()->addListener('loco.expr.functions', function (LocoEvent $e) {
+  $e['functions']['portnum'] = function ($base, $group, $offset = 0) {
+    if (!is_numeric($base) || !is_numeric($group) || !is_numeric($offset)) {
+      throw new \RuntimeException("Invalid call to 'portnum $base $group $offset'. Three integers expected.");
+    }
+    return $base + (100 * $group) + $offset;
+  };
+});

--- a/.loco/worker-n.yml
+++ b/.loco/worker-n.yml
@@ -100,16 +100,11 @@ services:
     pid_file: '$LOCO_SVC_VAR/run/mysql.pid'
     message: 'MySQL is running on "<comment>$LOCALHOST:$MYSQLD_PORT</comment>". The default credentials are user="<comment>root</comment>" and password="".'
 
-  ## Load timezone data into MySQL.
-  ## IMHO, it would make more sense to use `mysqld --init-file`... but it's futzy (across versions).
-  ## Many `mysql.com` versions have very limited syntax ("\n" handling). `mariadb` doesn't even seem to read the file...
-  mysql-tz:
-    depends: ['mysql']
-    run: 'loco-mysql-wait 300 && mysql_tzinfo_to_sql "$TZDIR" | mysql mysql && sleep 259200'
-
-  buildkit:
+  mysetup:
     init:
+      - 'loco-mysql-wait 300'
       - 'loco-buildkit-init'
+      - 'mysql_tzinfo_to_sql "$TZDIR" | mysql mysql'
     message: 'Buildkit (<comment>$BKIT</comment>) is configured to use these services. It produces builds in "<comment>$HTTPD_VDROOT</comment>".'
 
 

--- a/.loco/worker-n.yml
+++ b/.loco/worker-n.yml
@@ -1,0 +1,118 @@
+format: 'loco-0.1'
+
+## The "worker-n" configuration is used to setup N-many parallel workers, each with a fully separate stack.
+##
+## Port numbers are derived from `EXECUTOR_NUMBER` (ie the Jenkins variable which identifies parallel workers).
+##
+## A few examples:
+##
+## | EXECUTOR_NUMBER | | HTTPD_PORT | MYSQLD_PORT |
+## +-----------------+-+------------+-------------+
+## | 0               | | 6000       | 6001        |
+## | 1               | | 6100       | 6101        |
+## | 2               | | 6200       | 6201        |
+##
+## Port numbers are chosen by the 'portnum' helper (.loco/plugin/portnum.php).
+
+environment:
+ ## HOSTS_TYPE: When creating an HTTP service, should we register the hostname in "/etc/hosts" ('file') or not ('none')?
+ - HOSTS_TYPE=none
+
+ ## HTTPD_*: Determine how a local folder (eg "./build/dmaster") relates to a local HTTP service (eg "http://dmaster.bknix:8001").
+ - HTTPD_DOMAIN=bknix
+ - HTTPD_PORT=$(portnum "$BASE_PORT" "$EXECUTOR_NUMBER" 0)
+ - HTTPD_VDROOT=$BKIT/build
+ - HTTPD_VISIBILITY=all
+
+ ## *_PORT: Most daemons run on auxiliary/non-standard TCP/UDP ports.
+ - BASE_PORT=6000
+ - MAIL_SMTP_PORT=$(portnum "$BASE_PORT" "$EXECUTOR_NUMBER" 3)
+ - MAIL_HTTP_PORT=$(portnum "$BASE_PORT" "$EXECUTOR_NUMBER" 4)
+ - MEMCACHED_PORT=$(portnum "$BASE_PORT" "$EXECUTOR_NUMBER" 6)
+ - MYSQLD_PORT=$(portnum "$BASE_PORT" "$EXECUTOR_NUMBER" 1)
+ - PHPFPM_PORT=$(portnum "$BASE_PORT" "$EXECUTOR_NUMBER" 2)
+ - REDIS_PORT=$(portnum "$BASE_PORT" "$EXECUTOR_NUMBER" 5)
+
+ ## XDEBUG_*: Enable or disable main XDebug options
+ - XDEBUG_MODE=off
+ #- XDEBUG_PORT=9003
+ #- XDEBUG_CONFIG=...
+
+ ## CIVIBUILD_ADMIN_PASS: When creating an administrative user, set the default password.
+ # - CIVIBUILD_ADMIN_PASS=admin
+
+ ## LOCALHOST: Bind services to a local IP address.
+ - LOCALHOST=127.0.0.1
+
+ # For multiprofile CI, data is split
+ - LOCO_VAR=$HOME/_bknix/ramdisk/worker-$EXECUTOR_NUMBER
+
+ # CLI applications should use our stuff
+ - AMPHOME=$HOME/_bknix/amp/worker-$EXECUTOR_NUMBER
+ - CIVIBUILD_HOME=$HTTPD_VDROOT
+ - BKIT=$LOCO_PRJ
+ - BKITBLD=$HTTPD_VDROOT
+ - MYSQL_HOME=$LOCO_VAR/mysql/conf
+ - NODE_PATH=$BKIT/node_modules:$NODE_PATH
+ - PATH=$BKIT/bin:$BKIT/node_modules/.bin:$LOCO_PRJ/.loco/bin:$PATH
+
+#### Functional service definitions
+services:
+
+  redis:
+    run: 'redis-server --port "$REDIS_PORT" --bind "$LOCALHOST" --pidfile "$LOCO_SVC_VAR/redis.pid" --dir "$LOCO_SVC_VAR"'
+    pid_file: '$LOCO_SVC_VAR/redis.pid'
+    message: 'Redis is running on "<comment>$LOCALHOST:$REDIS_PORT</comment>".'
+
+  memcached:
+    enabled: false
+    run: 'memcached --port=$MEMCACHED_PORT --pidfile="$LOCO_SVC_VAR/memcached.pid"'
+    pid_file: '$LOCO_SVC_VAR/memcached.pid'
+    message: 'Memcached is running on "<comment>$LOCALHOST:$MEMCACHED_PORT</comment>".'
+
+  php-fpm:
+    run: 'php-fpm -y "$LOCO_SVC_VAR/php-fpm.conf" --nodaemonize'
+    pid_file: '$LOCO_SVC_VAR/php-fpm.pid'
+    message: 'PHP-FPM is running on "<comment>$LOCALHOST:$PHPFPM_PORT</comment>"'
+
+  # To enable in CI, need to either set LOCALHOST to a public IP, or setup some kind of reverse proxy.
+  #mailcatcher:
+  #  run: 'mailcatcher --ip "$LOCALHOST" --smtp-port "$MAIL_SMTP_PORT" --http-port "$MAIL_HTTP_PORT" -f'
+  #  message: 'Mailcatcher is running on "<comment>smtp://$LOCALHOST:$MAIL_SMTP_PORT</comment>" and "<comment>http://$LOCALHOST:$MAIL_HTTP_PORT</comment>"'
+
+  ## apache-vdr uses a "virtual document root" to host a wildcard domain;
+  ## Formula: "http://{SUBDOMAIN}.{HTTPD_DOMAIN}:{HTTPD_PORT}/" <==> "./build/{SUBDOMAIN}/"
+  ## Ex: "http://foobar.bknix:8001/" <==> "./build/foobar/"
+  apache-vdr:
+    init:
+      - cp "$LOCO_SVC_CFG"/conf/magic "$LOCO_SVC_CFG"/conf/mime.types "$LOCO_SVC_VAR/conf"
+      - mk-apache-links
+      - 'if [ ! -d "$HTTPD_VDROOT" ]; then mkdir "$HTTPD_VDROOT"; fi'
+    run: 'apachectl -d "$LOCO_SVC_VAR" -DFOREGROUND'
+    pid_file: '$LOCO_SVC_VAR/httpd.pid'
+    message: 'Apache HTTPD is running at "<comment>http://$LOCALHOST:$HTTPD_PORT</comment>" with content from "<comment>$HTTPD_VDROOT</comment>".'
+
+  mysql:
+    enabled: true
+    init:
+      - 'loco-mysql-init'
+    run: 'mysqld --datadir="$LOCO_SVC_VAR/data"'
+    pid_file: '$LOCO_SVC_VAR/run/mysql.pid'
+    message: 'MySQL is running on "<comment>$LOCALHOST:$MYSQLD_PORT</comment>". The default credentials are user="<comment>root</comment>" and password="".'
+
+  ## Load timezone data into MySQL.
+  ## IMHO, it would make more sense to use `mysqld --init-file`... but it's futzy (across versions).
+  ## Many `mysql.com` versions have very limited syntax ("\n" handling). `mariadb` doesn't even seem to read the file...
+  mysql-tz:
+    depends: ['mysql']
+    run: 'loco-mysql-wait 300 && mysql_tzinfo_to_sql "$TZDIR" | mysql mysql && sleep 259200'
+
+  buildkit:
+    init:
+      - 'loco-buildkit-init'
+    message: 'Buildkit (<comment>$BKIT</comment>) is configured to use these services. It produces builds in "<comment>$HTTPD_VDROOT</comment>".'
+
+
+## Configure the loco=>systemd export
+export:
+  include_env: '/^(PATH|NIX_SSL_.*|LOCALE_ARCHIVE|TZDIR)$/'

--- a/nix/bin/use-bknix
+++ b/nix/bin/use-bknix
@@ -35,7 +35,6 @@ TXT_WHITE='\[\033[0;37m\]'
 MODE=env
 USE_LOCO_FILE=""
 PROFILE=
-RECURSE_OPT=
 
 if [ -z "$OWNER" ]; then
   OWNER=$USER
@@ -52,7 +51,6 @@ while [ -n "$1" ]; do
     -r|--run) MODE=run ; ;;
     -N|--worker-n)
       USE_LOCO_FILE=".loco/worker-n.yml"
-      RECURSE_OPT=--worker-n
       if [ "x$EXECUTOR_NUMBER" = "x" ]; then
         echo "Error: The --worker-n option requires EXECUTOR_NUMBER" 1>&2
         exit 1
@@ -125,45 +123,36 @@ if [ ! -d "$BKIT" ]; then
   echo "WARNING: Could not find suitable BKIT in \"$HOME\" (eg \"bknix\", \"buildkit\", \"bknix-min\")" >&2
 fi
 
+function createScript() {
+  CODE=`cd "$BKIT" && SHELL_VERBOSITY= loco env -c "$USE_LOCO_FILE" --export`
+  echo "$CODE"
+  eval "$CODE"
+  echo "export PS1=\"[${TXT_CYAN}bknix-$PROFILE${TXT_RESET}:${TXT_GREEN}\w${TXT_RESET}] \" ;"
+  bknix-profile env
+  if [ -f "$BKIT/nix/etc/bashrc.local" ]; then
+    echo "source \"$BKIT/nix/etc/bashrc.local\""
+  fi
+  echo
+}
+
+## Note: "mktemp" in BSD and GNU work differently, but this formulation seems close enough to be portable.
+TMPFILE=$(mktemp -t .use-bknix.XXXXXXXX)
+function cleanup_bashrc() {
+  rm -f "$TMPFILE"
+}
+trap cleanup_bashrc EXIT
+createScript > "$TMPFILE"
+
 case "$MODE" in
   env)
-    CODE=`cd "$BKIT" && SHELL_VERBOSITY= loco env -c "$USE_LOCO_FILE" --export`
-    echo "$CODE"
-    eval "$CODE"
-    echo "export PS1=\"[${TXT_CYAN}bknix-$PROFILE${TXT_RESET}:${TXT_GREEN}\w${TXT_RESET}] \" ;"
-    bknix-profile env
-    if [ -f "$BKIT/nix/etc/bashrc.local" ]; then
-      echo "source \"$BKIT/nix/etc/bashrc.local\""
-    fi
-    echo
+    cat "$TMPFILE"
     ;;
   shell)
-    ## We will can ourselves in --env mode and use that as the bash --rcfile.
-
     ## Bash v4(?) would support '--rcfile <( ...some command ... )'; but for
     ## backward compat, we explicitly make a temp file.
-
-    ## Note: "mktemp" in BSD and GNU work differently, but this formulation seems close enough to be portable.
-    TMPFILE=$(mktemp -t .use-bknix.XXXXXXXX)
-    function cleanup_bashrc() {
-      rm -f "$TMPFILE"
-    }
-    trap cleanup_bashrc EXIT
-
-    "$0" "$PROFILE" $RECURSE_OPT --env > "$TMPFILE"
     bash --rcfile "$TMPFILE" -i
     ;;
   run)
-    ## We will call ourselves in --env mode, load that, and then run the given command..
-
-    ## Note: "mktemp" in BSD and GNU work differently, but this formulation seems close enough to be portable.
-    TMPFILE=$(mktemp -t .use-bknix.XXXXXXXX)
-    function cleanup_bashrc() {
-      rm -f "$TMPFILE"
-    }
-    trap cleanup_bashrc EXIT
-
-    "$0" "$PROFILE" $RECURSE_OPT --env > "$TMPFILE"
     source "$TMPFILE"
     "$@"
     ;;

--- a/nix/bin/use-bknix
+++ b/nix/bin/use-bknix
@@ -33,44 +33,62 @@ TXT_WHITE='\[\033[0;37m\]'
 ## Input parsing
 
 MODE=env
+USE_LOCO_FILE=""
+PROFILE=
+RECURSE_OPT=
 
 if [ -z "$OWNER" ]; then
   OWNER=$USER
 fi
 
-PROFILE="$1"
-shift
+while [ -n "$1" ]; do
+  OPT="$1"
+  shift
 
-for BASEDIR in "/nix/var/nix/profiles/per-user/$OWNER" "/nix/var/nix/profiles" ;do
+  case "$OPT" in
+    old|min|dfl|max|edge) PROFILE="$OPT" ; ;;
+    -s|--shell) MODE=shell ; ;;
+    -e|--env) MODE=env ; ;;
+    -r|--run) MODE=run ; ;;
+    -N|--worker-n)
+      USE_LOCO_FILE=".loco/worker-n.yml"
+      RECURSE_OPT=--worker-n
+      if [ "x$EXECUTOR_NUMBER" = "x" ]; then
+        echo "Error: The --worker-n option requires EXECUTOR_NUMBER" 1>&2
+        exit 1
+      fi
+      ;;
+    *) echo "Unrecognized option: $OPT" ; exit 1 ; ;;
+  esac
+
+  if [ "$MODE" = "run" -a -n "$PROFILE" ]; then
+    ## The rest of the args are RUN_CMD.
+    break
+  fi
+done
+
+for BASEDIR in "/nix/var/nix/profiles/per-user/$OWNER" "/nix/var/nix/profiles" ; do
   PRFDIR="$BASEDIR/bknix-$PROFILE"
   if [ -d "$PRFDIR" ]; then
     break
   fi
 done
 
-if [ -n "$1" ]; then
-  case "$1" in
-    -s|--shell) MODE=shell ; ;;
-    -e|--env) MODE=env ; ;;
-    -r|--run) MODE=run ; ;;
-    *) MODE=env ; ;;
-  esac
-  shift
-else
-  MODE=env
-fi
+#echo "PARSED: PROFILE=$PROFILE MODE=$MODE USE_LOCO_FILE=$USE_LOCO_FILE PRFDIR=$PRFDIR" > /dev/stderr
+#exit 10
 
 ###########################################################
 ## Validation/help
 if [ -z "$PROFILE" -o ! -d "$PRFDIR" ]; then
   echo "The specified profile does not correspond to an actual profile"
   echo
-  echo "usage: $0 <profile> [-e|--env|-s|--shell|-r|--run] [runcmd]"
+  echo "usage: $0 <PROFILE> [-N|--worker-n] [-e|--env|-s|--shell|-r|--run] [RUN_CMD]"
   echo ""
   echo "options:"
-  echo "  -e|--env    Display environment variables for the profile"
-  echo "  -s|--shell  Open a subshell with the profile"
-  echo "  -r|--run    Run a command in a subshell"
+  echo "  -e|--env       Display environment variables for the profile"
+  echo "  -s|--shell     Open a subshell with the profile"
+  echo "  -r|--run       Run a command in a subshell"
+  echo "  -N|--worker-n  Allocate ports for a temporary worker #N"
   echo ""
   echo "example: Generate environment variables for \"dfl\" profile"
   echo "  $0 dfl"
@@ -86,10 +104,14 @@ fi
 ## Main
 
 export PATH="$PRFDIR/bin:$PATH"
-USE_LOCO_FILE=""
+# PATH="$HOME/src/loco/bin:$PATH"
 
 for CANDIDATE in "$HOME/bknix" "$HOME/bknix-$PROFILE" "$HOME/buildkit" "$HOME/buildkit-$PROFILE" ; do
-  if [ -f "$CANDIDATE/.loco/$OWNER-$PROFILE.yml" ]; then
+  if [ -n "$USE_LOCO_FILE" -a -f "$CANDIDATE/$USE_LOCO_FILE" ]; then
+    export BKIT="$CANDIDATE"
+    ## Keep USE_LOCO_FILE
+    break
+  elif [ -f "$CANDIDATE/.loco/$OWNER-$PROFILE.yml" ]; then
     export BKIT="$CANDIDATE"
     USE_LOCO_FILE=".loco/$OWNER-$PROFILE.yml"
     break
@@ -128,7 +150,7 @@ case "$MODE" in
     }
     trap cleanup_bashrc EXIT
 
-    "$0" "$PROFILE" --env > "$TMPFILE"
+    "$0" "$PROFILE" $RECURSE_OPT --env > "$TMPFILE"
     bash --rcfile "$TMPFILE" -i
     ;;
   run)
@@ -141,7 +163,7 @@ case "$MODE" in
     }
     trap cleanup_bashrc EXIT
 
-    "$0" "$PROFILE" --env > "$TMPFILE"
+    "$0" "$PROFILE" $RECURSE_OPT --env > "$TMPFILE"
     source "$TMPFILE"
     "$@"
     ;;

--- a/nix/pkgs/loco/default.nix
+++ b/nix/pkgs/loco/default.nix
@@ -7,8 +7,8 @@ in stdenv.mkDerivation rec {
 
     name = "loco";
     src = pkgs.fetchurl {
-      url = https://github.com/totten/loco/releases/download/v0.5.4/loco-0.5.4.phar;
-      sha256 = "tGCAuBy4LVjxvcMXCIZuyXMy+qgfAdHFgpGpxWmshxs=";
+      url = https://github.com/totten/loco/releases/download/v0.6.0/loco-0.6.0.phar;
+      sha256 = "0cZJY01qsvAQ1rTtYjkdDsTc7Jmgku8y2g1Kn1mixa8=";
       executable = true;
     };
     buildInputs = [ ];

--- a/nix/pkgs/loco/default.nix
+++ b/nix/pkgs/loco/default.nix
@@ -7,8 +7,8 @@ in stdenv.mkDerivation rec {
 
     name = "loco";
     src = pkgs.fetchurl {
-      url = https://github.com/totten/loco/releases/download/v0.6.1/loco-0.6.1.phar;
-      sha256 = "lmJxtEjOQWiy60paxjX7VHmVNQjksOejlN0nAgD/7sQ=";
+      url = https://github.com/totten/loco/releases/download/v0.6.2/loco-0.6.2.phar;
+      sha256 = "Y95wgEK3/6cXHPLUlsD+Cq2D/ZILZYUpr1Xn5bsYSYo=";
       executable = true;
     };
     buildInputs = [ ];

--- a/nix/pkgs/loco/default.nix
+++ b/nix/pkgs/loco/default.nix
@@ -7,8 +7,8 @@ in stdenv.mkDerivation rec {
 
     name = "loco";
     src = pkgs.fetchurl {
-      url = https://github.com/totten/loco/releases/download/v0.6.0/loco-0.6.0.phar;
-      sha256 = "0cZJY01qsvAQ1rTtYjkdDsTc7Jmgku8y2g1Kn1mixa8=";
+      url = https://github.com/totten/loco/releases/download/v0.6.1/loco-0.6.1.phar;
+      sha256 = "lmJxtEjOQWiy60paxjX7VHmVNQjksOejlN0nAgD/7sQ=";
       executable = true;
     };
     buildInputs = [ ];


### PR DESCRIPTION
Use Cases
----------------

Before describing the PR specifically, let's compare some use-cases.

| Use-case | Lifecycle | Launcher |
| -- | -- | -- |
| __Local development__ | At any given time, you run one stack (*`min` or `max` or `edge` or similar*), and you want full access to it. You may periodically switch to a different stack, and the general settings (*port numbers, file-paths, etc*) should stay the same. | Use `loco run` to execute the services in foreground. |
| __Autobuild test-sites__ | At any given time, you have a rotating set of 10-40 test-sites running on 3-4 stacks (`min` and `max` and `edge`, etc). All stacks run in parallel. | Use `loco export` to configure `systemd` to run all services. |
| __Transactional test-runs__ | At any given time, you have 0-3 test scripts (eg `phpunit`) evaluating 0-3 PRs. Each script initializes and destroys its own copy of the stack. | Use `loco start`/`loco stop` to temporarily run independent services. |

This PR adds better support for __Transactional test-runs__.

Before
---------

* For __Local development__, define one configuration (`.loco/loco.yml`) with well-established ports. (Ex: `8001` is always httpd, regardless of your version of apache/php/etc).
* For __Autobuild test-sites__, define many configurations (`.loco/jenkins-min.yml`, `.loco/jenkins-max.yml`, etc). Each configuration has distinct and stable ports. (Ex:`8002` is httpd for `min`, and `8003` is httpd for `max`.)
* No specific support for __Transactional test-runs__. They run on top of the __Autobuild test-sites__.

After
------

* For __Transactional test-runs__, define one configuration (`.loco/worker-n.yml`) with dynamic ports. These will only be used for the duration of the test-run.
    * When you start worker `#1`, it chooses a port (perhaps `6100` for httpd).
    * When you start worker `#2`, it chooses a different port (perhaps `6200` for httpd).
    * If you look into the PR, you will see the formula used to choose a dynamic port, eg
        ```
        MYSQLD_PORT=$(portnum "$BASE_PORT" "$EXECUTOR_NUMBER" 1)
        ```


Example (1)
------------

On my local system, I created a new user with their own copy of `buildkit` and did a transactional test-run with this script:

```bash
#!/usr/bin/env bash

## Mock the Jenkins environment
export EXECUTOR_NUMBER=1
export WORKSPACE="$HOME/fake-jenkins/workspace/FakeJob"
mkdir -p "$WORKSPACE"
git config --global user.email "jenkins@example.com"
git config --global user.name "Jenkins CI"

## Run the job
eval $(use-bknix min -e -N)
cd "$LOCO_PRJ"
loco start
civi-test-pr --patch="https://github.com/civicrm/civicrm-core/pull/25445" phpunit-e2e karma --no-interaction
loco stop

## Assert: $WORKSPACE/junit now has test-results from the E2E and karma suites.
```

Important notes:

* As before, `use-bknix` configures the environment to reference the requested stack (e.g. `min`).
* __New__: When calling `use-bknix`, pass `-N` (`--worker-n`) to use `worker-n.yml` and its dynamic ports.
* __New__: Explicitly start and stop services (at the start and end of the test-run).

Example (2)
------------

On my local system, as my regular user (with `buildkit` installed), I can run the transactional test-script with one command:

```
EXECUTOR_NUMBER=1 use-bknix min -N -r \
  civi-test-pr -n --loco --patch=https://github.com/civicrm/civicrm-core/pull/25445 phpunit-e2e 
```

Important notes:

* As in Example (1), the environment is setup with `use-bknix` and `-N` (`--worker-n`).
* __New__: The test script automatically starts and stops services via loco (`--loco`).

Compared to Example (1), this should be more maintainable (e.g. multiple jobs share the code), and it should be better at cleanup (e.g. the "shutdown" steps are effectively in a `try/finally` block).