### PR TITLE
install-runner.sh - Script to setup transactional test host

### DIFF
--- a/.loco/worker-n.yml
+++ b/.loco/worker-n.yml
@@ -50,6 +50,9 @@ environment:
  # CLI applications should use our stuff
  - AMPHOME=$HOME/_bknix/amp/worker-$EXECUTOR_NUMBER
  - CIVIBUILD_HOME=$HTTPD_VDROOT
+ #- CIVIBUILD_HOME=$HOME/_bknix/civibuild
+ #^^^ Would move the cache folder, which means that you could have the rest of the `build/` folder on ramdis.
+ #However, the startup script (install-runner.sh) doesn't quite play nice because it's not using worker-n.yml.
  - BKIT=$LOCO_PRJ
  - BKITBLD=$HTTPD_VDROOT
  - MYSQL_HOME=$LOCO_VAR/mysql/conf

--- a/nix/README.md
+++ b/nix/README.md
@@ -20,10 +20,10 @@ CiviCRM system-requirements:
 Given that you have several pieces of software (e.g. PHP + MySQL + Redis), the *launcher* or *process manager*
 is responsible for starting and stopping processes. `bknix` works with a few launchers:
 
-* `loco run`: [Loco](https://github.com/totten/loco) runs local processes in the foreground. This is useful for local development.
+* `loco run` / `loco start`: [Loco](https://github.com/totten/loco) runs local processes in the foreground. This is useful for local development.
   It can be configured by editing the YAML file ([loco.yml](../.loco/loco.yml)), by setting environment variables
   (`HTTPD_PORT` et al), and/or by editing the [configuration templates](../.loco/config).
-* `systemd`: This is the most common process manager on Linux hosts. This is useful for CI nodes. The `loco.yml`
+* `systemd`: This is the most common process manager on Linux hosts. This is useful for long-running nodes. The `loco.yml`
   can be exported to systemd notation manually (via `loco export`) or automatically (as part of `install-ci.sh`).
 
 ## Usage
@@ -110,13 +110,26 @@ complete tutorial, choose from below:
     <tr>
       <td>
         <ul>
-          <li>Run frequent tests in a mix of environments (continuous-integration)</li>
+          <li>Run long-term services with multiple profiles (continuous-integration)</li>
         </ul>
       </td>
       <td>
         <ul>
           <li><a href="doc/requirements.md">System requirements</a></li>
           <li><a href="doc/install-ci.md">Install all profiles and system services for concurrent usage (<code>install-ci.sh</code>)</a></li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <ul>
+          <li>Run transactional services with multiple profiles (continuous-integration)</li>
+        </ul>
+      </td>
+      <td>
+        <ul>
+          <li><a href="doc/requirements.md">System requirements</a></li>
+          <li><a href="doc/install-runner.md">Install all profiles. Start and stop services for brief periods. (<code>install-runner.sh</code>)</a></li>
         </ul>
       </td>
     </tr>
@@ -139,7 +152,7 @@ With `nix-shell` or `install-developer.sh`, it is typical to only launch one
 | Mailcatcher (SMTP) (*loco-only*) | 1025  |
 | Mailcatcher (HTTP) (*loco-only*) | 1080  |
 
-With `install-ci.sh`, the services use a wide range of ports.
+With [`install-ci.sh`](doc/install-ci.md) or [`install-runner.sh`](doc/install-runner.md), the services use a wide range of ports.
 
 <!-- FIXME: Document use of HTTPD_PORT, MYSQLD_PORT, etc -->
 

--- a/nix/README.md
+++ b/nix/README.md
@@ -6,7 +6,7 @@ For discussion of strengths and weaknesses, see [Critical comparison](doc/compar
 
 ## Profiles
 
-A *profile* is list of packages (e.g. PHP 7.0 + MySQL 5.7 + Redis 4.0 + NodeJS 6.14).  `bknix` includes a few profiles designed around the
+A *profile* is list of packages (e.g. PHP 8.1 + MySQL 5.7 + Redis 4.0 + NodeJS 14.0).  `bknix` includes a few profiles designed around the
 CiviCRM system-requirements:
 
 * [dfl](profiles/dfl/default.nix): An in-between set of packages. This is a good default for middle-of-the-road testing/development.
@@ -20,7 +20,7 @@ CiviCRM system-requirements:
 Given that you have several pieces of software (e.g. PHP + MySQL + Redis), the *launcher* or *process manager*
 is responsible for starting and stopping processes. `bknix` works with a few launchers:
 
-* `loco run` / `loco start`: [Loco](https://github.com/totten/loco) runs local processes in the foreground. This is useful for local development.
+* `loco`: [Loco](https://github.com/totten/loco) runs local processes in the foreground (`loco run`) or background (`loco start`). This is useful for local development.
   It can be configured by editing the YAML file ([loco.yml](../.loco/loco.yml)), by setting environment variables
   (`HTTPD_PORT` et al), and/or by editing the [configuration templates](../.loco/config).
 * `systemd`: This is the most common process manager on Linux hosts. This is useful for long-running nodes. The `loco.yml`
@@ -33,7 +33,7 @@ For day-to-day usage, one must first launch the services (`mysqld`, `php-fpm`, e
 ```
 me@localhost:~$ cd bknix
 me@localhost:~/bknix$ nix-shell -A min
-[nix-shell:~/bknix]$ loco run
+[nix-shell:~/bknix]$ loco start
 ...
 ======================[ Startup Summary ]======================
 [VOLUME] Loco data volume is a ram disk "/Users/myuser/bknix/.loco/var".
@@ -44,28 +44,26 @@ me@localhost:~/bknix$ nix-shell -A min
 [mysql] MySQL is running on "127.0.0.1:3307". The default credentials are user="root" and password="".
 [buildkit] Buildkit (/Users/myuser/bknix/civicrm-buildkit) is configured to use these services. It produces builds in "/Users/myuser/bknix/build".
 
-Services have been started. To shutdown, press Ctrl-C.
+Services have been started. To shutdown, run 'loco stop'.
 ===============================================================
+
+[nix-shell:~/bknix]$ civibuild create dmaster --civi-ver 5.8
+...
+
+[nix-shell:~/bknix]$ loco stop
 ```
 
 In this example, note that:
 
 * We chose the profile `min`. This determines the specific software and versions that will be available.
 * We opened a suitable shell with `cd bknix` and `nix-shell -A min`.
-* We started the processes with `loco run`.
-* The services are running in the foreground -- additional errors and log messages will be displayed on this console.
-
-After launching the services, we can open another shell and do more development tasks -- such as building a test site:
-
-```
-me@localhost:~$ cd bknix
-me@localhost:~/bknix$ nix-shell -A min
-[nix-shell:~/bknix]$ civibuild create dmaster --civi-ver 5.8
-```
+* We started the services in background with `loco start`. (To run services in the foreground, use `loco run`.)
+* After launching the services, we can create specific test-sites running on top of them.
+* When we finish, stop the services with `loco stop`.
 
 ## Choose your own adventure
 
-The example above used `nix-shell` and `loco run`. This is good for experimenting with bknix in the CLI. However, 
+The example above used `nix-shell` and `loco start`. This is good for experimenting with bknix in the CLI. However,
 if you're using an IDE or continuous-testing server, then other approaches may work better. For a more
 complete tutorial, choose from below:
 

--- a/nix/bin/await-bknix.flag-file
+++ b/nix/bin/await-bknix.flag-file
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+## Usage: await-bknix <profile>
+## Purpose: Check to see if "profile" is online. Sleep+poll until it comes online.
+##
+## This implementation relies on having a system startup script to create the flag file "/var/local/bknix-ready"
+
+######################################################################
+
+## Polling interval
+SLEEP=5
+
+## Maximum amount of time to spend polling. After MAX_SLEEP, give up
+MAX_SLEEP=600
+
+######################################################################
+
+function usage() {
+  local prog=$(basename "$0")
+  echo "usage: $prog <user> <profile>"
+  echo "example: $prog $USER min"
+}
+
+## Check if the user/profile is online. Wait until it is.
+##
+## usage: main <user> <profile>
+## return: n/a
+function main() {
+  local slept=0
+
+  if [ -z "$1" -o -z "$2" ]; then
+    usage
+    exit 3
+  fi
+
+  echo "System uptime: $(uptime)"
+  echo "Ensuring that user $1 has active profile $2."
+
+  while true; do
+    if [ -f /var/local/bknix-ready ]; then
+      echo OK
+      break
+    fi
+
+    if [ $slept -lt $MAX_SLEEP ]; then
+      echo "Waiting..."
+      sleep "$SLEEP"
+      slept=$(( $SLEEP + $slept ))
+    else
+      echo "Services did not come online after $slept seconds. Giving up."
+      exit 2
+    fi
+  done
+}
+
+######################################################################
+main "$1" "$2"

--- a/nix/bin/install-runner.sh
+++ b/nix/bin/install-runner.sh
@@ -44,9 +44,15 @@ BKNIX_CI_TEMPLATE="runner"
 
 assert_root_user
 check_reqs
+if [ -f "/var/local/bknix-ready" ]; then
+  rm -f /var/local/bknix-ready
+fi
+
 install_cachix
 init_folder "$BKNIXSRC/examples/$BKNIX_CI_TEMPLATE" /etc/bknix-ci
 install_bin "$BINDIR"/use-bknix /usr/local/bin/use-bknix
-# install_bin "$BINDIR"/await-bknix /usr/local/bin/await-bknix
+install_bin "$BINDIR"/await-bknix.flag-file /usr/local/bin/await-bknix
 install_all_jenkins
 install_all_publisher
+
+touch /var/local/bknix-ready

--- a/nix/bin/install-runner.sh
+++ b/nix/bin/install-runner.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# This installs each of the bknix profiles in a way that's useful for the CI runners.
+# Specifically, for each profile:
+#   - Install the binaries in /nix/var/nix/profiles/bknix-$PROFILE
+#   - Initialize a data folder in /home/$OWNER/bknix-$PROFILE
+#   - Do not register systemd services for php/mysql/etc
+#
+# Pre-requisites:
+#   Use a Debian-like main OS
+#   Install the "nix" package manager.
+#   Only tested with multiuser mode.
+#   Login as proper root (e.g. `sudo -i bash`)
+#
+# Tip: The default list of active profiles for CI is "dfl min max" (jenkins).
+# To enable "old" or "edge" profiles (or "publisher" user), customize:
+#  - /etc/bknix-ci/install_all_jenkins.sh
+#  - /etc/bknix-ci/install_all_publisher.sh
+#
+# Example: Install (or upgrade) all the profiles
+#   ./bin/install-runner.sh
+#
+# Example: Install (or upgrade) all the profiles, overwriting any local config files
+#   FORCE_INIT=-f ./bin/install-runner.sh
+#
+# After installation, an automated script can use a statement like:
+#    eval $(use-bknix min)
+#    eval $(use-bknix max)
+#    eval $(use-bknix dfl)
+
+###########################################################
+## Bootstrap
+
+set -e
+BINDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+BKNIXSRC=$(dirname "$BINDIR")
+cd "$BKNIXSRC"
+source "$BINDIR/../lib/common.sh"
+
+###########################################################
+## Main
+
+BKNIX_CI_TEMPLATE="runner"
+
+assert_root_user
+check_reqs
+install_cachix
+init_folder "$BKNIXSRC/examples/$BKNIX_CI_TEMPLATE" /etc/bknix-ci
+install_bin "$BINDIR"/use-bknix /usr/local/bin/use-bknix
+# install_bin "$BINDIR"/await-bknix /usr/local/bin/await-bknix
+install_all_jenkins
+install_all_publisher

--- a/nix/bin/use-bknix
+++ b/nix/bin/use-bknix
@@ -56,6 +56,12 @@ while [ -n "$1" ]; do
         exit 1
       fi
       ;;
+    -N0) USE_LOCO_FILE=".loco/worker-n.yml" ; export EXECUTOR_NUMBER=0 ; ;;
+    -N1) USE_LOCO_FILE=".loco/worker-n.yml" ; export EXECUTOR_NUMBER=1 ; ;;
+    -N2) USE_LOCO_FILE=".loco/worker-n.yml" ; export EXECUTOR_NUMBER=2 ; ;;
+    -N3) USE_LOCO_FILE=".loco/worker-n.yml" ; export EXECUTOR_NUMBER=3 ; ;;
+    -N4) USE_LOCO_FILE=".loco/worker-n.yml" ; export EXECUTOR_NUMBER=4 ; ;;
+    -N5) USE_LOCO_FILE=".loco/worker-n.yml" ; export EXECUTOR_NUMBER=5 ; ;;
     *) echo "Unrecognized option: $OPT" ; exit 1 ; ;;
   esac
 

--- a/nix/doc/install-ci.md
+++ b/nix/doc/install-ci.md
@@ -1,8 +1,8 @@
-# Installation for Jenkins/CI Worker nodes
+# Installation for Jenkins/CI Worker nodes (Long Running)
 
 A Jenkins/CI worker node, we want all profiles to be used concurrently. For each profile:
 
-* There is a configuration file, `.loco/USER-PROFILE.yaml` which lists the services.
+* There is a configuration file, `.loco/USER-PROFILE.yml` which lists the services.
 * The binaries are installed to `/nix/var/nix/profiles/bknix-PROFILE/bin`
 * The data directory is `~/bknix-PROFILE`
 * Each service from the YAML file is installed in `systemd`

--- a/nix/doc/install-runner.md
+++ b/nix/doc/install-runner.md
@@ -1,0 +1,71 @@
+# Installation for Jenkins/CI Worker nodes (Transactional)
+
+A Jenkins/CI worker node. All binaries/profiles are preinstalled. Services are stopped and started transactionally (*for specific tasks*).
+
+* There is a configuration file, `.loco/worker-n.yml` which lists the services.
+* The binaries are installed to `/nix/var/nix/profiles/bknix-PROFILE/bin`
+* The data directory is `~/bknix`
+* Services are started and stopped as-needed (using `loco start` or `loco run`).
+* Each service has its own unique port.
+
+| Service     | Worker 0     | Worker 1     | Worker 2     |
+|-------------|--------------|--------------|--------------|
+| Apache HTTP | 6000         | 6100         | 6200         |
+| Memcached   | 6006         | 6106         | 6206         |
+| MySQL       | 6001         | 6101         | 6201         |
+| PHP FPM     | 6002         | 6102         | 6202         |
+| PHP Xdebug  | 9003         | 9003         | 9003         |
+| Redis       | 6005         | 6105         | 6205         |
+
+## Initial installation
+
+(*These steps were developed on Debian 9.*)
+
+```bash
+## Install multiuser nix pkg mgr, per https://nixos.org/nix/manual/#sect-multi-user-installation
+sudo apt-get install rsync
+sh <(curl https://nixos.org/nix/install) --daemon
+
+## Get the config file
+sudo -i bash
+git clone https://github.com/civicrm/civicrm-buildkit /root/buildkit
+cd /root/buildkit
+
+## Initialize the min, max, and dfl profiles for the users "jenkins" and "publisher"
+./nix/bin/install-runner.sh
+
+## Do a trial run
+su - jenkins
+EXECUTOR_NUMBER=1 use-bknix dfl -s -N
+which php
+php --version
+loco start
+# ... and so on ...
+loco stop
+```
+
+## Updates
+
+There are two typical levels of updates:
+
+1. (*Lighter*) Update all copies of `civicrm-buildkit.git` to revise the common CLI tools (`cv`, `drush`, etc).
+2. (*More thorough*) Update all copies of `civicrm-buildkit.git` as well as all service binaries (`httpd`, `mysqld`, etc).
+
+For the lighter update:
+
+```bash
+sudo -i bash
+cd /root/buildkit/
+./nix/bin/update-ci-buildkit.sh
+```
+
+For a the thorough update:
+
+```bash
+sudo -i bash
+cd /root/buildkit/
+./nix/bin/install-ci.sh
+```
+
+(TIP: If this complains about missing nix commands, then the call to su/sudo may not have properly managed
+the environment. Try a different form of su/sudo.)

--- a/nix/examples/runner/install_all_jenkins.sh
+++ b/nix/examples/runner/install_all_jenkins.sh
@@ -7,6 +7,7 @@
 
 RAMDISKSIZE=3G
 PROFILES="dfl min max edge"
+SPLIT_BUILDKIT=0
 
 ## Services are started transactionally
 NO_SYSTEMD=1

--- a/nix/examples/runner/install_all_jenkins.sh
+++ b/nix/examples/runner/install_all_jenkins.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+## This is an example of how to setup /etc/bknix-ci/install_all_jenkins.sh
+## for an ephmeral taskr-running node.
+##
+## It defines very high-level options for installing profiles for user "jenkins".
+
+RAMDISKSIZE=3G
+PROFILES="dfl min max edge"
+
+## Services are started transactionally
+NO_SYSTEMD=1
+SYSTEMD_ENABLE="no"
+SYSTEMD_START="no"

--- a/nix/examples/runner/install_all_publisher.sh
+++ b/nix/examples/runner/install_all_publisher.sh
@@ -7,6 +7,7 @@
 
 RAMDISKSIZE=250M
 PROFILES="min"
+SPLIT_BUILDKIT=0
 
 ## Services are started transactionally
 NO_SYSTEMD=1

--- a/nix/examples/runner/install_all_publisher.sh
+++ b/nix/examples/runner/install_all_publisher.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+## This is an example of how to setup /etc/bknix-ci/install_all_publisher.sh
+## for an ephmeral taskr-running node.
+##
+## It defines very high-level options for installing profiles for user "publisher".
+
+RAMDISKSIZE=250M
+PROFILES="min"
+
+## Services are started transactionally
+NO_SYSTEMD=1
+SYSTEMD_ENABLE="no"
+SYSTEMD_START="no"

--- a/nix/examples/runner/loco-overrides.yaml
+++ b/nix/examples/runner/loco-overrides.yaml
@@ -1,0 +1,5 @@
+## The "nip" examples are used on "A.B.C.D.nip.io" hosts
+environment:
+  ## Local-only deployments cannot be accessed on public Internet.
+  ## But we still want a wildcard DNS for '{buildname}.{hostname}`.
+  - HTTPD_DOMAIN=${LOCALHOST}.nip.io


### PR DESCRIPTION
This script configures a node for use as a transactional test runner. 