### PR TITLE
loco.yml - For local dev, prefer symlinked assets

### DIFF
--- a/.loco/loco.yml
+++ b/.loco/loco.yml
@@ -51,6 +51,7 @@ environment:
  - MYSQL_HOME=$LOCO_VAR/mysql/conf
  - NODE_PATH=$BKIT/node_modules:$NODE_PATH
  - PATH=$BKIT/bin:$BKIT/node_modules/.bin:$LOCO_PRJ/.loco/bin:$PATH
+ - CIVICRM_COMPOSER_ASSET=symdir
 
 volume:
   ramdisk: $RAMDISK_SIZE


### PR DESCRIPTION
* _Before_: When you install standalone or d9 on "bknix"/"loco", it publishes assets by _copying all the files_. That default is the lowest-common-denominator that's everywhere. 
* _After_: When you install standalone or d9 on "bknix"/"loco", it publishes assets by _symlinking the folders_. That should require less fussing around with `composer civicrm:publish` calls during development.
* _Comment_:
    * If you're using "bknix"/"loco", then you should have symlink support.
    * This shouldn't have any effect on other environments (e.g. Jenkins workers; e.g. `apt`-based or `docker`-based workstations).