### PR TITLE
standalone - A few fixes

### DIFF
--- a/app/config/standalone-clean/download.sh
+++ b/app/config/standalone-clean/download.sh
@@ -7,6 +7,11 @@
 # @todo Requires that we register with packagist?
 # mkdir "$WEB_ROOT"
 # composer create-project civicrm/civicrm-standalone "$WEB_ROOT" --no-interaction
-git clone https://github.com/civicrm/civicrm-standalone $WEB_ROOT
-cd $WEB_ROOT
-composer install
+git clone https://github.com/civicrm/civicrm-standalone "$WEB_ROOT"
+# git clone https://github.com/artfulrobot/civicrm-standalone -b artfulrobot-clean-install-paths "$WEB_ROOT"
+
+pushd "$WEB_ROOT"
+  amp datadir "./data" "./web/uploads"
+  composer install
+  composer civicrm:publish
+popd

--- a/app/config/standalone-clean/download.sh
+++ b/app/config/standalone-clean/download.sh
@@ -4,13 +4,20 @@
 
 ###############################################################################
 
-# @todo Requires that we register with packagist?
-# mkdir "$WEB_ROOT"
-# composer create-project civicrm/civicrm-standalone "$WEB_ROOT" --no-interaction
+[ -z "$CMS_VERSION" ] && CMS_VERSION=master
+## Interpreted as tag/branch of "civicrm-standalone.git".
+## May use git remotes to referencing Github ("{user}/{branch}").
+
 git clone https://github.com/civicrm/civicrm-standalone "$WEB_ROOT"
-# git clone https://github.com/artfulrobot/civicrm-standalone -b artfulrobot-clean-install-paths "$WEB_ROOT"
 
 pushd "$WEB_ROOT"
+  if [[ "$CMS_VERSION" == *"/"* ]]; then
+    _git_owner=$(dirname "$CMS_VERSION")
+    git remote add "$_git_owner" "https://github.com/${_git_owner}/civicrm-standalone.git"
+    git fetch "$_git_owner"
+  fi
+  git checkout "$CMS_VERSION"
+
   amp datadir "./data" "./web/uploads"
   composer install
   composer civicrm:publish

--- a/app/config/standalone-clean/install.sh
+++ b/app/config/standalone-clean/install.sh
@@ -15,6 +15,8 @@ CIVI_DOMAIN_NAME="Demonstrators Anonymous"
 CIVI_DOMAIN_EMAIL="\"Demonstrators Anonymous\" <info@example.org>"
 CIVI_CORE="${WEB_ROOT}/vendor/civicrm/civicrm-core"
 CIVI_UF="Standalone"
+CIVI_SETTINGS="${WEB_ROOT}/data/civicrm.settings.php"
+CIVI_TEMPLATEC="${WEB_ROOT}/data/templates_c"
 GENCODE_CONFIG_TEMPLATE="${CMS_ROOT}/civicrm.config.php.standalone"
 
 civicrm_install_cv

--- a/app/config/standalone-clean/uninstall.sh
+++ b/app/config/standalone-clean/uninstall.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+## uninstall.sh -- Delete config files and databases
+
+###############################################################################
+
+if [ -f "$CIVI_SETTINGS" ]; then
+  chmod u+w $(dirname "$CIVI_SETTINGS")
+  rm -f "$CIVI_SETTINGS"
+fi
+
+amp_uninstall


### PR DESCRIPTION
* Auto-publish assets
   * Note: I personally like [symdir style](https://lab.civicrm.org/dev/civicrm-asset-plugin/#options) and opened a separate (#766) as way to encourage it without forcing it everywhere.
* Mark data folder permissions
   * @artfulrobot This expands on [this line](https://github.com/artfulrobot/civicrm-buildkit/blob/3641381ec8f1d4f1f76d52db2f2e7958af41b21a/app/config/standalone-clean/download.sh#L17) in your branch. The command `amp datadir` is a bit like `chmod a+rwx`, but it adapts to [local policy](https://github.com/amp-cli/amp/blob/master/doc/perm.md).
* Fix support for `civibuild reinstall <sitename>`
    * This requires some extra bits for removing the old configuration.