### PR TITLE
(REF) PHPUnit - Allow env-var to specify version

### DIFF
--- a/bin/civi-test-run
+++ b/bin/civi-test-run
@@ -99,7 +99,7 @@ function task_phpunit() {
 ## usage: task_phpunit_expr <logical-suite-name> <pwd> [...phpunit file/filter options...]
 ## example: task_phpunit_expr Foo.xml "$CIVI_CORE" tests/phpunit/Foo/
 function task_phpunit_expr() {
-  local PHPUNIT=$(getPhpunitVer)
+  local PHPUNIT_BASE=$(getPhpunitVer)
   local SUITE_NAME="$1"
   local WORK_DIR="$2"
   shift 2
@@ -107,7 +107,7 @@ function task_phpunit_expr() {
   [ ! -d "$JUNITDIR" ] && mkdir -p "$JUNITDIR"
 
   pushd "$WORK_DIR"
-    if ! $GUARD $TIMER $PHPUNIT ${PHPUNIT_ARGS[@]} --log-junit "$JUNITDIR/$SUITE_NAME.xml" "$@" ; then
+    if ! $GUARD $TIMER $PHPUNIT_BASE ${PHPUNIT_ARGS[@]} --log-junit "$JUNITDIR/$SUITE_NAME.xml" "$@" ; then
       EXITCODES="$EXITCODES phpunit"
     fi
     echo "Found EXITCODES=\"$EXITCODES\""

--- a/bin/civi-test-run
+++ b/bin/civi-test-run
@@ -3,6 +3,23 @@ set -e
 TIMER=vtime
 
 function getPhpunitVer() {
+  if [ -n "$PHPUNIT" ]; then
+    case "$PHPUNIT" in
+      phpunit5)
+        echo "$PHPUNIT --tap"
+        return
+        ;;
+      phpunit6|phpunit7|phpunit8)
+        echo "$PHPUNIT --printer \Civi\Test\TAP"
+        return
+        ;;
+      phpunit9)
+        echo "$PHPUNIT --debug"
+        return
+        ;;
+    esac
+  fi
+
   CIVIVER=$(getCiviVer)
   if [ $(php -r "echo version_compare('$CIVIVER', '5.39', '>=');") ]; then
     echo "phpunit8 --printer \Civi\Test\TAP"
@@ -123,7 +140,7 @@ function task_phpunit_core_extension() {
 
   pushd "$CIVI_CORE/ext/$EXTENSION"
     for GROUP in headless e2e ; do
-      if ! $GUARD $TIMER $(getPhpunitVer) --printer='Civi\Test\TAP' --log-junit="$JUNITDIR/junit-${JUNIT_NAME}-${GROUP}.xml" --group "$GROUP" ; then
+      if ! $GUARD $TIMER $(getPhpunitVer) --log-junit="$JUNITDIR/junit-${JUNIT_NAME}-${GROUP}.xml" --group "$GROUP" ; then
        EXITCODES="$EXITCODES $EXTENSION-$GROUP"
      fi
      echo "Found EXITCODES=\"$EXITCODES\""

--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,7 @@
       "phpunit6": {"version": "6.x", "url": "https://phar.phpunit.de/phpunit-6.phar", "path": "extern/phpunit6/phpunit6.phar", "type": "phar"},
       "phpunit7": {"version": "7.5.15", "url": "https://phar.phpunit.de/phpunit-7.5.15.phar", "path": "extern/phpunit7/phpunit7.phar", "type": "phar"},
       "phpunit8": {"version": "8.5.27", "url": "https://phar.phpunit.de/phpunit-{$version}.phar", "path": "extern/phpunit8/phpunit8.phar", "type": "phar"},
-      "phpunit9": {"version": "9.5.21", "url": "https://phar.phpunit.de/phpunit-{$version}.phar", "path": "extern/phpunit9/phpunit9.phar", "type": "phar"},
+      "phpunit9": {"version": "9.6.5", "url": "https://phar.phpunit.de/phpunit-{$version}.phar", "path": "extern/phpunit9/phpunit9.phar", "type": "phar"},
       "phpunit-xml-cleanup": {"version": "0.2", "url": "https://raw.githubusercontent.com/civicrm/phpunit-xml-cleanup/v{$version}/bin/phpunit-xml-cleanup", "path": "extern/phpunit-xml-cleanup.php", "type": "file"},
       "pogo": {"version": "0.5.0", "url": "https://github.com/totten/pogo/releases/download/v{$version}/pogo-{$version}.phar", "path": "bin/pogo", "type": "phar"},
       "wp": {"version": "2.6.0", "url": "https://github.com/wp-cli/wp-cli/releases/download/v{$version}/wp-cli-{$version}.phar", "path": "bin/wp", "type": "phar"}

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ededac91487bc5bc9c4f3c0ebfe08967",
+    "content-hash": "c97ef9da4b73eb7c0bd050e5eba48de1",
     "packages": [
         {
             "name": "civicrm/composer-downloads-plugin",


### PR DESCRIPTION
# Overview

Make it easier to pre-run tests on newer versions of phpunit.

(*This PR is a related to https://github.com/civicrm/civicrm-core/pull/25836, but there is no specific dependency between them. They can be merged independently.*)

# Before

* Autodetect PHPUnit version based on CiviCRM version. (De facto choice: `phpunit8`)

# After

* Optionally, set env-var `PHPUNIT` to the name/path of the PHPUnit command.
* Autodetect PHPUnit version based on PHP version. (De facto choice: `phpunit8`)


