### PR TITLE
bknix - Declare `coreutils` requirement

### DIFF
--- a/nix/profiles/base/default.nix
+++ b/nix/profiles/base/default.nix
@@ -9,6 +9,7 @@ in [
     pkgs.ansi2html
     pkgs.bzip2
     dists.bkit.bknixProfile
+    pkgs.coreutils
     pkgs.curl
     pkgs.gettext
     pkgs.git


### PR DESCRIPTION
coreutils is the GNU package providing commands like [`ls`,`chmod`, `df`, and so on](https://github.com/coreutils/coreutils/tree/master/src).

It's generally implicit that all the environments running buildkit have these commands.  However, at one point I found it handy to specifically load this.  (I think I was playing around with Docker builds based on bknix profiles?  Or maybe using `--pure`? It might also help things like #779?) I've had this patch sitting on my laptop for a while and figured "Commit it or lose it".

In any event, the effect of this patch should be that bknix environments will use specific versions of `ls`, `chmod`, etc as per nixpkgs (rather than inheriting the versions from the host).
