### PR TITLE
civilint - Call "civistrings" and look for warnings

### DIFF
--- a/bin/civilint
+++ b/bin/civilint
@@ -219,6 +219,16 @@ if grep -q . "$TMP/js.txt" ; then
   fi
 fi
 
+CIVISTRINGS_EXIT=0
+if grep -q . "$TMP/js.txt" "$TMP/php.txt" ; then
+  echo "============================[ civistrings ]============================="
+  cat  "$TMP/js.txt" "$TMP/php.txt" | ( xargs $BINDIR/civistrings 2>&1 ) | grep '^\[warn' > "$TMP/civistrings-check.log"
+  if grep -q . "$TMP/civistrings-check.log" ; then
+    CIVISTRINGS_EXIT=1
+    cat "$TMP/civistrings-check.log"
+  fi
+fi
+
 ## Finish up
 if [ "$PHPCS_EXIT" -gt 0 -o "$PHPL_EXIT" -gt 0 ]; then
   echo >&2 "Found PHP errors"
@@ -229,6 +239,9 @@ fi
 if [ "$JSHINT_EXIT" -gt 0 ]; then
   echo >&2 "Found JS errors"
 fi
-if [ "$PHPCS_EXIT" -gt 0 -o "$PHPL_EXIT" -gt 0 -o "$PHPCS_CSS_EXIT" -gt 0 -o "$JSHINT_EXIT" -gt 0 ]; then
+if [ "$CIVISTRINGS_EXIT" -gt 0 ]; then
+  echo >&2 "Found civistrings errors"
+fi
+if [ "$PHPCS_EXIT" -gt 0 -o "$PHPL_EXIT" -gt 0 -o "$PHPCS_CSS_EXIT" -gt 0 -o "$JSHINT_EXIT" -gt 0 -o "$CIVISTRINGS_EXIT" -gt 0 ]; then
   exit 1
 fi


### PR DESCRIPTION
@mlutfy - I was reading [this comment](https://github.com/civicrm/civicrm-core/pull/26565#issuecomment-1599288709) and took a quick stab at updating civilint. In principle, this would cause the style-checks to fail if a modified file has any warnings from `civistrings`.

There are two things I'm not sure about here:

1. The specific error message would only be on the console. (Takes a little more work to bubble-up to the report in Jenkins.) But that's livable (and maybe fixable).
2. It may be a little too zealous? Like, it would enforce style-rules on pre-existing things in all branches (e.g. current patch went into 5.64-dev; so 5.63-rc and 5.62-stable still have more messy bits). And there are a few oddballs where it's intentionally deviant (e.g. `Civi/Angular/Manager.php` `getTranslatedStrings()`).