### PR TITLE
civicrm_install_cv - On "Standalone", convey ADMIN_USER, ADMIN_PASS, ADMIN_EMAIL

### DIFF
--- a/src/civibuild.lib.sh
+++ b/src/civibuild.lib.sh
@@ -689,8 +689,16 @@ function civicrm_install_cv() {
 
   local loadGenOpt
   [ -n "$NO_SAMPLE_DATA" ] && loadGenOpt="" || loadGenOpt="-m loadGenerated=1"
+  declare -a installOpts=()
+  if [ "$CIVI_UF" == "Standalone" ]; then
+    cvutil_assertvars civicrm_install ADMIN_USER ADMIN_PASS ADMIN_EMAIL
+    installOpts+=("-m" "extras.adminUser=$ADMIN_USER" "-m" "extras.adminPass=$ADMIN_PASS" -m "extras.adminEmail=$ADMIN_EMAIL")
+  fi
+  if [ -z "$NO_SAMPLE_DATA" ]; then
+    installOpts+=("-m" "loadGenerated=1")
+  fi
 
-  cv core:install -vv -f --cms-base-url="$CMS_URL" --db="$CIVI_DB_DSN" -m "siteKey=$CIVI_SITE_KEY" $loadGenOpt
+  cv core:install -vv -f --cms-base-url="$CMS_URL" --db="$CIVI_DB_DSN" -m "siteKey=$CIVI_SITE_KEY" "${installOpts[@]}"
   local settings=$( cv ev 'echo CIVICRM_SETTINGS_PATH;' )
   cvutil_inject_settings "$settings" "civicrm.settings.d"
   civicrm_update_domain


### PR DESCRIPTION
Background:

* Most build profiles allow you to specify the `--admin-user`, `--admin-pass`, `--admin-email`.
* These correspond to env-vars ADMIN_USER, ADMIN_PASS, ADMIN_EMAIL -- which are stored persistently.

Before:

* When building a standalone site, these flags aren't respected.
* New password generated everytime you call `civibuild reinstall`.

After:

* When building a standalone site, these flags are respected (*assuming https://github.com/civicrm/civicrm-core/pull/26643 is merged*)
* Password is stable (remains the same with each call to `civibuild reinstall`).

Comment:

* This depends on 26643 to work correctly - but the order-of-merges should be forgiving. (If we merge this first, then it shouldn't break anything - we just won't get the fix yet.)