### PR TITLE
Standalone - Support for HAN-C and HAN-D

### DIFF
--- a/app/config/standalone-clean/install.sh
+++ b/app/config/standalone-clean/install.sh
@@ -19,6 +19,12 @@ CIVI_SETTINGS="${WEB_ROOT}/data/civicrm.settings.php"
 CIVI_TEMPLATEC="${WEB_ROOT}/data/templates_c"
 GENCODE_CONFIG_TEMPLATE="${CMS_ROOT}/civicrm.config.php.standalone"
 
+pushd "$CIVI_CORE"
+  ./tools/standalone/bin/scaffold "$WEB_ROOT"
+  ## This may technically be a bit redundant with 'composer install' for new builds.
+  ## But for long-lived sites that have rebuilds, it's handy.
+popd
+
 civicrm_install_cv
 
 composer civicrm:publish

--- a/app/config/standalone-dev/demo-user.php
+++ b/app/config/standalone-dev/demo-user.php
@@ -1,0 +1,38 @@
+<?php
+
+// Add a demo user.
+
+if (PHP_SAPI !== 'cli') {
+  die("phpunit can only be run from command line.");
+}
+
+foreach (['DEMO_EMAIL', 'DEMO_USER', 'DEMO_PASS'] as $var) {
+  if (empty(getenv($var))) {
+    throw new \Exception("Missing: $var");
+  }
+}
+
+// Since users+contacts are stored in same DB, we can do transaction.
+CRM_Core_Transaction::create()->run(function () {
+
+  $contactID = \Civi\Api4\Contact::create(FALSE)
+    ->setValues([
+      'contact_type' => 'Individual',
+      'first_name' => 'Demo',
+      'last_name' => 'User',
+    ])
+    ->execute()->first()['id'];
+  $adminEmail = getenv('DEMO_EMAIL');
+  $params = [
+    'cms_name' => getenv('DEMO_USER'),
+    'cms_pass' => getenv('DEMO_PASS'),
+    'notify' => FALSE,
+    $adminEmail => $adminEmail,
+    'contactID' => $contactID,
+  ];
+  $userID = \CRM_Core_BAO_CMSUser::create($params, $adminEmail);
+
+  // @todo decide which permissions the demo user should have; create a role for those; apply the role to the user.
+  // This code can be added later once the data structures for roles etc. have settled.
+
+});

--- a/app/config/standalone-dev/download.sh
+++ b/app/config/standalone-dev/download.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+## download.sh -- Download CiviCRM core and configure it for standalone development
+
+###############################################################################
+
+[ -z "$CMS_VERSION" ] && CMS_VERSION=master
+## Hmm, not really used...
+
+mkdir -p "$WEB_ROOT" "$WEB_ROOT/web" "$WEB_ROOT/web/uploads" "$WEB_ROOT/data"
+
+pushd "$WEB_ROOT"
+  amp datadir "./data" "./web/uploads"
+
+  git clone ${CACHE_DIR}/civicrm/civicrm-core.git                     -b "$CIVI_VERSION" web/core
+  git clone ${CACHE_DIR}/civicrm/civicrm-packages.git                 -b "$CIVI_VERSION" web/core/packages
+popd
+
+pushd "$WEB_ROOT/web/core"
+  composer install
+popd

--- a/app/config/standalone-dev/install.sh
+++ b/app/config/standalone-dev/install.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+## install.sh -- Create config files and databases; fill the databases
+[ -d "$WEB_ROOT/web" ] && CMS_ROOT="$WEB_ROOT/web"
+
+###############################################################################
+## Create virtual-host and databases
+
+amp_install
+
+###############################################################################
+## Setup CiviCRM (config files, database tables)
+
+CIVI_DOMAIN_NAME="Demonstrators Anonymous"
+CIVI_DOMAIN_EMAIL="\"Demonstrators Anonymous\" <info@example.org>"
+CIVI_CORE="${WEB_ROOT}/web/core"
+CIVI_UF="Standalone"
+CIVI_SETTINGS="${WEB_ROOT}/data/civicrm.settings.php"
+CIVI_TEMPLATEC="${WEB_ROOT}/data/templates_c"
+GENCODE_CONFIG_TEMPLATE="${CMS_ROOT}/civicrm.config.php.standalone"
+
+pushd "$CIVI_CORE"
+  ./tools/standalone/bin/scaffold "$WEB_ROOT"
+  ## This may technically be a bit redundant with 'composer install' for new builds.
+  ## But for long-lived sites that have rebuilds, it's handy.
+popd
+
+civicrm_install_cv
+
+###############################################################################
+## Extra configuration
+
+env DEMO_USER="$DEMO_USER" DEMO_PASS="$DEMO_PASS" DEMO_EMAIL="$DEMO_EMAIL" \
+  cv scr "$SITE_CONFIG_DIR/demo-user.php"
+  ## Might be nice as a dedicated command...

--- a/app/config/standalone-dev/serve.sh
+++ b/app/config/standalone-dev/serve.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+cvutil_assertvars standalone_serve CMS_ROOT CIVI_CORE CMS_URL
+
+export PHP_CLI_SERVER_WORKERS=5
+PHP_SERVE=$( echo "$CMS_URL" | cut -f3 -d/ )
+
+pushd "$CMS_ROOT"
+  php -S "$PHP_SERVE" -t "$CMS_ROOT" "$CIVI_CORE/tools/standalone/router.php"
+popd

--- a/app/config/standalone-dev/uninstall.sh
+++ b/app/config/standalone-dev/uninstall.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+## uninstall.sh -- Delete config files and databases
+
+###############################################################################
+
+if [ -f "$CIVI_SETTINGS" ]; then
+  chmod u+w $(dirname "$CIVI_SETTINGS")
+  rm -f "$CIVI_SETTINGS"
+fi
+
+amp_uninstall

--- a/src/civibuild.defaults.sh
+++ b/src/civibuild.defaults.sh
@@ -326,6 +326,7 @@ DECLARED_ACTIONS="
   phpunit-info
   run
   show
+  serve
   snapshot snapshots
   restore restore-all
   upgrade-test ut

--- a/src/command/serve.run.sh
+++ b/src/command/serve.run.sh
@@ -1,0 +1,12 @@
+cvutil_assertvars serve WEB_ROOT
+
+#PHP_SERVE=$( echo "$CMS_URL" | cut -f3 -d/ )
+#pushd "$CMS_ROOT"
+#  echo  php -S "$PHP_SERVE" -t "$CMS_ROOT" "$CIVI_CORE/tools/standalone/router.php"
+#  php -S "$PHP_SERVE" -t "$CMS_ROOT" "$CIVI_CORE/tools/standalone/router.php"
+#popd
+
+pushd "$WEB_ROOT" > /dev/null
+  civibuild_app_run serve
+popd > /dev/null
+

--- a/src/help/default.hlp
+++ b/src/help/default.hlp
@@ -14,6 +14,7 @@ civibuild [options] command
   [32mlist[0m                  Display a list of build-names found in the build directory
   [32medit [0m                 Edit the config file for a build or snapshot
   [32mshow[0m                  Show key details about the build
+  [32mserve[0m                 Run PHP CLI server (if supported)
  [33mSnapshots[0m
   [32msnapshots[0m             List available snapshots
   [32msnapshot[0m              Create a snapshot of the CMS+CRM DBs

--- a/src/help/serve.hlp
+++ b/src/help/serve.hlp
@@ -1,0 +1,11 @@
+[33mUsage:[0m
+  serve <build-name>
+
+[33mArguments:[0m
+[32m  <build-name>[0m           The name of the build to serve
+
+Run PHP built-in HTTP server
+
+[33mNB:[0m This is supported for CiviCRM standalone. It is not supported on CMSs.
+
+[0m


### PR DESCRIPTION
There will be two standalone profiles:

* `standalone-clean`: As today, install `civicrm-standalone.git` (and recursively load other packages like `civicrm-core`) (*HAN-C*)
* `standalone-dev`: Install `civicrm-core` directly (*HAN-D*)