### PR TITLE
Remove devel and volunteer from D7 builds

### DIFF
--- a/app/config/backdrop-demo/download.sh
+++ b/app/config/backdrop-demo/download.sh
@@ -26,8 +26,6 @@ pushd "$WEB_ROOT/web/modules" >> /dev/null
   git clone ${CACHE_DIR}/civicrm/civicrm-core.git      -b "$CIVI_VERSION"     civicrm
   git clone ${CACHE_DIR}/civicrm/civicrm-backdrop.git  -b "1.x-$CIVI_VERSION" civicrm/backdrop
   git clone ${CACHE_DIR}/civicrm/civicrm-packages.git  -b "$CIVI_VERSION"     civicrm/packages
-  git clone "${CACHE_DIR}/civicrm/civivolunteer.git"                       -b "$VOL_VERSION"       civicrm/tools/extensions/civivolunteer
-  git clone "${CACHE_DIR}/ginkgostreet/org.civicrm.angularprofiles.git"    -b "$NG_PRFL_VERSION"   civicrm/tools/extensions/org.civicrm.angularprofiles
   git clone "${CACHE_DIR}/civicrm/org.civicoop.civirules.git"              -b "$RULES_VERSION"     civicrm/tools/extensions/org.civicoop.civirules
   git clone "${CACHE_DIR}/TechToThePeople/civisualize.git"                 -b "master"             civicrm/tools/extensions/civisualize
   git clone "${CACHE_DIR}/civicrm/org.civicrm.module.cividiscount.git"     -b "$DISC_VERSION"      civicrm/tools/extensions/cividiscount

--- a/app/config/caches.sh
+++ b/app/config/caches.sh
@@ -24,7 +24,6 @@ git_cache_setup "https://github.com/civicrm/civicrm-packages.git"            "$C
 git_cache_setup "https://github.com/civicrm/civicrm-joomla.git"              "$CACHE_DIR/civicrm/civicrm-joomla.git"
 git_cache_setup "https://github.com/civicrm/civicrm-wordpress.git"           "$CACHE_DIR/civicrm/civicrm-wordpress.git"
 git_cache_setup "https://github.com/civicrm/civicrm-demo-wp.git"             "$CACHE_DIR/civicrm/civicrm-demo-wp.git"
-git_cache_setup "https://github.com/eileenmcnaughton/civicrm_developer.git"  "$CACHE_DIR/eileenmcnaughton/civicrm_developer.git"
 git_cache_setup "https://github.com/civicrm/api4.git"                        "$CACHE_DIR/civicrm/api4.git"
 
 git_cache_setup "https://lab.civicrm.org/extensions/civirules.git" "$CACHE_DIR/civicrm/org.civicoop.civirules.git"

--- a/app/config/caches.sh
+++ b/app/config/caches.sh
@@ -27,13 +27,7 @@ git_cache_setup "https://github.com/civicrm/civicrm-demo-wp.git"             "$C
 git_cache_setup "https://github.com/eileenmcnaughton/civicrm_developer.git"  "$CACHE_DIR/eileenmcnaughton/civicrm_developer.git"
 git_cache_setup "https://github.com/civicrm/api4.git"                        "$CACHE_DIR/civicrm/api4.git"
 
-git_cache_setup "https://github.com/civicrm/civivolunteer.git" "$CACHE_DIR/civicrm/civivolunteer.git"
-git_cache_setup "https://lab.civicrm.org/extensions/angularprofiles.git" "$CACHE_DIR/ginkgostreet/org.civicrm.angularprofiles.git"
-
 git_cache_setup "https://lab.civicrm.org/extensions/civirules.git" "$CACHE_DIR/civicrm/org.civicoop.civirules.git"
-git_cache_setup "https://github.com/TechToThePeople/civisualize.git" "$CACHE_DIR/TechToThePeople/civisualize.git"
+git_cache_setup "https://lab.civicrm.org/extensions/civisualize.git" "$CACHE_DIR/TechToThePeople/civisualize.git"
 git_cache_setup "https://lab.civicrm.org/extensions/cividiscount.git" "$CACHE_DIR/civicrm/org.civicrm.module.cividiscount.git"
 git_cache_setup "https://github.com/civicrm/org.civicrm.contactlayout.git" "$CACHE_DIR/civicrm/org.civicrm.contactlayout.git"
-
-## SVN data is stale (last updated Apr 2014). Use daily tarballs instead.
-#svn_cache_setup "https://svn.civicrm.org/l10n/trunk"                         "$CACHE_DIR/civicrm/l10n-trunk.svn"

--- a/app/config/civihr/drush.make.tmpl
+++ b/app/config/civihr/drush.make.tmpl
@@ -73,20 +73,6 @@ projects[userprotect][subdir] = contrib
 projects[userprotect][version] = "1.1"
 
 ; ****************************************
-; Developer modules
-; ****************************************
-
-projects[devel][subdir] = contrib
-projects[devel][version] = 1.5
-
-libraries[civicrmdeveloper][destination] = modules
-libraries[civicrmdeveloper][directory_name] = contrib/civicrm_developer
-libraries[civicrmdeveloper][download][type] = git
-libraries[civicrmdeveloper][download][url] = %%CACHE_DIR%%/eileenmcnaughton/civicrm_developer.git
-libraries[civicrmdeveloper][download][branch] = master
-libraries[civicrmdeveloper][overwrite] = TRUE
-
-; ****************************************
 ; Compucorp contrib modules
 ; ****************************************
 

--- a/app/config/d8leg-clean/download.sh
+++ b/app/config/d8leg-clean/download.sh
@@ -12,6 +12,6 @@ composer create-project drupal/legacy-project:"$CMS_VERSION" "$WEB_ROOT/web" --n
 
 pushd "$WEB_ROOT/web" >> /dev/null
   composer_allow_common_plugins
-  composer require drupal/{devel,libraries,userprotect}
+  composer require drupal/{libraries,userprotect}
   civicrm_download_composer_d8
 popd >> /dev/null

--- a/app/config/d8prj-clean/download.sh
+++ b/app/config/d8prj-clean/download.sh
@@ -11,6 +11,6 @@ composer create-project drupal-composer/drupal-project:"$CMS_VERSION" "$WEB_ROOT
 
 pushd "$WEB_ROOT" >> /dev/null
   composer_allow_common_plugins
-  composer require drupal/{devel,libraries,userprotect}
+  composer require drupal/{libraries,userprotect}
   civicrm_download_composer_d8
 popd >> /dev/null

--- a/app/config/d8prj-empty/download.sh
+++ b/app/config/d8prj-empty/download.sh
@@ -10,5 +10,5 @@
 composer create-project drupal-composer/drupal-project:"$CMS_VERSION" "$WEB_ROOT" --no-interaction
 
 pushd "$WEB_ROOT" >> /dev/null
-  composer require drupal/{devel,libraries}
+  composer require drupal/libraries
 popd >> /dev/null

--- a/app/config/d8prj-re/download.sh
+++ b/app/config/d8prj-re/download.sh
@@ -12,7 +12,7 @@
 composer create-project drupal-composer/drupal-project:"$CMS_VERSION" "$WEB_ROOT" --no-interaction
 
 pushd "$WEB_ROOT" >> /dev/null
-  composer require drupal/{devel,libraries}
+  composer require drupal/libraries
 
   ## NOTE: No support for CIVI_VERSION
   ## NOTE: pear/log has a silly requirement for exactly 1.0.0

--- a/app/config/d8rec-clean/download.sh
+++ b/app/config/d8rec-clean/download.sh
@@ -10,6 +10,6 @@
 composer create-project drupal/recommended-project:"$CMS_VERSION" "$WEB_ROOT" --no-interaction
 
 pushd "$WEB_ROOT" >> /dev/null
-  composer require drupal/{devel,libraries,userprotect}
+  composer require drupal/{libraries,userprotect}
   civicrm_download_composer_d8
 popd >> /dev/null

--- a/app/config/drupal-case/drush.make.tmpl
+++ b/app/config/drupal-case/drush.make.tmpl
@@ -93,16 +93,6 @@ projects[userprotect][version] = "1.0"
 ; Developer modules
 ; ****************************************
 
-projects[devel][subdir] = contrib
-projects[devel][version] = 1.3
-
-libraries[civicrmdeveloper][destination] = modules
-libraries[civicrmdeveloper][directory_name] = contrib/civicrm_developer
-libraries[civicrmdeveloper][download][type] = git
-libraries[civicrmdeveloper][download][url] = %%CACHE_DIR%%/eileenmcnaughton/civicrm_developer.git
-libraries[civicrmdeveloper][download][branch] = master
-libraries[civicrmdeveloper][overwrite] = TRUE
-
 libraries[shoreditch][destination] = modules
 libraries[shoreditch][directory_name] = civicrm/ext/shoreditch
 libraries[shoreditch][download][type] = git

--- a/app/config/drupal-clean/download.sh
+++ b/app/config/drupal-clean/download.sh
@@ -9,14 +9,13 @@
 drupal_download
 
 pushd "$WEB_ROOT/web"
-  drush dl -y libraries-1.0 views-3.7 devel-1.x
-  drupal7_po_download "${CIVICRM_LOCALES:-de_DE}" drupal-7.x views-7.x-3.x devel-7.x-1.x
+  drush dl -y libraries-1.0 views-3.7
+  drupal7_po_download "${CIVICRM_LOCALES:-de_DE}" drupal-7.x views-7.x-3.x
 
   pushd sites/all/modules
     git clone "${CACHE_DIR}/civicrm/civicrm-core.git"                        -b "$CIVI_VERSION"      civicrm
     git clone "${CACHE_DIR}/civicrm/civicrm-drupal.git"                      -b "7.x-$CIVI_VERSION"  civicrm/drupal
     git clone "${CACHE_DIR}/civicrm/civicrm-packages.git"                    -b "$CIVI_VERSION"      civicrm/packages
-    git clone "${CACHE_DIR}/eileenmcnaughton/civicrm_developer.git"          -b master               civicrm_developer
     api4_download_conditional civicrm                                                                civicrm/ext/api4
 
     extract-url --cache-ttl 172800 civicrm=http://download.civicrm.org/civicrm-l10n-core/archives/civicrm-l10n-daily.tar.gz

--- a/app/config/drupal-clean42/drush.make.tmpl
+++ b/app/config/drupal-clean42/drush.make.tmpl
@@ -66,17 +66,3 @@ projects[libraries][version] = 1.0
 
 projects[views][subdir] = contrib
 projects[views][version] = 3.7
-
-; ****************************************
-; Developer modules
-; ****************************************
-
-projects[devel][subdir] = contrib
-projects[devel][version] = 1.3
-
-libraries[civicrmdeveloper][destination] = modules
-libraries[civicrmdeveloper][directory_name] = contrib/civicrm_developer
-libraries[civicrmdeveloper][download][type] = git
-libraries[civicrmdeveloper][download][url] = %%CACHE_DIR%%/eileenmcnaughton/civicrm_developer.git
-libraries[civicrmdeveloper][download][branch] = master
-libraries[civicrmdeveloper][overwrite] = TRUE

--- a/app/config/drupal-demo/download.sh
+++ b/app/config/drupal-demo/download.sh
@@ -13,17 +13,14 @@
 drupal_download
 
 pushd "$WEB_ROOT/web"
-  drush8 dl -y libraries-1 redirect-1 webform-4 options_element-1 webform_civicrm-4 views-3 login_destination-1 userprotect-1 devel-1 civicrm_error-2.x-dev
-  drupal7_po_download "${CIVICRM_LOCALES:-de_DE}" drupal-7.x webform-7.x-4.x webform_civicrm-7.x-4.x views-7.x-3.x login_destination-7.x-1.x userprotect-7.x-1.x devel-7.x-1.x
+  drush8 dl -y libraries-1 redirect-1 webform-4 options_element-1 webform_civicrm-4 views-3 login_destination-1 userprotect-1
+  drupal7_po_download "${CIVICRM_LOCALES:-de_DE}" drupal-7.x webform-7.x-4.x webform_civicrm-7.x-4.x views-7.x-3.x login_destination-7.x-1.x userprotect-7.x-1.x
 
   pushd sites/all/modules
     git clone "${CACHE_DIR}/civicrm/civicrm-core.git"                        -b "$CIVI_VERSION"      civicrm
     git clone "${CACHE_DIR}/civicrm/civicrm-drupal.git"                      -b "7.x-$CIVI_VERSION"  civicrm/drupal
     git clone "${CACHE_DIR}/civicrm/civicrm-packages.git"                    -b "$CIVI_VERSION"      civicrm/packages
     api4_download_conditional civicrm                                                                civicrm/ext/api4
-    git clone "${CACHE_DIR}/eileenmcnaughton/civicrm_developer.git"          -b master               civicrm_developer
-    git clone "${CACHE_DIR}/civicrm/civivolunteer.git"                       -b "$VOL_VERSION"       civicrm/tools/extensions/civivolunteer
-    git clone "${CACHE_DIR}/ginkgostreet/org.civicrm.angularprofiles.git"    -b "$NG_PRFL_VERSION"   civicrm/tools/extensions/org.civicrm.angularprofiles
     git clone "${CACHE_DIR}/civicrm/org.civicoop.civirules.git"              -b "$RULES_VERSION"     civicrm/tools/extensions/org.civicoop.civirules
     git clone "${CACHE_DIR}/TechToThePeople/civisualize.git"                 -b "master"             civicrm/tools/extensions/civisualize
     git clone "${CACHE_DIR}/civicrm/org.civicrm.module.cividiscount.git"     -b "$DISC_VERSION"      civicrm/tools/extensions/cividiscount

--- a/app/config/drupal-demo/install.sh
+++ b/app/config/drupal-demo/install.sh
@@ -135,28 +135,6 @@ EOPERM
 EOPERM
   ## Note: If you enable CiviGrant, the grant 'access CiviGrant', 'edit grants', 'delete in CiviGrant'
 
-  ## Setup demo extensions
-  cv en --ignore-missing $CIVI_DEMO_EXTS
-  if [[ "$CIVI_DEMO_EXTS" =~ volunteer ]]; then
-    drush scr "$PRJDIR/src/drush/perm.php" <<EOPERM
-      role 'anonymous user'
-      role 'authenticated user'
-      role 'civicrm_webtest_user'
-      add 'register to volunteer'
-EOPERM
-    drush scr "$PRJDIR/src/drush/perm.php" <<EOPERM
-      role 'civicrm_webtest_user'
-      add 'create volunteer projects'
-      add 'edit own volunteer projects'
-      add 'edit all volunteer projects'
-      add 'log own hours'
-      add 'edit volunteer project relationships'
-      add 'edit volunteer registration profiles'
-      add 'delete own volunteer projects'
-      add 'delete all volunteer projects'
-EOPERM
-  fi
-
   ## Demo sites always disable email and often disable cron
   drush cvapi StatusPreference.create ignore_severity=critical name=checkOutboundMail
   drush cvapi StatusPreference.create ignore_severity=critical name=checkLastCron

--- a/app/config/drupal-empty/download.sh
+++ b/app/config/drupal-empty/download.sh
@@ -9,6 +9,6 @@
 drupal_download
 
 pushd "$WEB_ROOT/web"
-  drush dl -y libraries-1.0 views-3.7 devel-1.x
-  drupal7_po_download "${CIVICRM_LOCALES:-de_DE}" drupal-7.x views-7.x-3.x devel-7.x-1.x
+  drush dl -y libraries-1.0 views-3.7
+  drupal7_po_download "${CIVICRM_LOCALES:-de_DE}" drupal-7.x views-7.x-3.x
 popd

--- a/app/config/drupal10-clean/download.sh
+++ b/app/config/drupal10-clean/download.sh
@@ -13,7 +13,6 @@ composer create-project drupal/recommended-project:"$CMS_VERSION" "$WEB_ROOT" --
 pushd "$WEB_ROOT" >> /dev/null
   composer_allow_common_plugins
   composer require drupal/userprotect
-  composer require drupal/devel
   composer require drush/drush
   ## Some D8 builds include a specific revision of phpunit, but Civi uses standalone phpunit (PHAR)
   if composer info | grep -q ^phpunit/phpunit\ ; then
@@ -22,6 +21,6 @@ pushd "$WEB_ROOT" >> /dev/null
     composer remove phpunit/phpunit
     composer install --no-dev --no-interaction
   fi
-  drupal8_po_download "${CIVICRM_LOCALES:-de_DE}" "drupal-$( _drupalx_version x.y ).x" devel-5.1.x
+  drupal8_po_download "${CIVICRM_LOCALES:-de_DE}" "drupal-$( _drupalx_version x.y ).x"
   civicrm_download_composer_d8
 popd >> /dev/null

--- a/app/config/drupal10-empty/download.sh
+++ b/app/config/drupal10-empty/download.sh
@@ -12,7 +12,6 @@ composer create-project drupal/recommended-project:"$CMS_VERSION" "$WEB_ROOT" --
 
 pushd "$WEB_ROOT" >> /dev/null
   composer_allow_common_plugins
-  composer require drupal/devel
   composer require drush/drush
-  drupal8_po_download "${CIVICRM_LOCALES:-de_DE}" "drupal-$( _drupalx_version x.y ).x" devel-5.1.x
+  drupal8_po_download "${CIVICRM_LOCALES:-de_DE}" "drupal-$( _drupalx_version x.y ).x"
 popd >> /dev/null

--- a/app/config/drupal8-clean/download.sh
+++ b/app/config/drupal8-clean/download.sh
@@ -12,7 +12,7 @@ drush8 -y dl drupal-${CMS_VERSION} --destination="$WEB_ROOT" --drupal-project-re
 mv "$WEB_ROOT/drupal" "$WEB_ROOT/web"
 
 pushd "$WEB_ROOT/web" >> /dev/null
-  drush8 dl -y devel-1 libraries userprotect
+  drush8 dl -y libraries userprotect
   composer_allow_common_plugins
   composer update psr/log ## Some D8 builds are too specific
   ## Some D8 builds include a specific revision of phpunit, but Civi uses standalone phpunit (PHAR)

--- a/app/config/drupal8-demo/download.sh
+++ b/app/config/drupal8-demo/download.sh
@@ -16,7 +16,6 @@ composer create-project drupal/recommended-project:"$CMS_VERSION" "$WEB_ROOT" --
 pushd "$WEB_ROOT" >> /dev/null
   composer_allow_common_plugins
   composer require drupal/userprotect
-  composer require drupal/devel
   ## Some D8 builds include a specific revision of phpunit, but Civi uses standalone phpunit (PHAR)
   if composer info | grep -q ^phpunit/phpunit\ ; then
     composer config "discard-changes" true ## Weird. phpcs has changes which interfere with other work.
@@ -24,8 +23,6 @@ pushd "$WEB_ROOT" >> /dev/null
     composer install --no-dev --no-interaction
   fi
   civicrm_download_composer_d8
-  git clone "${CACHE_DIR}/civicrm/civivolunteer.git"                       -b "$VOL_VERSION"       vendor/civicrm/civicrm-core/tools/extensions/civivolunteer
-  git clone "${CACHE_DIR}/ginkgostreet/org.civicrm.angularprofiles.git"    -b "$NG_PRFL_VERSION"   vendor/civicrm/civicrm-core/tools/extensions/org.civicrm.angularprofiles
   git clone "${CACHE_DIR}/civicrm/org.civicoop.civirules.git"              -b "$RULES_VERSION"     vendor/civicrm/civicrm-core/tools/extensions/org.civicoop.civirules
   git clone "${CACHE_DIR}/TechToThePeople/civisualize.git"                 -b "master"             vendor/civicrm/civicrm-core/tools/extensions/civisualize
   git clone "${CACHE_DIR}/civicrm/org.civicrm.module.cividiscount.git"     -b "$DISC_VERSION"      vendor/civicrm/civicrm-core/tools/extensions/cividiscount

--- a/app/config/drupal8-demo/drush.make.tmpl
+++ b/app/config/drupal8-demo/drush.make.tmpl
@@ -72,20 +72,6 @@ libraries[api4][download][url] = %%CACHE_DIR%%/civicrm/api4.git
 libraries[api4][download][branch] = master
 libraries[api4][overwrite] = TRUE
 
-libraries[civivolunteer][destination] = libraries
-libraries[civivolunteer][directory_name] = civicrm/tools/extensions/civivolunteer
-libraries[civivolunteer][download][type] = git
-libraries[civivolunteer][download][url] = %%CACHE_DIR%%/civicrm/civivolunteer.git
-libraries[civivolunteer][download][branch] = %%VOL_VERSION%%
-libraries[civivolunteer][overwrite] = TRUE
-
-libraries[ng_profiles][destination] = libraries
-libraries[ng_profiles][directory_name] = civicrm/tools/extensions/org.civicrm.angularprofiles
-libraries[ng_profiles][download][type] = git
-libraries[ng_profiles][download][url] = %%CACHE_DIR%%/ginkgostreet/org.civicrm.angularprofiles.git
-libraries[ng_profiles][download][branch] = %%NG_PRFL_VERSION%%
-libraries[ng_profiles][overwrite] = TRUE
-
 libraries[civisualize][destination] = libraries
 libraries[civisualize][directory_name] = civicrm/tools/extensions/civisualize
 libraries[civisualize][download][type] = git

--- a/app/config/drupal8-demo/install.sh
+++ b/app/config/drupal8-demo/install.sh
@@ -82,24 +82,10 @@ pushd "${CMS_ROOT}/sites/${DRUPAL_SITE_DIR}" >> /dev/null
   drush8 -y rap demoadmin 'access toolbar,administer CiviCase,access all cases and activities,access my cases and activities,add cases,delete in CiviCase,administer CiviCampaign,manage campaign,reserve campaign contacts,release campaign contacts,interview campaign contacts,gotv campaign contacts,sign CiviCRM Petition,access CiviGrant,edit grants, delete in CiviGrant'
 
   # Move extensions into web accessible areas
-  if [ -d "$CIVI_CORE/tools/extensions/org.civicrm.angularprofiles" ]; then
-    mv $CIVI_CORE/tools/extensions/org.civicrm.angularprofiles files/civicrm/ext
-  fi
   if [ -d "$CIVI_CORE/tools/extensions/org.civicrm.contactlayout" ]; then
     mv $CIVI_CORE/tools/extensions/org.civicrm.contactlayout files/civicrm/ext
   fi
-  if [ -d "$CIVI_CORE/tools/extensions/civivolunteer" ]; then
-    mv $CIVI_CORE/tools/extensions/civivolunteer files/civicrm/ext
-  fi
   cv api extension.refresh
-
-  ## Setup demo extensions
-  cv en --ignore-missing $CIVI_DEMO_EXTS
-  if [[ "$CIVI_DEMO_EXTS" =~ volunteer ]]; then
-    drush8 -y rap anonymous 'register to volunteer'
-    drush8 -y rap authenticated 'register to volunteer'
-    drush8 -y rap demoadmin 'create volunteer projects,edit own volunteer projects,edit all volunteer projects,log own hours,edit volunteer project relationships,edit volunteer registration profiles,delete own volunteer projects,delete all volunteer projects'
-  fi
 
   ## Demo sites always disable email and often disable cron
   drush8 cvapi StatusPreference.create ignore_severity=critical name=checkOutboundMail

--- a/app/config/drupal8-den/download.sh
+++ b/app/config/drupal8-den/download.sh
@@ -13,7 +13,7 @@ drush8 -y dl drupal-${CMS_VERSION} --destination="$WEB_ROOT" --drupal-project-re
 mv "$WEB_ROOT/drupal" "$WEB_ROOT/web"
 
 pushd "$WEB_ROOT/web" >> /dev/null
-  drush8 dl -y devel-1 libraries userprotect
+  drush8 dl -y libraries userprotect
 
   #### Ideally...
   ## composer require civicrm/civicrm-asset-plugin:'~1.0.0' civicrm/civicrm-{core,packages,drupal-8}:"$CIVI_VERSION_COMP" --prefer-source

--- a/app/config/drupal8-empty/download.sh
+++ b/app/config/drupal8-empty/download.sh
@@ -12,5 +12,5 @@ drush8 -y dl drupal-${CMS_VERSION} --destination="$WEB_ROOT" --drupal-project-re
 mv "$WEB_ROOT/drupal" "$WEB_ROOT/web"
 
 pushd "$WEB_ROOT/web"
-  drush8 dl -y devel-1 libraries
+  drush8 dl -y libraries
 popd

--- a/app/config/drupal9-clean/download.sh
+++ b/app/config/drupal9-clean/download.sh
@@ -13,7 +13,6 @@ composer create-project drupal/recommended-project:"$CMS_VERSION" "$WEB_ROOT" --
 pushd "$WEB_ROOT" >> /dev/null
   composer_allow_common_plugins
   composer require drupal/userprotect
-  composer require drupal/devel
   ## Some D8 builds include a specific revision of phpunit, but Civi uses standalone phpunit (PHAR)
   if composer info | grep -q ^phpunit/phpunit\ ; then
     composer config "discard-changes" true ## Weird. phpcs has changes which interfere with other work.
@@ -21,6 +20,6 @@ pushd "$WEB_ROOT" >> /dev/null
     composer remove phpunit/phpunit
     composer install --no-dev --no-interaction
   fi
-  drupal8_po_download "${CIVICRM_LOCALES:-de_DE}" "drupal-$( _drupalx_version x.y ).x" devel-5.0.x
+  drupal8_po_download "${CIVICRM_LOCALES:-de_DE}" "drupal-$( _drupalx_version x.y ).x"
   civicrm_download_composer_d8
 popd >> /dev/null

--- a/app/config/drupal9-demo/download.sh
+++ b/app/config/drupal9-demo/download.sh
@@ -17,7 +17,6 @@ composer create-project drupal/recommended-project:"$CMS_VERSION" "$WEB_ROOT" --
 pushd "$WEB_ROOT" >> /dev/null
   composer_allow_common_plugins
   composer require drupal/userprotect
-  composer require drupal/devel
   ## Some D8 builds include a specific revision of phpunit, but Civi uses standalone phpunit (PHAR)
   if composer info | grep -q ^phpunit/phpunit\ ; then
     composer config "discard-changes" true ## Weird. phpcs has changes which interfere with other work.
@@ -25,10 +24,8 @@ pushd "$WEB_ROOT" >> /dev/null
     composer remove phpunit/phpunit
     composer install --no-dev --no-interaction
   fi
-  drupal8_po_download "${CIVICRM_LOCALES:-de_DE}" "drupal-$( _drupalx_version x.y ).x" devel-5.0.x
+  drupal8_po_download "${CIVICRM_LOCALES:-de_DE}" "drupal-$( _drupalx_version x.y ).x"
   civicrm_download_composer_d8
-  git clone "${CACHE_DIR}/civicrm/civivolunteer.git"                       -b "$VOL_VERSION"       vendor/civicrm/civicrm-core/tools/extensions/civivolunteer
-  git clone "${CACHE_DIR}/ginkgostreet/org.civicrm.angularprofiles.git"    -b "$NG_PRFL_VERSION"   vendor/civicrm/civicrm-core/tools/extensions/org.civicrm.angularprofiles
   git clone "${CACHE_DIR}/civicrm/org.civicoop.civirules.git"              -b "$RULES_VERSION"     vendor/civicrm/civicrm-core/tools/extensions/org.civicoop.civirules
   git clone "${CACHE_DIR}/TechToThePeople/civisualize.git"                 -b "master"             vendor/civicrm/civicrm-core/tools/extensions/civisualize
   git clone "${CACHE_DIR}/civicrm/org.civicrm.module.cividiscount.git"     -b "$DISC_VERSION"      vendor/civicrm/civicrm-core/tools/extensions/cividiscount

--- a/app/config/drupal9-demo/install.sh
+++ b/app/config/drupal9-demo/install.sh
@@ -68,24 +68,10 @@ pushd "${CMS_ROOT}/sites/${DRUPAL_SITE_DIR}" >> /dev/null
   drush8 -y scr "$SITE_CONFIG_DIR/install-welcome.php"
 
   # Move extensions into web accessible areas
-  if [ -d "$CIVI_CORE/tools/extensions/org.civicrm.angularprofiles" ]; then
-    mv $CIVI_CORE/tools/extensions/org.civicrm.angularprofiles files/civicrm/ext
-  fi
   if [ -d "$CIVI_CORE/tools/extensions/org.civicrm.contactlayout" ]; then
     mv $CIVI_CORE/tools/extensions/org.civicrm.contactlayout files/civicrm/ext
   fi
-  if [ -d "$CIVI_CORE/tools/extensions/civivolunteer" ]; then
-    mv $CIVI_CORE/tools/extensions/civivolunteer files/civicrm/ext
-  fi
   cv api extension.refresh
-
-  ## Setup demo extensions
-  cv en --ignore-missing $CIVI_DEMO_EXTS
-  if [[ "$CIVI_DEMO_EXTS" =~ volunteer ]]; then
-    drush8 -y rap anonymous 'register to volunteer'
-    drush8 -y rap authenticated 'register to volunteer'
-    drush8 -y rap demoadmin 'create volunteer projects,edit own volunteer projects,edit all volunteer projects,log own hours,edit volunteer project relationships,edit volunteer registration profiles,delete own volunteer projects,delete all volunteer projects'
-  fi
 
   ## Demo sites always disable email and often disable cron
   drush8 cvapi StatusPreference.create ignore_severity=critical name=checkOutboundMail

--- a/app/config/drupal9-empty/download.sh
+++ b/app/config/drupal9-empty/download.sh
@@ -12,6 +12,5 @@ composer create-project drupal/recommended-project:"$CMS_VERSION" "$WEB_ROOT" --
 
 pushd "$WEB_ROOT" >> /dev/null
   composer_allow_common_plugins
-  composer require drupal/devel
-  drupal8_po_download "${CIVICRM_LOCALES:-de_DE}" "drupal-$( _drupalx_version x.y ).x" devel-5.0.x
+  drupal8_po_download "${CIVICRM_LOCALES:-de_DE}" "drupal-$( _drupalx_version x.y ).x"
 popd >> /dev/null

--- a/app/config/wp-demo/download.sh
+++ b/app/config/wp-demo/download.sh
@@ -26,8 +26,6 @@ pushd "$WEB_ROOT/web/wp-content/plugins" >> /dev/null
   git clone ${CACHE_DIR}/civicrm/civicrm-packages.git                 -b "$CIVI_VERSION" civicrm/civicrm/packages
   api4_download_conditional civicrm/civicrm                                              civicrm/civicrm/ext/api4
   git clone ${CACHE_DIR}/civicrm/civicrm-demo-wp.git                  -b master          civicrm-demo-wp
-  git clone ${CACHE_DIR}/civicrm/civivolunteer.git                    -b "$VOL_VERSION"  civicrm/civicrm/tools/extensions/civivolunteer
-  git clone ${CACHE_DIR}/ginkgostreet/org.civicrm.angularprofiles.git -b "$NG_PRFL_VERSION" civicrm/civicrm/tools/extensions/org.civicrm.angularprofiles
   git clone "${CACHE_DIR}/civicrm/org.civicoop.civirules.git"              -b "master"  civicrm/civicrm/tools/extensions/org.civicoop.civirules
   git clone "${CACHE_DIR}/TechToThePeople/civisualize.git"                 -b "master"  civicrm/civicrm/tools/extensions/civisualize
   git clone "${CACHE_DIR}/civicrm/org.civicrm.module.cividiscount.git"     -b "master"  civicrm/civicrm/tools/extensions/cividiscount

--- a/app/config/wp-demo/install.sh
+++ b/app/config/wp-demo/install.sh
@@ -156,21 +156,6 @@ wp eval '$c=[civi_wp()->users->set_wp_user_capabilities()];if (is_callable($c)) 
 ## Force basepage
 wp eval '$c=[civi_wp()->basepage->create_wp_basepage()];if (is_callable($c)) $c();'
 
-## Setup demo extensions
-cv en --ignore-missing $CIVI_DEMO_EXTS
-if [[ "$CIVI_DEMO_EXTS" =~ volunteer ]]; then
-  wp cap add civicrm_admin \
-    register_to_volunteer \
-    log_own_hours \
-    create_volunteer_projects \
-    edit_own_volunteer_projects \
-    edit_all_volunteer_projects \
-    delete_all_volunteer_projects \
-    delete_own_volunteer_projects \
-    edit_volunteer_registration_profiles \
-    edit_volunteer_project_relationships
-fi
-
 ## Demo sites always disable email and often disable cron
 wp civicrm api StatusPreference.create ignore_severity=critical name=checkOutboundMail
 wp civicrm api StatusPreference.create ignore_severity=critical name=checkLastCron


### PR DESCRIPTION
The Drupal 7 sandbox is failing because of devel:

```
There are no stable releases for project devel.                        [warning]
Choose one of the available releases for devel:
 [0]  :  Cancel                                      
 [1]  :  7.x-1.x-dev  -  2020-Feb-20  -  Development 
 [2]  :  7.x-1.7      -  2019-Feb-22  -  Recommended 
 [3]  :  7.x-1.1      -  2011-Jul-20  -  Security
Cancelled.                                                              [cancel]
```

I'm sure it's an easy fix, but there's no need for it anyway.

I also removed CiviVolunteer while I was there.