### PR TITLE
src/civibuild.aliases.sh: add smaster for c-i demo builds

### DIFF
--- a/src/civibuild.aliases.sh
+++ b/src/civibuild.aliases.sh
@@ -76,6 +76,8 @@ function civibuild_alias_resolve() {
     bmaster)     SITE_TYPE=backdrop-demo    ; CIVI_VERSION=master    ; CMS_TITLE="CiviCRM Sandbox on Backdrop"       ;;
     b-master)    SITE_TYPE=backdrop-demo    ; CIVI_VERSION=master    ; CMS_TITLE="CiviCRM Sandbox on Backdrop"       ;;
 
+    smaster)     SITE_TYPE=standalone-clean ; CIVI_VERSION=master    ; CMS_TITLE="CiviCRM Standalone Sandbox"        ;;
+
     civihr)      SITE_TYPE=civihr           ; CIVI_VERSION=5.3.1     ; CMS_TITLE="CiviHR Sandbox"                    ; NO_SAMPLE_DATA=1       ;;
 
     bempty)      SITE_TYPE=backdrop-empty   ; CIVI_VERSION=none      ; CMS_TITLE="Backdrop Sandbox"                  ;;


### PR DESCRIPTION
Adds an `smaster` alias so that we can run:

```
civibuild create smaster --url http://example.org
```

which is what Jenkins wants when rebuilding the demo sites (https://test.civicrm.org/view/Sites/job/demo.civicrm.org/).

I added the DNS record, and updated Jenkins, but only tested locally.

side-note: I removed "dcase" in Jenkins, because it was broken and not used.