### PR TITLE
standalone-clean: provide the admin role to the demo user

### DIFF
--- a/app/config/standalone-clean/demo-user.php
+++ b/app/config/standalone-clean/demo-user.php
@@ -32,7 +32,10 @@ CRM_Core_Transaction::create()->run(function () {
   ];
   $userID = \CRM_Core_BAO_CMSUser::create($params, $adminEmail);
 
-  // @todo decide which permissions the demo user should have; create a role for those; apply the role to the user.
-  // This code can be added later once the data structures for roles etc. have settled.
+  // Provide the "Administer" role to the demo user
+  \Civi\Api4\User::update(FALSE)
+    ->addWhere('id', '=', $userID)
+    ->addValue('roles:name', ['admin'])
+    ->execute();
 
 });


### PR DESCRIPTION
Related issue: https://lab.civicrm.org/infra/ops/-/issues/998

Makes it possible for the demo user to login.

I pondered at the idea of separating the "CiviCRM System Admin" and "Data Admin", but it quickly gets confusing, especially for a sandbox site. Currently the other sandboxes grant "administer CiviCRM", so people can already change the password of the demo user and mess around.

If it becomes too much of a problem, we can cross that bridge when we get there, but meanwhile we have a sandbox online for testing purposes.