### PR TITLE
CiviCRM-Ext-Matrix - Add (basic) support for volunteer

### DIFF
--- a/src/jobs/CiviCRM-Ext-Matrix.job
+++ b/src/jobs/CiviCRM-Ext-Matrix.job
@@ -51,6 +51,10 @@ case "$EXTKEY" in
     EXTGITS="https://github.com/civicrm/org.civicrm.shoreditch https://github.com/civicrm/api4"
     EXTS="org.civicrm.shoreditch org.civicrm.api4"
     ;;
+  org.civicrm.volunteer)
+    EXTGITS="https://lab.civicrm.org/extensions/angularprofiles.git https://github.com/civicrm/org.civicrm.volunteer"
+    EXTS="org.civicrm.angularprofiles org.civicrm.volunteer"
+    ;;
   uk.co.vedaconsulting.mosaico)
     EXTGITS="https://github.com/civicrm/org.civicrm.shoreditch https://github.com/veda-consulting/uk.co.vedaconsulting.mosaico"
     EXTS="org.civicrm.shoreditch uk.co.vedaconsulting.mosaico"


### PR DESCRIPTION
Before any major update, we skim https://test.civicrm.org/job/CiviCRM-Ext-Matrix/ and decide if any errors are related to core changes. 

This PR is a pre-req for adding `org.civicrm.volunteer` to the matrix.

I did a trial run, and it's not ready to add to the matrix -- the tests aren't working in the regular test environment. (Apparent issue: needs update for `phpunit8`) But it's still nice to have this patch in case someone does tidy-up the `volunteer` test suite.

(*Clarification: After this patch is merged, and after the `volunteer` has passing suite, then we can enable it on the matrix.*)