### PR TITLE
Fix wmf install to use pushd rather than boot path

### DIFF
--- a/app/config/wmff/install.sh
+++ b/app/config/wmff/install.sh
@@ -40,7 +40,7 @@ rm -f ${WEB_ROOT}/drupal/sites/default/files/civicrm/templates_c/*.php
 ## Set site key if requested in Docker environment
 [ ! -z "$FR_DOCKER_CIVI_SITE_KEY" ] && CIVI_SITE_KEY=${FR_DOCKER_CIVI_SITE_KEY}
 
-export CIVICRM_BOOT="Drupal:/${WEB_ROOT}/drupal"
+pushd "$CMS_ROOT"
 
 civicrm_install_cv
 


### PR DESCRIPTION
this doesn't require the drupal fix to be included