### PR TITLE
Revert WMF install updates

### DIFF
--- a/app/config/wmff/install.sh
+++ b/app/config/wmff/install.sh
@@ -40,7 +40,7 @@ rm -f ${WEB_ROOT}/drupal/sites/default/files/civicrm/templates_c/*.php
 ## Set site key if requested in Docker environment
 [ ! -z "$FR_DOCKER_CIVI_SITE_KEY" ] && CIVI_SITE_KEY=${FR_DOCKER_CIVI_SITE_KEY}
 
-pushd "$CMS_ROOT"
+export CIVICRM_BOOT="Drupal:/${WEB_ROOT}/drupal"
 
 civicrm_install_cv
 

--- a/app/config/wmff/install.sh
+++ b/app/config/wmff/install.sh
@@ -40,9 +40,7 @@ rm -f ${WEB_ROOT}/drupal/sites/default/files/civicrm/templates_c/*.php
 ## Set site key if requested in Docker environment
 [ ! -z "$FR_DOCKER_CIVI_SITE_KEY" ] && CIVI_SITE_KEY=${FR_DOCKER_CIVI_SITE_KEY}
 
-export CIVICRM_BOOT="Drupal:/${WEB_ROOT}/drupal"
-
-civicrm_install_cv
+civicrm_install
 
 ## Comment out for now
 "${WEB_ROOT}/drupal/sites/default/civicrm/extensions/rpow/bin/harvey-dent" --root "${WEB_ROOT}/drupal"


### PR DESCRIPTION
I thought it was working but....

14:12:57 +++ cv en --ignore-missing rpow search_kit wmf-civicrm
14:12:58 Extension cache does not contain requested item(s)
14:12:58 Refreshing extension cache
14:12:58 Warning: Skipped unrecognized extension "rpow"
14:12:58 Warning: Skipped unrecognized extension "wmf-civicrm"
14:12:58 Enabling extension "org.civicrm.search_kit"
14:13:04 ++++ cat sites/default/enabled_modules