### PR TITLE
nix/profiles - Add a profile with MariaDB 10.5 and PHP 8.0

### DIFF
--- a/nix/profiles/alt/default.nix
+++ b/nix/profiles/alt/default.nix
@@ -1,0 +1,16 @@
+let
+    dists = import ../../pins;
+
+in (import ../base/default.nix) ++ (import ../mgmt/default.nix) ++ [
+
+    dists.bkit.php80
+    dists.default.nodejs-14_x
+    dists.default.apacheHttpd
+    dists.default.mailhog
+    dists.default.memcached
+    dists.v2105.mariadb     ## MariaDB 10.5
+    # dists.default.mariadb ## Currently MariaDB 10.6
+    dists.default.redis
+    dists.bkit.transifexClient
+
+]

--- a/nix/profiles/default.nix
+++ b/nix/profiles/default.nix
@@ -43,4 +43,9 @@ rec {
     * A nice, in-between list of requirements
     */
    dfl = import ./dfl/default.nix;
+
+   /**
+    * Another in-between mix of versions
+    */
+   alt = import ./alt/default.nix;
 }


### PR DESCRIPTION
This will allow adding another column to https://test.civicrm.org/job/CiviCRM-Core-Matrix/
