### PR TITLE
Phars.php - If one is skipping download, then skip completely

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,6 +49,7 @@
         "phar-json": "phars.json"
       }
     ],
+    "compile-passthru": "always",
     "downloads": {
       "drush-backdrop": {"version": "1.x-1.x", "url": "https://github.com/backdrop-contrib/backdrop-drush-extension/archive/{$version}.zip", "path": "extern/drush-lib/backdrop"},
       "drush-language": {"version": "7.x-1.5", "url": "https://ftp.drupal.org/files/projects/drush_language-{$version}.zip", "path": "extern/drush-lib/language"},

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3d056dcc2e3e984efa21555ff28eae09",
+    "content-hash": "91eaf046e04556a65484ac13fc7aa619",
     "packages": [
         {
             "name": "civicrm/composer-compile-plugin",

--- a/src/Civi/Buildkit/Phars.php
+++ b/src/Civi/Buildkit/Phars.php
@@ -63,6 +63,12 @@ class Phars {
    * @throws \Exception
    */
   protected static function downloadFile(string $remoteUrl, string $expectHash, string $localFile, int $blockSize = 65536): void {
+    if (is_dir($localFile)) {
+      fprintf(STDERR, "Cannot overwrite folder (%s) with file (%s). Skip download.\n", $localFile, $remoteUrl);
+      // This should arguably be fatal... I'm not sure it's going to bubble-up
+      return;
+    }
+
     $parent = dirname($localFile);
     if (!is_dir($parent)) {
       if (!mkdir($parent, 0755, TRUE)) {
@@ -101,11 +107,11 @@ class Phars {
     }
 
     // Civix could be a directory if checked out as a repo (unusual but possible configuration).
-    if (file_exists($localFile) && !is_dir($localFile)) {
+    if (file_exists($localFile)) {
       unlink($localFile);
     }
 
-    if (!is_dir($localFile) && !rename($tempFile, $localFile)) {
+    if (!rename($tempFile, $localFile)) {
       throw new \Exception("Failed to move temp file to destination.");
     }
   }

--- a/src/Civi/Buildkit/Phars.php
+++ b/src/Civi/Buildkit/Phars.php
@@ -57,6 +57,10 @@ class Phars {
         $todos[$name] = $phar + ['why' => 'does not exist'];
         continue;
       }
+      if (is_dir($phar['buildkit-path'])) {
+        static::printf("  - WARNING: Cannot overwrite folder (%s) with file. Skip download.\n", $phar['buildkit-path']);
+        continue;
+      }
       $hash = hash_file('sha256', $phar['buildkit-path'], FALSE);
       if (!static::validateChecksum($phar['sha256'], $hash)) {
         $todos[$name] = $phar + ['why' => 'wrong checksum'];
@@ -71,12 +75,6 @@ class Phars {
    * @throws \Exception
    */
   protected static function downloadFile(string $remoteUrl, string $expectHash, string $localFile, int $blockSize = 65536): void {
-    if (is_dir($localFile)) {
-      static::printf("    WARNING: Cannot overwrite folder (%s) with file. Skip download.\n", $localFile);
-      // This should arguably be fatal... I'm not sure it's going to bubble-up
-      return;
-    }
-
     $parent = dirname($localFile);
     if (!is_dir($parent)) {
       if (!mkdir($parent, 0755, TRUE)) {

--- a/src/Civi/Buildkit/Phars.php
+++ b/src/Civi/Buildkit/Phars.php
@@ -23,13 +23,21 @@ class Phars {
       ));
     }
 
-    fprintf(STDERR, "%s\n", print_r(['phars' => $phars], 1));
+    // static::printf("%s\n", print_r(['phars' => $phars], 1));
     $todos = static::findUpdates($phars);
-    fprintf(STDERR, "%s\n", print_r(['todos' => $todos], 1));
+    // static::printf("%s\n", print_r(['todos' => $todos], 1));
     foreach ($todos as $name => $todo) {
+      static::printf("  - Download %s (%s)\n", $todo['buildkit-path'], $todo['url']);
       static::downloadFile($todo['url'], $todo['sha256'], $todo['buildkit-path']);
       chmod($todo['buildkit-path'], intval($todo['file-mode'] ?? '0755', 8));
     }
+  }
+
+  /**
+   * Show a printfing. Accepts printf()-style parameters.
+   */
+  protected static function printf($expr, ...$args): void {
+    fprintf(STDERR, $expr, ...$args);
   }
 
   /**
@@ -64,7 +72,7 @@ class Phars {
    */
   protected static function downloadFile(string $remoteUrl, string $expectHash, string $localFile, int $blockSize = 65536): void {
     if (is_dir($localFile)) {
-      fprintf(STDERR, "Cannot overwrite folder (%s) with file (%s). Skip download.\n", $localFile, $remoteUrl);
+      static::printf("    WARNING: Cannot overwrite folder (%s) with file. Skip download.\n", $localFile);
       // This should arguably be fatal... I'm not sure it's going to bubble-up
       return;
     }


### PR DESCRIPTION
Before: If the target-file is actually a folder, then it downloads the file - but doesn't install it.

After: If the target-file is actually a folder, then it shows a warning and skips the download.

