### PR TITLE
Stop WP from doing a Major upgrade on install

### DIFF
--- a/src/civibuild.lib.sh
+++ b/src/civibuild.lib.sh
@@ -1019,6 +1019,7 @@ function wp_install() {
         define('SECURE_AUTH_SALT', '$(cvutil_makepasswd 32)');
         define('LOGGED_IN_SALT',   '$(cvutil_makepasswd 32)');
         define('NONCE_SALT',       '$(cvutil_makepasswd 32)');
+        define( 'WP_AUTO_UPDATE_CORE', minor );
 PHP
 
     wp core install \


### PR DESCRIPTION
If we specify a version - keep that version.

Problem:

Install wp-demo and specify a version  `--cms-ver 6.2.2`  

Buildkit installs Version 6.2.2

Launch the site and login

WP updates to WP latest (currently 6.3)

Solution:

Set `WP_AUTO_UPDATE_CORE` to only auto-update  minor versions.