### PR TITLE
Reinstate CIVI_DEMO_EXTS

### DIFF
--- a/app/config/backdrop-demo/install.sh
+++ b/app/config/backdrop-demo/install.sh
@@ -54,9 +54,6 @@ pushd "$CMS_ROOT" >> /dev/null
 
   backdrop_po_import
 
-  ## Setup demo extensions
-  cv en --ignore-missing $CIVI_DEMO_EXTS
-
   ## Demo sites always disable email and often disable cron
   cv api StatusPreference.create ignore_severity=critical name=checkOutboundMail
   cv api StatusPreference.create ignore_severity=critical name=checkLastCron

--- a/app/config/wp-demo/install.sh
+++ b/app/config/wp-demo/install.sh
@@ -119,6 +119,7 @@ wp cap add civicrm_admin \
   edit_event_participants \
   edit_grants \
   edit_groups \
+  edit_message_templates \
   edit_memberships \
   edit_own_manual_batches \
   edit_pledges \

--- a/src/civibuild.defaults.sh
+++ b/src/civibuild.defaults.sh
@@ -208,7 +208,8 @@ CIVI_EXT_DIR=
 CIVI_EXT_URL=
 
 ## List of extensions to enable on `*-demo` builds
-CIVI_DEMO_EXTS='civirules civisualize cividiscount org.civicrm.search_kit org.civicrm.search org.civicrm.contactlayout org.civicrm.angularprofiles org.civicrm.volunteer civicrm_admin_ui message_admin org.civicrm.afform org.civicrm.afform_admin'
+## Note: Some of these are enabled by default on current releases. That doesn't hurt anything, and it's handy for testing older releases.
+CIVI_DEMO_EXTS='civirules civisualize cividiscount org.civicrm.search_kit org.civicrm.search org.civicrm.contactlayout civicrm_admin_ui message_admin org.civicrm.afform org.civicrm.afform_admin'
 
 ## DB credentials for Civi test DB
 ## (suggested: autogenerate via 'amp create -f --root="$WEB_ROOT" --name=civi --prefix=TEST_ --skip-url')

--- a/src/civibuild.lib.sh
+++ b/src/civibuild.lib.sh
@@ -768,6 +768,7 @@ EOPHP
   if cv ev 'exit(version_compare(CRM_Utils_System::version(), "5.19.alpha", "<") ?0:1);' ; then
     cv en --ignore-missing api4
   fi
+  cv en --ignore-missing $CIVI_DEMO_EXTS
 }
 
 ###############################################################################


### PR DESCRIPTION
This is a follow-up to #793, which had aimed to specifically remove `devel` and `volunteer`. However, I didn't notice that 4b7a2c4f9312e0bb37 actually disabled activation of *all* demo extensions. This means that extensions like `civicrm_admin_ui`, `civirules`, `cividiscount` `message_admin`, and `contactlayout` aren't active.

This re-instates in a more centralized spot that should harder to miss.

Before + After
----------------

* __Original__: All the `*-demo` builds had `install.sh` steps to call:
    ```
    cv en --ignore-missing $CIVI_DEMO_EXTS`
    ```
* __Recent__: Most of the `*-demo` builds lost the calls to `cv en ...`. (The exception is `backdrop-demo`, which still had it.)
* __Now__: This re-adds the call `cv en ...` to all `*-demo` types.
    * Note: Instead of splitting the call across the various `*-demo/install.sh` scripts, there is one consolidated call (through the shared function `civicrm_apply_demo_defaults`).

Comments
---------------

I did a trial-run of each of these:

```
env     command                                                 bld     browse
---     -------                                                 ---     ------
max:    civibuild create tmpd7 --type drupal-demo               [x]     [x]
max:    civibuild create tmpd9 --type drupal9-demo              [x]     [x]
max:    civibuild create tmpd10 --type drupal10-demo            [x]     [x]
min:    civibuild create tmpbd --type backdrop-demo             [x]     [x]
min:    civibuild create tmpwp --type wp-demo                   [x]     [x]
```

On each, I logged in to spot-check that the demo extensions were active. Noticed and fixed one quirk on wp-demo.