### PR TITLE
run-bknix-job - Show a suggested replay command

### DIFF
--- a/src/jobs/env.txt
+++ b/src/jobs/env.txt
@@ -1,6 +1,7 @@
 ## Master list of all known environment-variables
 #
 # This list may be required for forwarding jobs between different users/environments.
+# Note that none of these variables are considered sensitive. That's good, since they may published in the build log.
 #
 
 ## Civi jobs

--- a/src/jobs/homerdo-task.sh
+++ b/src/jobs/homerdo-task.sh
@@ -74,6 +74,9 @@ function do_all() {
 
   "$SELF" request > "$request"
 
+  echo >&2 "[$USER] To replay this request, run:"
+  show_request_cmd "$request" "    " >&2
+
   local img=$(cd "$imageDir" && flock . "$SELF" pick-image "$request" $$ )
   if [ ! -e "$img" ]; then
     echo >&2 "Failed to pick image from $imageDir for $request"
@@ -257,6 +260,20 @@ function do_exec() {
 
 #####################################################################
 ## Utilities
+
+function show_request_cmd() {
+  local request="$1"
+  local prefix="$2"
+
+  echo
+  echo "${prefix}env \\"
+  cat "$request" | sed 's;/home/homer;\$HOME;' | while read LINE ; do
+    echo "${prefix}  $LINE \\"
+  done
+  echo -n "$prefix  "
+  printf "run-bknix-job %q %q\n" "$BKPROF" "$JOB_NAME"
+  echo
+}
 
 ## Ensure that the WORKSPACE folder is setup.
 function use_workspace() {


### PR DESCRIPTION
This patch would add a message to the Jenkins output of any jobs based on `run-bknix-jobs`. Something like:

```
[dispatcher] Generate request
[dispatcher] To replay this request, run:

    env \
      BUILD_NUMBER=123 \
      BKPROF=dfl \
      JOB_NAME=shell \
      WORKSPACE=$HOME/tmp/mock-workspace \
      EXECUTOR_NUMBER=0 \
      run-bknix-job dfl shell
```

If you have bknix installed locally, then you can invoke the command to run the same job.

I've only done some light test locally, but so far it seems OK...
