### PR TITLE
bknix - Enable `imap` PECL on MacOS/php81+php82

### DIFF
--- a/nix/pkgs/php81/default.nix
+++ b/nix/pkgs/php81/default.nix
@@ -16,7 +16,7 @@ let
 in pkgs.php81.buildEnv {
 
   ## EVALUATE: apcu_bc
-  extensions = { all, enabled}: with all; enabled++ [ xdebug redis tidy apcu yaml memcached imagick opcache phpExtras.runkit7_4 ];
+  extensions = { all, enabled}: with all; enabled++ [ xdebug redis tidy apcu imap yaml memcached imagick opcache phpExtras.runkit7_4 ];
   extraConfig = phpIniSnippet1 + phpIniSnippet2;
 
 }

--- a/nix/pkgs/php82/default.nix
+++ b/nix/pkgs/php82/default.nix
@@ -16,7 +16,7 @@ let
 in pkgs.php82.buildEnv {
 
   ## EVALUATE: apcu_bc
-  extensions = { all, enabled }: with all; enabled++ [ phpExtras.xdebug32 redis tidy apcu yaml memcached imagick opcache phpExtras.runkit7_4 ];
+  extensions = { all, enabled }: with all; enabled++ [ phpExtras.xdebug32 redis tidy apcu imap yaml memcached imagick opcache phpExtras.runkit7_4 ];
   extraConfig = phpIniSnippet1 + phpIniSnippet2;
 
 }


### PR DESCRIPTION
* For Linux, the `imap` PECL is already provided by default.
* For MacOS, it historically had build problems. These seem to be fixed now-a-days (on newer versions), but we have to opt-in.