### PR TITLE
Karma - Freedom from the phantoms of Javascript

### DIFF
--- a/.loco/jenkins-dfl.yml
+++ b/.loco/jenkins-dfl.yml
@@ -47,6 +47,10 @@ environment:
  - NODE_PATH=$BKIT/node_modules:$NODE_PATH
  - PATH=$BKIT/bin:$BKIT/node_modules/.bin:$LOCO_PRJ/.loco/bin:$PATH
 
+default_environment:
+ ## Gen4 cfg uses $(which chromium). This file is for gen3, which is harder to QA.
+ - CHROME_BIN=/nix/var/nix/profiles/bknix-dfl/bin/chromium
+
 #### Functional service definitions
 services:
 

--- a/.loco/jenkins-edge.yml
+++ b/.loco/jenkins-edge.yml
@@ -47,6 +47,10 @@ environment:
  - NODE_PATH=$BKIT/node_modules:$NODE_PATH
  - PATH=$BKIT/bin:$BKIT/node_modules/.bin:$LOCO_PRJ/.loco/bin:$PATH
 
+default_environment:
+ ## Gen4 cfg uses $(which chromium). This file is for gen3, which is harder to QA.
+ - CHROME_BIN=/nix/var/nix/profiles/bknix-edge/bin/chromium
+
 #### Functional service definitions
 services:
 

--- a/.loco/jenkins-max.yml
+++ b/.loco/jenkins-max.yml
@@ -47,6 +47,10 @@ environment:
  - NODE_PATH=$BKIT/node_modules:$NODE_PATH
  - PATH=$BKIT/bin:$BKIT/node_modules/.bin:$LOCO_PRJ/.loco/bin:$PATH
 
+default_environment:
+ ## Gen4 cfg uses $(which chromium). This file is for gen3, which is harder to QA.
+ - CHROME_BIN=/nix/var/nix/profiles/bknix-max/bin/chromium
+
 #### Functional service definitions
 services:
 

--- a/.loco/jenkins-min.yml
+++ b/.loco/jenkins-min.yml
@@ -47,6 +47,10 @@ environment:
  - NODE_PATH=$BKIT/node_modules:$NODE_PATH
  - PATH=$BKIT/bin:$BKIT/node_modules/.bin:$LOCO_PRJ/.loco/bin:$PATH
 
+default_environment:
+ ## Gen4 cfg uses $(which chromium). This file is for gen3, which is harder to QA.
+ - CHROME_BIN=/nix/var/nix/profiles/bknix-min/bin/chromium
+
 #### Functional service definitions
 services:
 

--- a/.loco/publisher-max.yml
+++ b/.loco/publisher-max.yml
@@ -39,6 +39,10 @@ environment:
  - NODE_PATH=$BKIT/node_modules:$NODE_PATH
  - PATH=$BKIT/bin:$BKIT/node_modules/.bin:$LOCO_PRJ/.loco/bin:$PATH
 
+default_environment:
+ ## Gen4 cfg uses $(which chromium). This file is for gen3, which is harder to QA.
+ - CHROME_BIN=/nix/var/nix/profiles/bknix-max/bin/chromium
+
 #### Functional service definitions
 services:
 

--- a/.loco/publisher-min.yml
+++ b/.loco/publisher-min.yml
@@ -39,6 +39,10 @@ environment:
  - NODE_PATH=$BKIT/node_modules:$NODE_PATH
  - PATH=$BKIT/bin:$BKIT/node_modules/.bin:$LOCO_PRJ/.loco/bin:$PATH
 
+default_environment:
+ ## Gen4 cfg uses $(which chromium). This file is for gen3, which is harder to QA.
+ - CHROME_BIN=/nix/var/nix/profiles/bknix-min/bin/chromium
+
 #### Functional service definitions
 services:
 

--- a/bin/civi-test-run
+++ b/bin/civi-test-run
@@ -199,7 +199,7 @@ function task_karma() {
     ADMIN_USER=$(cv ev 'echo $GLOBALS["_CV"]["ADMIN_USER"];')
     cv api -U "$ADMIN_USER" contact.get id=user_contact_id
     if [ -f karma.conf.js ]; then
-      if ! $GUARD $TIMER env OPENSSL_CONF=/dev/null karma start --browsers PhantomJS --single-run --reporters dots,junit ; then
+      if ! $GUARD $TIMER env OPENSSL_CONF=/dev/null karma start --single-run --reporters dots,junit ; then
         EXITCODES="$EXITCODES karma"
       fi
       echo "Found EXITCODES=\"$EXITCODES\""


### PR DESCRIPTION
Follow-up to #818. Includes two parts:

* Update `civi-test-run` to relax the browser settings. Tested this locally on with both `5.63` (PhantomJS) and `master` (ChromeHeadless)
* Add some updates for older gen3 test nodes (specifically, `test-1.civicrm.org`). Testing still in progress.