### PR TITLE
Enable unit testing using Smarty3

### DIFF
--- a/app/civicrm.settings.d/400-smarty3.php
+++ b/app/civicrm.settings.d/400-smarty3.php
@@ -1,18 +1,26 @@
 <?php
 
-switch($GLOBALS['_CV']['CIVI_UF']) {
-  case 'Drupal':
-  case 'Backdrop':
-  case 'WordPress':
-  case 'Standalone':
-  case 'Joomla':
-    $packages_path = $GLOBALS['_CV']['CIVI_CORE'] . DIRECTORY_SEPARATOR . 'packages';
-    break;
+if (!isset($GLOBALS['_CV']) && isset($GLOBALS['civicrm_paths']) && !empty($GLOBALS['civicrm_paths']['civicrm.packages'])) {
+  $packages_path = $GLOBALS['civicrm_paths']['civicrm.packages']['path'];
+}
+elseif (!isset($GLOBALS['_CV'])) {
+  return;
+}
+else {
+  switch($GLOBALS['_CV']['CIVI_UF']) {
+   case 'Drupal':
+     case 'Backdrop':
+    case 'WordPress':
+    case 'Standalone':
+    case 'Joomla':
+      $packages_path = $GLOBALS['_CV']['CIVI_CORE'] . DIRECTORY_SEPARATOR . 'packages';
+      break;
 
-  case 'Drupal8':
-    $packages_path = $GLOBALS['_CV']['CIVI_CORE'] . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'civicrm_packages';
-    break;
+    case 'Drupal8':
+      $packages_path = $GLOBALS['_CV']['CIVI_CORE'] . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'civicrm_packages';
+      break;
 
+  }
 }
 if (getenv('SMARTY3_ENABLE') && file_exists($packages_path . DIRECTORY_SEPARATOR . 'smarty3' . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'autoload.php') && !defined('CIVICRM_SMARTY3_AUTOLOAD_PATH')) {
   define('CIVICRM_SMARTY3_AUTOLOAD_PATH', $packages_path . DIRECTORY_SEPARATOR . 'smarty3' . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'autoload.php');

--- a/app/civicrm.settings.d/400-smarty3.php
+++ b/app/civicrm.settings.d/400-smarty3.php
@@ -1,0 +1,19 @@
+<?php
+
+switch($GLOBALS['_CV']['CIVI_UF']) {
+  case 'Drupal':
+  case 'Backdrop':
+  case 'WordPress':
+  case 'Standalone':
+  case 'Joomla':
+    $packages_path = $GLOBALS['_CV']['CIVI_CORE'] . DIRECTORY_SEPARATOR . 'packages';
+    break;
+
+  case 'Drupal8':
+    $packages_path = $GLOBALS['_CV']['CIVI_CORE'] . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'civicrm_packages';
+    break;
+
+}
+if (getenv('SMARTY3_ENABLE') && file_exists($packages_path . DIRECTORY_SEPARATOR . 'smarty3' . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'autoload.php') && !defined('CIVICRM_SMARTY3_AUTOLOAD_PATH')) {
+  define('CIVICRM_SMARTY3_AUTOLOAD_PATH', $packages_path . DIRECTORY_SEPARATOR . 'smarty3' . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'autoload.php');
+}

--- a/src/jobs/CiviCRM-Core-PR.job
+++ b/src/jobs/CiviCRM-Core-PR.job
@@ -46,5 +46,6 @@ civibuild env-info
 $GUARD civibuild download "$BLDNAME" --type "$BLDTYPE" --civi-ver "$ghprbTargetBranch" \
   --patch "https://github.com/civicrm/civicrm-core/pull/${ghprbPullId}"
 
+export SMARTY3_ENABLE=true
 ## No obvious problems blocking a build...
 $GUARD civibuild install "$BLDNAME"

--- a/src/jobs/CiviCRM-D8-Matrix.job
+++ b/src/jobs/CiviCRM-D8-Matrix.job
@@ -57,6 +57,7 @@ civibuild show "$BLDNAME" \
   --new-scan "$WORKSPACE_BUILD/new-scan.json"
 cp "$WORKSPACE_BUILD/new-scan.json" "$WORKSPACE_BUILD/last-scan.json"
 
+export SMARTY3_ENABLE=true
 ## Execute tests
 civi-test-run -b "$BLDNAME" -j "$WORKSPACE_JUNIT" $SUITES
 exit $?

--- a/src/jobs/CiviCRM-Drupal-PR.job
+++ b/src/jobs/CiviCRM-Drupal-PR.job
@@ -70,6 +70,7 @@ $GUARD popd
 
 $GUARD civibuild install "$BLDNAME"
 
+export SMARTY3_ENABLE=true
 ## Run the tests
 $GUARD civi-test-run -b "$BLDNAME" -j "$WORKSPACE_JUNIT" $SUITES
 exit $?

--- a/src/jobs/CiviCRM-Packages-PR.job
+++ b/src/jobs/CiviCRM-Packages-PR.job
@@ -55,5 +55,6 @@ $GUARD civibuild download "$BLDNAME" --type "$BLDTYPE" --civi-ver "$CIVIVER" \
 $GUARD civibuild install "$BLDNAME"
 
 ## Run the tests
+export SMARTY3_ENABLE=true
 $GUARD civi-test-run -b "$BLDNAME" -j "$WORKSPACE_JUNIT" $SUITES --exclude-group ornery
 exit $?

--- a/src/jobs/CiviCRM-WordPress-PR.job
+++ b/src/jobs/CiviCRM-WordPress-PR.job
@@ -71,6 +71,7 @@ $GUARD popd
 
 $GUARD civibuild install "$BLDNAME"
 
+export SMARTY3_ENABLE=true
 ## Run the tests
 $GUARD civi-test-run -b "$BLDNAME" -j "$WORKSPACE_JUNIT" $SUITES --exclude-group ornery
 exit $?

--- a/src/pogo/civi-test-pr.php
+++ b/src/pogo/civi-test-pr.php
@@ -64,6 +64,7 @@ $c['app']->command("main [-N|--dry-run] [-S|--step] [--type=] [--patch=] [--keep
   $taskr->passthru('civibuild install {{0|s}}', [$c['buildName']]);
 
   $io->section("\nRun tests");
+  $taskr->passthru('export SMARTY3_ENABLE=true');
   $taskr->passthru('TIME_FUNC={{3|s}} civi-test-run -b {{0|s}} -j {{1|s}} {{2}}', [
     $c['buildName'],
     $c['junitDir'],


### PR DESCRIPTION
This aims to enable unit testing on PR test jobs but leaving smarty2 enabled on matrix jobs however you can enable it by doing export SMARTY3_ENABLE=true

ping @totten @eileenmcnaughton