### PR TITLE
Smarty3 Testing - Fix some bugs. Limit to `CiviCRM-D8-Matrix` (master). 

### DIFF
--- a/app/civicrm.settings.d/400-smarty3.php
+++ b/app/civicrm.settings.d/400-smarty3.php
@@ -17,11 +17,12 @@ else {
       break;
 
     case 'Drupal8':
-      $packages_path = $GLOBALS['_CV']['CIVI_CORE'] . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'civicrm_packages';
+      $packages_path = dirname($GLOBALS['_CV']['CIVI_CORE']) . DIRECTORY_SEPARATOR . 'civicrm-packages';
       break;
 
   }
 }
+
 if (getenv('SMARTY3_ENABLE') && file_exists($packages_path . DIRECTORY_SEPARATOR . 'smarty3' . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'autoload.php') && !defined('CIVICRM_SMARTY3_AUTOLOAD_PATH')) {
   define('CIVICRM_SMARTY3_AUTOLOAD_PATH', $packages_path . DIRECTORY_SEPARATOR . 'smarty3' . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'autoload.php');
 }

--- a/app/civicrm.settings.d/400-smarty3.php
+++ b/app/civicrm.settings.d/400-smarty3.php
@@ -23,6 +23,6 @@ else {
   }
 }
 
-if (getenv('SMARTY3_ENABLE') && file_exists($packages_path . DIRECTORY_SEPARATOR . 'smarty3' . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'autoload.php') && !defined('CIVICRM_SMARTY3_AUTOLOAD_PATH')) {
+if (getenv('SMARTY3_ENABLE') === 'true' && file_exists($packages_path . DIRECTORY_SEPARATOR . 'smarty3' . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'autoload.php') && !defined('CIVICRM_SMARTY3_AUTOLOAD_PATH')) {
   define('CIVICRM_SMARTY3_AUTOLOAD_PATH', $packages_path . DIRECTORY_SEPARATOR . 'smarty3' . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'autoload.php');
 }

--- a/src/jobs/CiviCRM-Core-PR.job
+++ b/src/jobs/CiviCRM-Core-PR.job
@@ -46,6 +46,5 @@ civibuild env-info
 $GUARD civibuild download "$BLDNAME" --type "$BLDTYPE" --civi-ver "$ghprbTargetBranch" \
   --patch "https://github.com/civicrm/civicrm-core/pull/${ghprbPullId}"
 
-export SMARTY3_ENABLE=true
 ## No obvious problems blocking a build...
 $GUARD civibuild install "$BLDNAME"

--- a/src/jobs/CiviCRM-D8-Matrix.job
+++ b/src/jobs/CiviCRM-D8-Matrix.job
@@ -4,6 +4,8 @@ set -e
 ## Example usage:
 ##
 ## $ env CIVIVER=5.59 SUITES=phpunit-e2e BLDTYPE='drupal9-clean_9.4.x-dev' run-bknix-job --mock max CiviCRM-D8-Matrix
+## $ env SMARTY3_ENABLE=true CIVIVER=master SUITES=phpunit-e2e BLDTYPE='drupal9-clean_9.4.x-dev' run-bknix-job --mock max CiviCRM-D8-Matrix
+## $ env SMARTY3_ENABLE=false CIVIVER=master SUITES=phpunit-e2e BLDTYPE='drupal9-clean_9.4.x-dev' run-bknix-job --mock max CiviCRM-D8-Matrix
 
 #################################################
 ## Environment variables
@@ -13,7 +15,9 @@ set -e
 ## CIVIVER: The version of CiviCRM to install, expressed as a branch or tag (e.g. `master`, `5.59`, `5.57.0`)
 ## SUITES: Space-limited list of test-suites (e.g. `phpunit-e2e phpunit-civi`)
 ## BLDTYPE: Name of the civibuild configuration to use. Optionally append version. (e.g. `drupal9-clean_9.4.x-dev`)
+## SMARTY3_ENABLE: "true" or "false". Whether to use Smarty3. (Default: version-dependent)
 assert_common EXECUTOR_NUMBER WORKSPACE CIVIVER SUITES
+assign_smarty
 
 ## Optionally peg to a specific CMS version
 CMS_REGEX="([a-z0-9\-]+)_([a-z0-9\-\.]+)"
@@ -57,7 +61,9 @@ civibuild show "$BLDNAME" \
   --new-scan "$WORKSPACE_BUILD/new-scan.json"
 cp "$WORKSPACE_BUILD/new-scan.json" "$WORKSPACE_BUILD/last-scan.json"
 
-export SMARTY3_ENABLE=true
+## Enable this if you want a log message to confirm the content of CIVICRM_SMARTY3_AUTOLOAD_PATH
+# (cd "$BKITBLD/$BLDNAME" && cv ev 'printf("CIVICRM_SMARTY3_AUTOLOAD_PATH=[%s]\n", CRM_Utils_Constant::value("CIVICRM_SMARTY3_AUTOLOAD_PATH"));' )
+
 ## Execute tests
 civi-test-run -b "$BLDNAME" -j "$WORKSPACE_JUNIT" $SUITES
 exit $?

--- a/src/jobs/CiviCRM-Drupal-PR.job
+++ b/src/jobs/CiviCRM-Drupal-PR.job
@@ -70,7 +70,6 @@ $GUARD popd
 
 $GUARD civibuild install "$BLDNAME"
 
-export SMARTY3_ENABLE=true
 ## Run the tests
 $GUARD civi-test-run -b "$BLDNAME" -j "$WORKSPACE_JUNIT" $SUITES
 exit $?

--- a/src/jobs/CiviCRM-Packages-PR.job
+++ b/src/jobs/CiviCRM-Packages-PR.job
@@ -55,6 +55,5 @@ $GUARD civibuild download "$BLDNAME" --type "$BLDTYPE" --civi-ver "$CIVIVER" \
 $GUARD civibuild install "$BLDNAME"
 
 ## Run the tests
-export SMARTY3_ENABLE=true
 $GUARD civi-test-run -b "$BLDNAME" -j "$WORKSPACE_JUNIT" $SUITES --exclude-group ornery
 exit $?

--- a/src/jobs/CiviCRM-WordPress-PR.job
+++ b/src/jobs/CiviCRM-WordPress-PR.job
@@ -71,7 +71,6 @@ $GUARD popd
 
 $GUARD civibuild install "$BLDNAME"
 
-export SMARTY3_ENABLE=true
 ## Run the tests
 $GUARD civi-test-run -b "$BLDNAME" -j "$WORKSPACE_JUNIT" $SUITES --exclude-group ornery
 exit $?

--- a/src/jobs/common.sh
+++ b/src/jobs/common.sh
@@ -78,6 +78,15 @@ function assert_common() {
   done
 }
 
+## Determine which version of Smarty to test.
+## If SMARTY3_ENABLE is already set, use it. Otherwise, choose a value of SMARTY3_ENABLE.
+function assign_smarty() {
+  if [[ "x$SMARTY3_ENABLE" = "x" && "$CIVIVER" = "master" ]]; then
+    SMARTY3_ENABLE=true
+  fi
+  export SMARTY3_ENABLE
+}
+
 ## Load the BKPROF into the current shell
 function use_bknix() {
   if [ -n "$LOADED_BKPROF" ]; then

--- a/src/pogo/civi-test-pr.php
+++ b/src/pogo/civi-test-pr.php
@@ -64,7 +64,6 @@ $c['app']->command("main [-N|--dry-run] [-S|--step] [--type=] [--patch=] [--keep
   $taskr->passthru('civibuild install {{0|s}}', [$c['buildName']]);
 
   $io->section("\nRun tests");
-  $taskr->passthru('export SMARTY3_ENABLE=true');
   $taskr->passthru('TIME_FUNC={{3|s}} civi-test-run -b {{0|s}} -j {{1|s}} {{2}}', [
     $c['buildName'],
     $c['junitDir'],


### PR DESCRIPTION
This is a follow-up to @seamuslee001's #821. A few changes:

1. Fix path-computation for `civicrm-packages` on D8/9/10. 
2. Allow `SMARTY3_ENABLE` to be set to either `true` or `false` (as a way to opt-in or opt-out).
3. Temporarily dial-back the default scope of Smarty3 testing -- only run it on `CiviCRM-D8-Matrix` (when the target version is `master`)

Why dial it back? Well, I spot-checked `CiviCRM-D8-Matrix.job` locally. To do so, I copied the example from the top comment and added the flag `SMARTY3_ENABLE`.  Compare these two commands:

```bash
env SMARTY3_ENABLE=false CIVIVER=master SUITES=phpunit-e2e BLDTYPE='drupal9-clean_9.4.x-dev' \
 run-bknix-job --mock max CiviCRM-D8-Matrix
```
```bash
env SMARTY3_ENABLE=true CIVIVER=master SUITES=phpunit-e2e BLDTYPE='drupal9-clean_9.4.x-dev' \
 run-bknix-job --mock max CiviCRM-D8-Matrix
```

The first command succeeds. The second runs many tests but eventually hits a fatal:

```
ok 1595 - E2E\Core\ErrorTest::testErrorChrome with data set "backend_permission" ('backend://civicrm/dev/fake-error', 'permission')
ok 1596 - E2E\Core\HookTest::testSymfonyListener_names

Fatal error: Cannot declare class Smarty, because the name is already in use in /home/totten/bknix/build/build-0/vendor/civicrm/civicrm-packages/Smarty/Smarty.class.php on line 64

Call Stack:
    0.0025    5579040   1. {main}() /home/totten/bknix/extern/phpunit9/phpunit9.phar:0
    0.0703   22605336   2. PHPUnit\TextUI\Command::main($exit = ???) /home/totten/bknix/extern/phpunit9/phpunit9.phar:2307
    ...
   42.2017  163678280   9. PHPUnit\Framework\TestCase->runBare() phar:///home/totten/bknix/extern/phpunit9/phpunit9.phar/phpunit/Framework/TestResult.php:588
   42.2018  163695768  10. PHPUnit\Framework\TestCase->runTest() phar:///home/totten/bknix/extern/phpunit9/phpunit9.phar/phpunit/Framework/TestCase.php:981
   42.2018  163695768  11. E2E\Core\LocalizedDataTest->testLocalizedData() phar:///home/totten/bknix/extern/phpunit9/phpunit9.phar/phpunit/Framework/TestCase.php:1315
   42.2018  163696144  12. E2E\Core\LocalizedDataTest->_getSqlLive($locale = 'de_DE') /home/totten/bknix/build/build-0/vendor/civicrm/civicrm-core/tests/phpunit/E2E/Core/LocalizedDataTest.php:27
   42.2876  166883712  13. CRM_Core_CodeGen_Schema->generateLocaleDataSql($locale = 'de_DE') /home/totten/bknix/build/build-0/vendor/civicrm/civicrm-core/tests/phpunit/E2E/Core/LocalizedDataTest.php:77
   42.2878  166897928  14. CRM_Core_CodeGen_Util_Template->__construct($filetype = 'sql', $beautify = ???) /home/totten/bknix/build/build-0/vendor/civicrm/civicrm-core/CRM/Core/CodeGen/Schema.php:85
   42.2879  166906736  15. CRM_Core_CodeGen_Util_Smarty->createSmarty() /home/totten/bknix/build/build-0/vendor/civicrm/civicrm-core/CRM/Core/CodeGen/Util/Template.php:24
   42.2889  167093200  16. require_once('/home/totten/bknix/build/build-0/vendor/civicrm/civicrm-packages/Smarty/Smarty.class.php') /home/totten/bknix/build/build-0/vendor/civicrm/civicrm-core/CRM/Core/CodeGen/Uti
/Smarty.php:51
```

Personally, I prefer doing that kind of testing locally. But it's also OK if we have some of the CI jobs exposed to this while we get it to work. Suggested roll out:

1. Enable for `CiviCRM-D8-Matrix.job` (when `CIVIVER=master`). Get it to pass.
2. Enable for `CiviCRM-E2E-Matrix.job` and `CiviCRM-Core-Matrix.job` (when `CIVIVER=master`). Get it to pass.
3. Enable for `CiviCRM-Core-Matrix-PR.job` (when `CIVIVER=master`). It should already be passing (given 1+2). Just confirm it.
4. Enable for other jobs (when `CIVIVER=master`). Confirm they're passing.
5. Go back and refine the criterion. (Instead of specifically checking `CIVIVER=master`, check the numeric version.)
