### PR TITLE
Define style jobs for several repos

### DIFF
--- a/nix/bin/run-bknix-job
+++ b/nix/bin/run-bknix-job
@@ -61,6 +61,22 @@ function run_bknix_mock() {
   cd "$WORKSPACE"
 }
 
+## If there's a redeploy while bash is running, then bash gets stupid.
+## Instead of loading bash scripts directly, we load through a temp file.
+## run_bknix_include <SCRIPT_1> <SCRIPT_2> ...
+function run_bknix_include() {
+  local tmpfile=$(run_bknix_mktemp)
+  touch "$tmpfile"
+  RUN_BKNIX_CLEANUP_FILES+=("$tmpfile")
+
+  for file in "$@" ; do
+    cat "$file" >> "$tmpfile"
+    echo >> "$tmpfile"
+  done
+
+  source "$tmpfile"
+}
+
 function run_bknix_main() {
   if [ -z "$BKNIX_JOBS" ]; then
     BKNIX_JOBS="/opt/buildkit/src/jobs"
@@ -145,14 +161,7 @@ function run_bknix_main() {
     run_bknix_fatal "Missing or invalid JOB_NAME. No such file \"$BKNIX_JOB_SCRIPT\"."
   fi
 
-  ## If there's a redeploy while bash is running, then bash gets stupid. Prefer to run bash scripts in temp files.
-  local tmpfile=$(run_bknix_mktemp)
-  touch "$tmpfile"
-  RUN_BKNIX_CLEANUP_FILES+=("$tmpfile")
-  cat "$BKNIX_JOBS/common.sh" >> $tmpfile
-  echo >> $tmpfile
-  cat "$BKNIX_JOB_SCRIPT" >> $tmpfile
-  source "$tmpfile"
+  run_bknix_include "$BKNIX_JOBS/common.sh" "$BKNIX_JOB_SCRIPT"
 }
 
 ## usage: run_bknix_download <url> <out-file>

--- a/src/jobs/CiviCRM-Backdrop-PR.job
+++ b/src/jobs/CiviCRM-Backdrop-PR.job
@@ -3,7 +3,7 @@ set -e
 
 ## Example usage:
 ##
-## $ env ghprbTargetBranch=1.x-master ghprbPullId=159 run-bknix-job --mock max CiviCRM-Backdrop-PR
+## $ env ghprbTargetBranch=1.x-master ghprbPullId=159 run-bknix-job --mock dfl CiviCRM-Backdrop-PR
 
 #################################################
 ## Environment variables
@@ -18,16 +18,8 @@ SUITES='upgrade phpunit-e2e phpunit-backdrop'
 ## ghprbPullId: Pull request ID number
 assert_common EXECUTOR_NUMBER WORKSPACE BLDTYPE SUITES ghprbPullId ghprbTargetBranch
 
-case "$ghprbTargetBranch" in
-  1.x-4.6*|1.x-4.7*|1.x-5*|1.x-master*)
-    CIVIVER=$(echo "$ghprbTargetBranch" | sed 's;^1.x-;;')
-    ;;
-  *)
-    ## This actually true for many branches, so we exit softly...
-    echo "PR test not allowed for $ghprbTargetBranch"
-    exit 0
-    ;;
-esac
+detect_civiver civicrm-backdrop "$ghprbTargetBranch"
+assert_testable_version "$CIVIVER"
 
 #################################################
 ## Main
@@ -53,19 +45,7 @@ $GUARD civibuild download "$BLDNAME" --type "$BLDTYPE" --civi-ver "$CIVIVER" \
 
 ## Check style first; fail quickly if we break style
 $GUARD pushd "$BLDDIR/web/modules/civicrm/backdrop"
-  case "$ghprbTargetBranch" in
-    1.x-4.3*|1.x-4.4*|1.x-4.5*|1.x-4.6*)
-      ## skip
-      ;;
-    *)
-      if git diff --name-only "origin/$ghprbTargetBranch.." | $GUARD civilint --checkstyle "$WORKSPACE_CHECKSTYLE" - ; then
-        echo "Style passed"
-      else
-        echo "Style error"
-        exit 1
-      fi
-      ;;
-  esac
+  $GUARD xcivilint "origin/$ghprbTargetBranch" "civicrm-backdrop#""${ghprbPullId}"
 $GUARD popd
 
 $GUARD civibuild install "$BLDNAME"

--- a/src/jobs/CiviCRM-Backdrop-Style.job
+++ b/src/jobs/CiviCRM-Backdrop-Style.job
@@ -3,9 +3,9 @@ set -e
 
 ## Example usage:
 ##
-## $ env ghprbTargetBranch=master ghprbPullId=28104 run-bknix-job --mock dfl CiviCRM-Core-Style
+## $ env ghprbTargetBranch=1.x-master ghprbPullId=159 run-bknix-job --mock dfl CiviCRM-Backdrop-Style
 
 #################################################
 
-CIVI_REPO=civicrm-core
+CIVI_REPO=civicrm-backdrop
 run_bknix_include "$BKNIX_JOBS/Generic-Style.job"

--- a/src/jobs/CiviCRM-Core-Style.job
+++ b/src/jobs/CiviCRM-Core-Style.job
@@ -3,7 +3,12 @@ set -e
 
 ## Example usage:
 ##
-## $ env ghprbTargetBranch=master ghprbPullId=12345 run-bknix-job --mock dfl CiviCRM-Core-Style
+## $ env ghprbTargetBranch=master ghprbPullId=28104 run-bknix-job --mock dfl CiviCRM-Core-Style
+##
+## If testing an alternate repo, set the var CIVI_REPO:
+##
+## $ env CIVI_REPO=civicrm-backdrop ghprbTargetBranch=1.x-master ghprbPullId=159 run-bknix-job --mock dfl CiviCRM-Core-Style
+## $ env CIVI_REPO=civicrm-drupal ghprbTargetBranch=7.x-master ghprbPullId=673 run-bknix-job --mock dfl CiviCRM-Core-Style
 
 #################################################
 ## Environment variables
@@ -12,9 +17,12 @@ set -e
 ## WORKSPACE: The path where Jenkins stores data for this job
 ## ghprbTargetBranch: The version of CiviCRM to install, expressed as a branch or tag (e.g. `master`, `5.59`, `5.57.0`)
 ## ghprbPullId: The pull request to apply
-assert_common EXECUTOR_NUMBER WORKSPACE ghprbPullId ghprbTargetBranch
+## CIVI_REPO: (Optional) The name of the github repo (`civicrm-core`, `civicrm-packages`, etc)
+CIVI_REPO=${CIVI_REPO:-civicrm-core}
+assert_common EXECUTOR_NUMBER WORKSPACE ghprbPullId ghprbTargetBranch CIVI_REPO
 
-assert_testable_version "$ghprbTargetBranch"
+detect_civiver "$CIVI_REPO" "$ghprbTargetBranch"
+assert_testable_version "$CIVIVER"
 
 #################################################
 ## Main
@@ -22,7 +30,7 @@ assert_testable_version "$ghprbTargetBranch"
 use_bknix_tmp
 
 ## Build definition
-BLDTYPE="dist"
+assert_common BKITBLD EXECUTOR_NUMBER
 BLDNAME="build-$EXECUTOR_NUMBER"
 BLDDIR="$BKITBLD/$BLDNAME"
 
@@ -37,10 +45,12 @@ fi
 civibuild env-info
 
 ## Download dependencies, apply patches
-civibuild download "$BLDNAME" --type "$BLDTYPE" --civi-ver "$ghprbTargetBranch" \
-  --patch "https://github.com/civicrm/civicrm-core/pull/${ghprbPullId}"
+civibuild download "$BLDNAME" --type "empty"
+cloneCmd=$(printf 'git clone ${CACHE_DIR}/civicrm/%q.git -b %q src' "$CIVI_REPO" "$ghprbTargetBranch")
+civibuild run "$BLDNAME" --eval "$cloneCmd"
+civibuild run "$BLDNAME" --eval 'git_cache_deref_remotes "$CACHE_DIR" "$WEB_ROOT"'
 
-## Check style first; fail quickly if we break style
-pushd "$BLDDIR/src"
-  xcivilint "origin/$ghprbTargetBranch" "civicrm-core#""${ghprbPullId}"
+pushd "$BLDDIR/web/src"
+  git scan am -N "https://github.com/civicrm/$CIVI_REPO/pull/${ghprbPullId}"
+  xcivilint "origin/$ghprbTargetBranch" "$CIVI_REPO""#""${ghprbPullId}"
 popd

--- a/src/jobs/CiviCRM-Core-Style.job
+++ b/src/jobs/CiviCRM-Core-Style.job
@@ -3,7 +3,7 @@ set -e
 
 ## Example usage:
 ##
-## $ env ghprbTargetBranch=master ghprbPullId=12345 run-bknix-job --mock max CiviCRM-Core-Style
+## $ env ghprbTargetBranch=master ghprbPullId=12345 run-bknix-job --mock dfl CiviCRM-Core-Style
 
 #################################################
 ## Environment variables
@@ -46,26 +46,5 @@ civibuild download "$BLDNAME" --type "$BLDTYPE" --civi-ver "$ghprbTargetBranch" 
 
 ## Check style first; fail quickly if we break style
 pushd "$BLDDIR/src"
-
-  ## Create text+html renderings
-  echo "---- Full Report ----"
-  set +e
-    git diff --name-only "origin/$ghprbTargetBranch.." | civilint - | tee "$WORKSPACE_HTML/civilint.txt"
-  set -e
-  (
-    echo "<html>"
-    echo "<h1>civilint: PR ${ghprbPullId}</h1>"
-    php -r 'echo "<p>Executed circa " . htmlentities(date("Y-m-d H:i P")) . "</p>\n";'
-    echo "<pre>"
-    php -r 'echo htmlentities(file_get_contents($argv[1]));' "$WORKSPACE_HTML/civilint.txt"
-    echo "</pre></html>"
-  ) > "$WORKSPACE_HTML/civilint.html"
-
-  ## Create CheckStyle XML rendering
-  if git diff --name-only "origin/$ghprbTargetBranch.." | civilint --checkstyle "$WORKSPACE_CHECKSTYLE" - ; then
-    echo "Style passed"
-  else
-    echo "Style error"
-    exit 1
-  fi
+  xcivilint "origin/$ghprbTargetBranch" "civicrm-core#""${ghprbPullId}"
 popd

--- a/src/jobs/CiviCRM-Core-Style.job
+++ b/src/jobs/CiviCRM-Core-Style.job
@@ -14,11 +14,7 @@ set -e
 ## ghprbPullId: The pull request to apply
 assert_common EXECUTOR_NUMBER WORKSPACE ghprbPullId ghprbTargetBranch
 
-## Pre-requisite: We only test PR's for main-line branches.
-case "$ghprbTargetBranch" in
-  4.6*|4.7*|5.*|master*) echo "PR test is supported for $ghprbTargetBranch" ;;
-  *)                     echo "PR test not supported for $ghprbTargetBranch" ; exit 1 ;;
-esac
+assert_testable_version "$ghprbTargetBranch"
 
 #################################################
 ## Main

--- a/src/jobs/CiviCRM-Drupal-PR.job
+++ b/src/jobs/CiviCRM-Drupal-PR.job
@@ -3,7 +3,7 @@ set -e
 
 ## Example usage:
 ##
-## $ env ghprbTargetBranch=7.x-master ghprbPullId=159 run-bknix-job --mock max CiviCRM-Drupal-PR
+## $ env ghprbTargetBranch=7.x-master ghprbPullId=159 run-bknix-job --mock dfl CiviCRM-Drupal-PR
 
 #################################################
 ## Environment variables
@@ -19,16 +19,8 @@ export TIME_FUNC="linear:500"
 ## ghprbPullId: Pull request ID number
 assert_common EXECUTOR_NUMBER WORKSPACE BLDTYPE SUITES ghprbPullId ghprbTargetBranch
 
-case "$ghprbTargetBranch" in
-  7.x-4.6*|7.x-4.7*|7.x-5*|7.x-master*)
-    CIVIVER=$(echo "$ghprbTargetBranch" | sed 's;^7.x-;;')
-    ;;
-  *)
-    ## This actually true for many branches, so we exit softly...
-    echo "PR test not allowed for $ghprbTargetBranch"
-    exit 0
-    ;;
-esac
+detect_civiver civicrm-drupal "$ghprbTargetBranch"
+assert_testable_version "$CIVIVER"
 
 #################################################
 ## Main
@@ -54,18 +46,7 @@ $GUARD civibuild download "$BLDNAME" --type "$BLDTYPE" --civi-ver "$CIVIVER" \
 
 ## Check style first; fail quickly if we break style
 $GUARD pushd "$BLDDIR/web/sites/all/modules/civicrm/drupal"
-  case "$ghprbTargetBranch" in
-    7.x-4.3*|7.x-4.4*|7.x-4.5*|7.x-4.6*)
-      ## skip
-      ;;
-    *)
-      if git diff --name-only "origin/$ghprbTargetBranch.." | $GUARD civilint --checkstyle "$WORKSPACE_CHECKSTYLE" - ; then
-        echo "Style passed"
-      else
-        echo "Style error"
-        exit 1
-      fi
-  esac
+  $GUARD xcivilint "origin/$ghprbTargetBranch" "civicrm-drupal#""${ghprbPullId}"
 $GUARD popd
 
 $GUARD civibuild install "$BLDNAME"

--- a/src/jobs/CiviCRM-Drupal-Style.job
+++ b/src/jobs/CiviCRM-Drupal-Style.job
@@ -3,9 +3,9 @@ set -e
 
 ## Example usage:
 ##
-## $ env ghprbTargetBranch=master ghprbPullId=28104 run-bknix-job --mock dfl CiviCRM-Core-Style
+## $ env ghprbTargetBranch=7.x-master ghprbPullId=673 run-bknix-job --mock dfl CiviCRM-Drupal-Style
 
 #################################################
 
-CIVI_REPO=civicrm-core
+CIVI_REPO=civicrm-drupal
 run_bknix_include "$BKNIX_JOBS/Generic-Style.job"

--- a/src/jobs/CiviCRM-WordPress-Style.job
+++ b/src/jobs/CiviCRM-WordPress-Style.job
@@ -3,9 +3,9 @@ set -e
 
 ## Example usage:
 ##
-## $ env ghprbTargetBranch=master ghprbPullId=28104 run-bknix-job --mock dfl CiviCRM-Core-Style
+## $ env ghprbTargetBranch=master ghprbPullId=307 run-bknix-job --mock dfl CiviCRM-WordPress-Style
 
 #################################################
 
-CIVI_REPO=civicrm-core
+CIVI_REPO=civicrm-wordpress
 run_bknix_include "$BKNIX_JOBS/Generic-Style.job"

--- a/src/jobs/Generic-Style.job
+++ b/src/jobs/Generic-Style.job
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -e
+
+## Example usage:
+##
+## $ env CIVI_REPO=civicrm-core ghprbTargetBranch=master ghprbPullId=28104 run-bknix-job --mock dfl Generic-Style
+## $ env CIVI_REPO=civicrm-backdrop ghprbTargetBranch=1.x-master ghprbPullId=159 run-bknix-job --mock dfl Generic-Style
+## $ env CIVI_REPO=civicrm-drupal ghprbTargetBranch=7.x-master ghprbPullId=673 run-bknix-job --mock dfl Generic-Style
+
+#################################################
+## Environment variables
+
+## EXECUTOR_NUMBER: The number of this concurrent process
+## WORKSPACE: The path where Jenkins stores data for this job
+## ghprbTargetBranch: The version of CiviCRM to install, expressed as a branch or tag (e.g. `master`, `5.59`, `5.57.0`)
+## ghprbPullId: The pull request to apply
+## CIVI_REPO: The name of the github repo (`civicrm-core`, `civicrm-packages`, etc)
+assert_common EXECUTOR_NUMBER WORKSPACE ghprbPullId ghprbTargetBranch CIVI_REPO
+
+detect_civiver "$CIVI_REPO" "$ghprbTargetBranch"
+assert_testable_version "$CIVIVER"
+
+#################################################
+## Main
+
+use_bknix_tmp
+
+## Build definition
+assert_common BKITBLD EXECUTOR_NUMBER
+BLDNAME="build-$EXECUTOR_NUMBER"
+BLDDIR="$BKITBLD/$BLDNAME"
+
+## Reset (cleanup after previous tests)
+clean_legacy_workspace "$WORKSPACE/checkstyle"
+init_std_workspace
+if [ -d "$BKITBLD/$BLDNAME" ]; then
+  echo y | civibuild destroy "$BLDNAME"
+fi
+
+## Report details about the test environment
+civibuild env-info
+
+## Download dependencies, apply patches
+civibuild download "$BLDNAME" --type "empty"
+cloneCmd=$(printf 'git clone ${CACHE_DIR}/civicrm/%q.git -b %q src' "$CIVI_REPO" "$ghprbTargetBranch")
+civibuild run "$BLDNAME" --eval "$cloneCmd"
+civibuild run "$BLDNAME" --eval 'git_cache_deref_remotes "$CACHE_DIR" "$WEB_ROOT"'
+
+pushd "$BLDDIR/web/src"
+  git scan am -N "https://github.com/civicrm/$CIVI_REPO/pull/${ghprbPullId}"
+  xcivilint "origin/$ghprbTargetBranch" "$CIVI_REPO""#""${ghprbPullId}"
+popd

--- a/src/jobs/common.sh
+++ b/src/jobs/common.sh
@@ -40,6 +40,9 @@ function assert_common() {
       ghprbTargetBranch)
         assert_regex '^[0-9a-z\.-]\+$' "$ghprbTargetBranch" "ghprbTargetBranch should be a branch name."
         ;;
+      CIVI_REPO)
+        assert_regex '^civicrm-\(backdrop\|core\|drupal\|drupal-8\|packages\|wordpress\)$' "$CIVI_REPO"
+        ;;
       BKITBLD)
         if [ -z "$BKITBLD" ]; then
           fatal "Failed to find BKITBLD for $BKPROF"

--- a/src/jobs/common.sh
+++ b/src/jobs/common.sh
@@ -274,7 +274,7 @@ function assert_testable_version() {
   fi
 
   case "$version" in
-    4.6*|4.7*|5.*|master*) echo "PR test is supported for $version" ;;
+    5.*|master*)           echo "PR test is supported for $version" ;;
     *)                     fatal "PR test not supported for $version" ;;
   esac
 

--- a/src/jobs/common.sh
+++ b/src/jobs/common.sh
@@ -225,6 +225,41 @@ function xcivilint() {
   fi
 }
 
+## Given that we are testing a specific repo+branch, figure out the CIVIVER.
+##
+## usage: detect_civiver REPO BASE_BRANCH
+## example: detect_civiver civicrm-backrop 1.x-5.0
+function detect_civiver() {
+  local repo="$1"
+  local baseBranch="$2"
+  local prefix=
+
+  case "$repo" in
+    civicrm-backdrop) prefix=1.x- ; ;;
+    civicrm-drupal) prefix=7.x- ; ;;
+    civicrm-core|civicrm-drupal-8|civicrm-joomla|civicrm-packages|civicrm-wordpress) prefix= ; ;;
+    *)
+      echo >&2 "Unrecognized repo name: $repo"
+      exit 1 ## Structural error in scripts
+      ;;
+  esac
+
+  if [ -z "$prefix" ]; then
+    CIVIVER="$baseBranch"
+  else
+    case "$baseBranch" in
+      ${prefix}4.6*|${prefix}4.7*|${prefix}5*|${prefix}master*)
+        CIVIVER=$(echo "$baseBranch" | sed 's;^'"$prefix"';;')
+        ;;
+      *)
+        ## This actually true for many branches, so we exit softly...
+        echo >&2 "PR test not allowed for $baseBranch"
+        exit 0 ## Misguided request by PR-author
+        ;;
+    esac
+  fi
+}
+
 ## usage: assert_testable_version CIVIVER
 ## example: assert_testable_version master
 ## example: assert_testable_version 4.6

--- a/src/jobs/common.sh
+++ b/src/jobs/common.sh
@@ -224,3 +224,20 @@ function xcivilint() {
     exit 1
   fi
 }
+
+## usage: assert_testable_version CIVIVER
+## example: assert_testable_version master
+## example: assert_testable_version 4.6
+function assert_testable_version() {
+  local version="$1"
+
+  if [ -z "$1" ]; then
+    fatal "assert_testable_version: The version number is blank!"
+  fi
+
+  case "$version" in
+    4.6*|4.7*|5.*|master*) echo "PR test is supported for $version" ;;
+    *)                     fatal "PR test not supported for $version" ;;
+  esac
+
+}


### PR DESCRIPTION
__Background__: For `civicrm-core`, PR tests run in several parallel jobs (style job, demo-site job, test-runner job). But for other repos, they still run as one.

__Change__: This PR defines a style job for `CiviCRM-{Drupal,Backdrop,WordPress}-Style`. The implementation for all style checks is shared (`Generic-Style.job`).
