### PR TITLE
dev/core#2998 - Fix contact_id being set incorrectly for demo user

### DIFF
--- a/app/config/standalone-clean/demo-user.php
+++ b/app/config/standalone-clean/demo-user.php
@@ -28,7 +28,7 @@ CRM_Core_Transaction::create()->run(function () {
     'cms_pass' => getenv('DEMO_PASS'),
     'notify' => FALSE,
     $adminEmail => $adminEmail,
-    'contactID' => $contactID,
+    'contact_id' => $contactID,
   ];
   $userID = \CRM_Core_BAO_CMSUser::create($params, $adminEmail);
 

--- a/app/config/standalone-dev/demo-user.php
+++ b/app/config/standalone-dev/demo-user.php
@@ -28,7 +28,7 @@ CRM_Core_Transaction::create()->run(function () {
     'cms_pass' => getenv('DEMO_PASS'),
     'notify' => FALSE,
     $adminEmail => $adminEmail,
-    'contactID' => $contactID,
+    'contact_id' => $contactID,
   ];
   $userID = \CRM_Core_BAO_CMSUser::create($params, $adminEmail);
 


### PR DESCRIPTION
This fixes an issue where the demo user was missing a value for contact_id due to a array key mismatch.