### PR TITLE
Update civistrings to 2022-08-30-c035da67

### DIFF
--- a/phars.json
+++ b/phars.json
@@ -18,8 +18,8 @@
    },
 
    "civistrings":  {
-     "url": "https://download.civicrm.org/civistrings/civistrings.phar-2022-02-16-75f490ca",
-     "sha256": "e2258ff4302bb51d60cb7c094ca5401c6d36a8e8ca9a4921afc4e8e61687b90e",
+     "url": "https://download.civicrm.org/civistrings/civistrings.phar-2022-08-30-c035da67",
+     "sha256": "657068d8302cdbd60387e634a6bfc6052d3e38005f9f4ed7c064c8e7f8b9a15e",
      "buildkit-path": "bin/civistrings"
    },
 


### PR DESCRIPTION
edit: civistrings, not civix

I would like to update this to help reduce warnings on string extractions.