### PR TITLE
bknix-min - Bump php to 7.4

### DIFF
--- a/nix/profiles/min/default.nix
+++ b/nix/profiles/min/default.nix
@@ -11,7 +11,7 @@ let
 
 in (import ../base/default.nix) ++ (import ../mgmt/default.nix) ++ [
 
-    (if isAppleM1 then dists.bkit.php74 else dists.bkit.php73)
+    dists.bkit.php74
     dists.default.nodejs-14_x
     dists.default.apacheHttpd
     dists.default.mailhog

--- a/nix/profiles/old/default.nix
+++ b/nix/profiles/old/default.nix
@@ -8,7 +8,7 @@ let
 
 in (import ../base/default.nix) ++ (import ../mgmt/default.nix) ++ [
 
-    dists.bkit.php72
+    dists.bkit.php73
     dists.default.nodejs-14_x
     dists.default.apacheHttpd
     dists.default.mailhog


### PR DESCRIPTION
Issue https://lab.civicrm.org/dev/core/-/issues/4812

Per https://github.com/civicrm/civicrm-core/pull/28583 this bumps the min php version.

Question: should we re-enable timecop as well? (was disabled just because of 7.3 according to https://github.com/civicrm/civicrm-buildkit/pull/749)