### PR TITLE
standalone-dev - enable debug & set env to Development

### DIFF
--- a/app/config/standalone-dev/install.sh
+++ b/app/config/standalone-dev/install.sh
@@ -30,6 +30,10 @@ civicrm_install_cv
 ###############################################################################
 ## Extra configuration
 
+# Settings appropriate to a dev environment
+cv setting:set environment=Development
+cv setting:set debug_enabled=1
+
 env DEMO_USER="$DEMO_USER" DEMO_PASS="$DEMO_PASS" DEMO_EMAIL="$DEMO_EMAIL" \
   cv scr "$SITE_CONFIG_DIR/demo-user.php"
   ## Might be nice as a dedicated command...


### PR DESCRIPTION
Since the build literally has `-dev` in the name, this seemed appropriate.