### PR TITLE
community-messages - Update git url

### DIFF
--- a/app/config/messages/download.sh
+++ b/app/config/messages/download.sh
@@ -6,7 +6,7 @@
 
 echo "[[Download civicrm-community-messages]]"
 
-git_cache_setup "https://github.com/civicrm/civicrm-community-messages.git"              "$CACHE_DIR/civicrm/civicrm-community-messages.git"
+git_cache_setup "https://lab.civicrm.org/infra/community-messages.git"  "$CACHE_DIR/civicrm/civicrm-community-messages.git"
 
 mkdir "$WEB_ROOT"
 pushd "$WEB_ROOT" >> /dev/null


### PR DESCRIPTION
This project moved from GitHub to GitLab.

But I'm unclear which branch is the correct one. Should it checkout `master` or [`symfony5`](https://lab.civicrm.org/infra/community-messages/-/tree/symfony5?ref_type=heads)?