### PR TITLE
standalone-dev build: Correct upload path (upload not uploads)

### DIFF
--- a/app/config/standalone-dev/download.sh
+++ b/app/config/standalone-dev/download.sh
@@ -7,10 +7,10 @@
 [ -z "$CMS_VERSION" ] && CMS_VERSION=master
 ## Hmm, not really used...
 
-mkdir -p "$WEB_ROOT" "$WEB_ROOT/web" "$WEB_ROOT/web/uploads" "$WEB_ROOT/data"
+mkdir -p "$WEB_ROOT" "$WEB_ROOT/web" "$WEB_ROOT/web/upload" "$WEB_ROOT/data"
 
 pushd "$WEB_ROOT"
-  amp datadir "./data" "./web/uploads"
+  amp datadir "./data" "./web/upload"
 
   git clone ${CACHE_DIR}/civicrm/civicrm-core.git                     -b "$CIVI_VERSION" web/core
   git clone ${CACHE_DIR}/civicrm/civicrm-packages.git                 -b "$CIVI_VERSION" web/core/packages


### PR DESCRIPTION
This has been bugging me for ages!

Install script created web/uploads instead of web/upload (resulting in an uploads/ dir *and* an upload/ dir)