### PR TITLE
 civibuild - Reduce default verbosity. Respect the -v (verbose) flag.

### DIFF
--- a/app/civibuild.conf.tmpl
+++ b/app/civibuild.conf.tmpl
@@ -52,6 +52,11 @@
 ## several places.
 
 #############################################################################
+## Example: Enable verbose flag for all builds
+
+# VERBOSE=1
+
+#############################################################################
 ## Example: Update civibuild's $PATH
 
 # PATH="$HOME/src/amp/bin:$PATH"

--- a/src/civibuild.app.sh
+++ b/src/civibuild.app.sh
@@ -16,13 +16,21 @@ function civibuild_app_usage() {
 ## Run an external script (based on the site-type)
 ## usage: civibuild_app_run <script-name>
 function civibuild_app_run() {
+  local _shellopt="$-"
+
   MAIN_SCRIPT="${SITE_CONFIG_DIR}/$1.sh"
   [ ! -f "$MAIN_SCRIPT" ] && echo "ERROR: Missing main script ($MAIN_SCRIPT)" && exit 98
 
   echo "[[Execute $MAIN_SCRIPT]]"
-  set -ex
+
+  set -e
+  if [[ -n "$VERBOSE" ]]; then
+    set -x
+  fi
+
   source "$MAIN_SCRIPT"
-  set +ex
+
+  set -${_shellopt}
 }
 
 ###############################################################################

--- a/src/civibuild.defaults.sh
+++ b/src/civibuild.defaults.sh
@@ -34,6 +34,9 @@
 ###############################################################################
 ## Common variables
 
+## Should we print lots of debug info?
+VERBOSE=
+
 ## The name of on-going action (eg "create" or "reset")
 ACTION=
 

--- a/src/civibuild.lib.sh
+++ b/src/civibuild.lib.sh
@@ -1607,7 +1607,6 @@ function git_cache_setup() {
 ## example: git_cache_setup_id civicrm/civicrm-core
 ## post-condition: $CACHE_DIR/$cache_id.git is a recently-updated clone
 function git_cache_setup_id() {
-  set +x
   cvutil_assertvars git_cache_setup_id CACHE_DIR
   for cache_id in "$@" ; do
     local path="$CACHE_DIR/${cache_id}.git"
@@ -1617,7 +1616,6 @@ function git_cache_setup_id() {
     fi
     git_cache_setup "$url" "$path"
   done
-  set -x
 }
 
 ###############################################################################

--- a/src/civibuild.parse.sh
+++ b/src/civibuild.parse.sh
@@ -126,8 +126,12 @@ function civibuild_parse() {
     shift
 
     case "$OPTION" in
-      -h|--help|-?)
+      -h|--help|-\?)
         civibuild_app_usage
+        ;;
+
+      -v)
+        VERBOSE=1
         ;;
 
       --admin-email)

--- a/src/help/clone-create.hlp
+++ b/src/help/clone-create.hlp
@@ -7,6 +7,7 @@
 
 [33mOptions:[0m
 [32m  -h, --help[0m           Displays help for a command
+[32m  -v[0m                   Verbose output
 [32m  --clone-id <name>[0m    The name of the specific clone. [Required]
 [32m  --force[0m              If necessary, destroy pre-existing files/directories/DBs
 

--- a/src/help/clone-destroy.hlp
+++ b/src/help/clone-destroy.hlp
@@ -7,6 +7,7 @@
 
 [33mOptions:[0m
 [32m  -h, --help[0m           Displays help for a command
+[32m  -v[0m                   Verbose output
 [32m  --clone-id <name>[0m    The name of the specific clone. [Optional]
 [32m  --force[0m              If necessary, destroy pre-existing files/directories/DBs
 

--- a/src/help/clone-show.hlp
+++ b/src/help/clone-show.hlp
@@ -7,6 +7,7 @@
 
 [33mOptions:[0m
 [32m  -h, --help[0m           Displays help for a command
+[32m  -v[0m                   Verbose output
 [32m  --clone-id <name>[0m    The name of the specific clone. [Required]
 [32m  --force[0m              If necessary, destroy pre-existing files/directories/DBs
 

--- a/src/help/create.hlp
+++ b/src/help/create.hlp
@@ -7,6 +7,7 @@
 
 [33mOptions:[0m
 [32m  -h, --help[0m           Displays help for a command
+[32m  -v[0m                   Verbose output
 [32m  --type <type>[0m        The type of system to install (ex: drupal-demo). Must be one of the available types - see https://docs.civicrm.org/dev/en/latest/tools/civibuild/#build-types (If omitted, assume <build-name>) [Optional]
 [32m  --web-root <path>[0m    The full path to the website root. [Default: ${BLDDIR}/<build-name>]
 [32m  --civi-ver <ver>[0m     The branch or tag of CiviCRM desired (master, 4.7, 4.6, 4.6.0, etc) [Optional]

--- a/src/help/default.hlp
+++ b/src/help/default.hlp
@@ -3,6 +3,7 @@ civibuild [options] command
 
 [33mOptions:[0m
 [32m  -h, --help <command>[0m Displays help for a command
+[32m  -v[0m                   Verbose output
 
 [33mCommands:[0m
  [33mBuild Management[0m

--- a/src/help/download.hlp
+++ b/src/help/download.hlp
@@ -6,6 +6,7 @@
 
 [33mOptions:[0m
 [32m  -h, --help[0m           Displays help for a command
+[32m  -v[0m                   Verbose output
 [32m  --type <type>[0m        The type of system to install (ex: drupal-demo). Must be one of the available types - see https://docs.civicrm.org/dev/en/latest/tools/civibuild/#build-types (If omitted, assume <build-name>) [Optional] 
 [32m  --web-root <path>[0m    The full path to the website root. [Default: ${BLDDIR}/<build-name>]
 [32m  --civi-ver <ver>[0m     The branch or tag of CiviCRM desired (master, 4.7, 4.6, 4.6.0, etc) [Optional]

--- a/src/help/edit.hlp
+++ b/src/help/edit.hlp
@@ -7,6 +7,7 @@
 
 [33mOptions:[0m
 [32m  -h, --help[0m           Displays help for a command
+[32m  -v[0m                   Verbose output
 
 [33mNB:[0m For more civibuild documentation see https://docs.civicrm.org/dev/en/latest/tools/civibuild/
 

--- a/src/help/install.hlp
+++ b/src/help/install.hlp
@@ -7,6 +7,7 @@
 
 [33mOptions:[0m
 [32m  -h, --help[0m           Displays help for a command
+[32m  -v[0m                   Verbose output
 [32m  --type <type>[0m        The type of system to install (ex: drupal-demo). Must be one of the available types - see https://docs.civicrm.org/dev/en/latest/tools/civibuild/#build-types (If omitted, assume <build-name>) [Optional] 
 [32m  --web-root <path>[0m    The full path to the website root. [Default: ${BLDDIR}/<build-name>]
 [32m  --civi-ver <ver>[0m     The branch or tag of CiviCRM desired (master, 4.7, 4.6, 4.6.0, etc) [Optional]

--- a/src/help/reinstall.hlp
+++ b/src/help/reinstall.hlp
@@ -8,6 +8,7 @@
 
 [33mOptions:[0m
 [32m  -h, --help[0m           Displays help for a command
+[32m  -v[0m                   Verbose output
 [32m  --type <type>[0m        The type of system to install (ex: drupal-demo). Must be one of the available types - see https://docs.civicrm.org/dev/en/latest/tools/civibuild/#build-types (If omitted, assume <build-name>) [Optional] 
 [32m  --web-root <path>[0m    The full path to the website root. [Default: ${BLDDIR}/<build-name>]
 [32m  --civi-ver <ver>[0m     The branch or tag of CiviCRM desired (master, 4.7, 4.6, 4.6.0, etc) [Optional]

--- a/src/help/run.hlp
+++ b/src/help/run.hlp
@@ -7,6 +7,7 @@
 
 [33mOptions:[0m
 [32m  -h, --help[0m           Displays help for a command
+[32m  -v[0m                   Verbose output
 [32m  --eval <code>[0m        Run an impromptu fragment of shell code (with the civibuild environment/functions)
 [32m  --script <file>[0m      Run a script fragment of shell code (in the civibuild environment/functions)
 

--- a/src/help/show.hlp
+++ b/src/help/show.hlp
@@ -7,6 +7,7 @@
 
 [33mOptions:[0m
 [32m  -h, --help[0m           Displays help for a command
+[32m  -v[0m                   Verbose output
 [32m  --html <dir>[0m         A new HTML dir which will report build status in detail
 [32m  --new-scan <file>[0m    A new JSON file which summarizes the git structure
 [32m  --last-scan <file>[0m   An existing JSON file which summarizes the old git structure


### PR DESCRIPTION
Before:

* By default, `civibuild` is very verbose.
* There are no option to change this.

After:

* By default `civibuild` is not so verbose.
* You may pass `-v` to make it verbose.
* You may set `VERBOSE=1` (in `civibuild.conf`) to make it persistently verbose