### PR TITLE
nix - Restore support for updating old-style CI profiles

### DIFF
--- a/nix/lib/common.sh
+++ b/nix/lib/common.sh
@@ -608,7 +608,9 @@ function install_xfce4_launchers() {
 ## Determine the location of the profile dir
 ## Ex: "get_nix_profile_path bknix-dfl" ==> "/nix/var/nix/profiles/per-user/myuser/bknix-dfl"
 function get_nix_profile_path() {
-  if [ -e "$HOME/.local/state/nix/profiles" ]; then
+  if [ "$USER" == "root" ]; then
+    echo "/nix/var/nix/profiles/$1"
+  elif [ -e "$HOME/.local/state/nix/profiles" ]; then
     echo "$HOME/.local/state/nix/profiles/$1"
   elif [ -e "/nix/var/nix/profiles/per-user/$USER" ]; then
     echo "/nix/var/nix/profiles/per-user/$USER/$1"


### PR DESCRIPTION
* The `install-ci.sh` installer (`test-1`, `test-2`) traditionally relied on creating a system-wide profile (e.g. `/nix/var/nix/profiles/bknix-min`). Other installers (like `install-developer.sh`) rely on per-user profiles. 
* In the past year or so, nix made some changes in how per-user profiles. A buildkit revision (71d7c69aa23400160b4adb89023e9da2b88d82dc) aimed to fix compatibility with the older+newer layouts. 
* However, that fix broke compatibility with `install-ci.sh` installer. `install-ci.sh`is deprecated but still used by a few hosts.
* In light testing on `test-2` (`install-ci.sh`) and my Macbook (`install-developer.sh`), this patch seems to work with both.