### PR TITLE
bknix - Switch default storage policy to regular disk (not ramdisk) 

### DIFF
--- a/.loco/loco.yml
+++ b/.loco/loco.yml
@@ -1,6 +1,12 @@
 format: 'loco-0.1'
 
 ## This is the default configuration used for local development environments.
+##
+## You can modify the configuration with any of these techniques:
+##  - Edit this file
+##  - Add an adjacent file (`loco.overrides.yml`) or global file (`/etc/bknix-ci/loco.overrides.yml`)
+##  - Add environment-variables to your shell configuration file (eg `~/.profile` or `~/.bashrc`)
+##  - Manually set environment-variables when you open your shell (*before calling loco*)
 
 #### General configuration
 default_environment:
@@ -32,6 +38,7 @@ default_environment:
  ## RAMDISK_SIZE: Optionally store all runtime data (incl MySQL) in a ramdisk.
  - RAMDISK_SIZE=off
  # - RAMDISK_SIZE=600
+ # 600mb is usually enough for 2-3 full dev environments, depending on CMS
 
  ## CIVICRM_LOCALES: When pre-generating CiviCRM datasets, limit the number of locales.
  - CIVICRM_LOCALES=en_US,fr_FR,de_DE

--- a/.loco/loco.yml
+++ b/.loco/loco.yml
@@ -29,8 +29,9 @@ default_environment:
  - XDEBUG_PORT=9003
  #- XDEBUG_CONFIG=...
 
- ## RAMDISK_SIZE: Most daemons (including MySQL) store runtime data in a ramdisk.
- - RAMDISK_SIZE=600
+ ## RAMDISK_SIZE: Optionally store all runtime data (incl MySQL) in a ramdisk.
+ - RAMDISK_SIZE=off
+ # - RAMDISK_SIZE=600
 
  ## CIVICRM_LOCALES: When pre-generating CiviCRM datasets, limit the number of locales.
  - CIVICRM_LOCALES=en_US,fr_FR,de_DE

--- a/.loco/plugin/bknix-overrides.php
+++ b/.loco/plugin/bknix-overrides.php
@@ -61,7 +61,8 @@ function applyOverrides(&$config, &$override) {
 Loco::dispatcher()->addListener('loco.config.filter', function($e) {
   $files = [
     preg_replace(';\.ya?ml$;', '.overrides.yml', $e['file']),
-    '/etc/bknix-ci/loco-overrides.yaml',
+    '/etc/bknix-ci/loco.overrides.yml', // Matches ^^^ better
+    '/etc/bknix-ci/loco-overrides.yaml', // Deprecated
   ];
   foreach ($files as $f) {
     if (file_exists($f)) {

--- a/phars.json
+++ b/phars.json
@@ -59,8 +59,8 @@
    },
 
    "loco":  {
-     "url": "https://github.com/totten/loco/releases/download/v0.7.1/loco-0.7.1.phar",
-     "sha256": "d97a3013cef9376850c33dd73535b574552e4f2e9ea4418f0507f776868ec039"
+     "url": "https://github.com/totten/loco/releases/download/v0.7.2/loco-0.7.2.phar",
+     "sha256": "aa433d1a81baf2eed32b11737df3f80d8bac1fdf13169fe8ad830fb3c5fc5473"
    },
 
    "phive":  {


### PR DESCRIPTION
When using buildkit's nix configuration to run PHP/MySQL, it generates runtime data (such as MySQL databases, esp `ibdata`). This changes the policy.

* Before
    * __Default__: Store data on ramdisk
    * __Opt-in__: You can edit `loco.yml` to disable the ramdisk. (To enable regular disk.)
* After
    * __Default__: Store data on regular disk
    * __Opt-in__: You can set an env-var (`RAMDISK_SIZE`) to enable ramdisk. (*You can do this by editing `loco.yml`... or calling `export`... or editing `.profile`... ad nauseum.*)
