### PR TITLE
composer.json - Update civicrm/coder for php82

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "php": ">=7.2",
     "totten/php-symbol-diff": "dev-master#54f869ca68a3cd75f3386f8490870369733d2c23",
     "civicrm/upgrade-test": "0.5",
-    "drupal/coder": "dev-8.x-2.x-civi#5fa299b7790535b9f5098417f848a173cb6ce4d4",
+    "drupal/coder": "dev-8.x-2.x-civi#e383f073ff163eb40496ff4092fa666bd66c2c14",
     "civicrm/composer-downloads-plugin": "^3.0",
     "civicrm/composer-compile-plugin": "~0.20",
     "squizlabs/php_codesniffer": ">=2.7 <4.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "91eaf046e04556a65484ac13fc7aa619",
+    "content-hash": "6291c696d571cfeb741408556aa52f3a",
     "packages": [
         {
             "name": "civicrm/composer-compile-plugin",
@@ -156,7 +156,7 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/civicrm/coder.git",
-                "reference": "5fa299b7790535b9f5098417f848a173cb6ce4d4"
+                "reference": "e383f073ff163eb40496ff4092fa666bd66c2c14"
             },
             "require": {
                 "ext-mbstring": "*",
@@ -189,7 +189,7 @@
                 "issues": "https://www.drupal.org/project/issues/coder",
                 "source": "https://www.drupal.org/project/coder"
             },
-            "time": "2021-09-30T18:55:03+00:00"
+            "time": "2024-03-12T23:22:51+00:00"
         },
         {
             "name": "nikic/php-parser",


### PR DESCRIPTION
Includes https://github.com/civicrm/coder/pull/19 to address a false-negative when running `civilint` on PHP 8.2