### PR TITLE
Update phars.json for wp-cli 2.10

### DIFF
--- a/phars.json
+++ b/phars.json
@@ -105,8 +105,8 @@
    },
 
    "wp":  {
-     "url": "https://github.com/wp-cli/wp-cli/releases/download/v2.9.0/wp-cli-2.9.0.phar",
-     "sha256": "af6b7ccc21ed0907cb504db5a059f0e120117905a6017bfdd4375cee3c93d864",
+     "url": "https://github.com/wp-cli/wp-cli/releases/download/v2.10.0/wp-cli-2.10.0.phar",
+     "sha256": "4c6a93cecae7f499ca481fa7a6d6d4299c8b93214e5e5308e26770dbfd3631df",
      "buildkit-path": "bin/wp"
    }
 }


### PR DESCRIPTION
Update wp-cli to version 2.10.0

- Been running in production since it's release Feb-2024
- tested locally updating