### PR TITLE
run-bknix-job: Work better in a world of many PHP/MySQL permutations

### DIFF
--- a/bin/run-job
+++ b/bin/run-job
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+{ # start: run-job
+
+RUN_BKNIX_CLEANUP_FILES=()
+RUN_BKNIX_CLEANUP_FUNCS=()
+trap run_job_cleanup EXIT
+
+function run_job_help() {
+  echo "usage: run-job [--mock] [JOB_NAME]"
+  echo
+  echo "example: run-job --mock CiviRM-Core-Matrix"
+  echo
+  echo "tip: If <JOB_NAME> is omitted, and if you execute within a real Jenkins"
+  echo "environment, then it will use the active \$JOB_NAME."
+  echo ""
+  echo "tip: If <JOB_NAME> is an HTTPS URL, then it will fetch and run the"
+  echo "script. This is useful if you want to configure Jenkins to temporarily"
+  echo "use a WIP script."
+  echo
+  echo "tip: To spin-up/spin-down a test environment, use run-bknix-job."
+}
+
+function run_job_fatal() {
+  echo "$@" 1>&2
+  echo 1>&2
+  run_job_help 1>&2
+  exit 1
+}
+
+function run_job_mktemp() {
+  local tmpfile="/tmp/run-bknix-$USER-"$(date '+%Y-%m-%d-%H-%M'-$RANDOM$RANDOM)
+  touch "$tmpfile"
+  chmod 600 "$tmpfile"
+  echo "$tmpfile"
+}
+
+function run_job_cleanup() {
+  for func in "${RUN_BKNIX_CLEANUP_FUNCS[@]}" ; do
+    #echo >&2 "[run-job: cleanup] $func"
+    $func
+  done
+  for file in "${RUN_BKNIX_CLEANUP_FILES[@]}" ; do
+    #echo >&2 "[run-job: cleanup] $file"
+    if [ -e "$file" ]; then
+      rm -f "$file"
+    fi
+  done
+}
+
+## If there's a redeploy while bash is running, then bash gets stupid.
+## Instead of loading bash scripts directly, we load through a temp file.
+## run_job_include <SCRIPT_1> <SCRIPT_2> ...
+function run_job_include() {
+  local tmpfile=$(run_job_mktemp)
+  touch "$tmpfile"
+  RUN_BKNIX_CLEANUP_FILES+=("$tmpfile")
+
+  for file in "$@" ; do
+    cat "$file" >> "$tmpfile"
+    echo >> "$tmpfile"
+  done
+
+  source "$tmpfile"
+}
+
+function run_job_main() {
+  if [ -z "$BKNIX_JOBS" ]; then
+    BKNIX_JOBS="/opt/buildkit/src/jobs"
+  fi
+  if [ ! -r "$BKNIX_JOBS/common.sh" ]; then
+    run_job_fatal "File $BKNIX_JOBS/common.sh is not readable."
+  fi
+  export BKNIX_JOBS
+
+  IS_MOCK_JENKINS=
+  while [[ $# -gt 0 ]]; do
+    key="$1"
+
+    case $key in
+      --help|-h) run_job_help ; exit 0 ; ;;
+      --mock) IS_MOCK_JENKINS=1 ; shift ; ;;
+      *)
+        break
+        ;;
+    esac
+  done
+
+  if [ -n "$1" ]; then
+    JOB_NAME="$1"
+    shift
+  fi
+
+  if [ $# -gt 0 ]; then
+    run_job_help
+    exit 1
+  fi
+
+  source "$BKNIX_JOBS/common.sh"
+  assert_common JOB_NAME
+
+  if [ -n "$IS_MOCK_JENKINS" ]; then
+    init_jenkins_mock
+  fi
+
+  if [ -d "$WORKSPACE/build" ]; then
+    rm -rf "$WORKSPACE/build"
+  fi
+
+  run_job_exec
+}
+
+## Execute the main job script
+function run_job_exec() {
+  ## JOB_NAME can be complicated (when using matrix jobs). We want a trimmed-down name.
+  BKNIX_JOB_NAME="$JOB_NAME"
+  case "$BKNIX_JOB_NAME" in
+    https:*)
+      BKNIX_JOB_URL="$BKNIX_JOB_NAME"
+      BKNIX_JOB_NAME=$(basename "$BKNIX_JOB_URL")
+      BKNIX_JOB_SCRIPT=$(run_job_mktemp)
+      RUN_BKNIX_CLEANUP_FILES+=("$BKNIX_JOB_SCRIPT")
+      run_job_download "$BKNIX_JOB_URL" "$BKNIX_JOB_SCRIPT"
+      ;;
+    *)
+      BKNIX_JOB_NAME=$(echo "$BKNIX_JOB_NAME" | cut -d '/' -f 1)
+      BKNIX_JOB_SCRIPT="$BKNIX_JOBS/$BKNIX_JOB_NAME.job"
+      ;;
+  esac
+  export BKNIX_JOB_SCRIPT BKNIX_JOB_NAME
+
+  if [ ! -e "$BKNIX_JOB_SCRIPT" ]; then
+    run_job_fatal "Missing or invalid JOB_NAME. No such file \"$BKNIX_JOB_SCRIPT\"."
+  fi
+
+  run_job_include "$BKNIX_JOB_SCRIPT"
+}
+
+## usage: run_job_download <url> <out-file>
+function run_job_download() {
+  if which wget >> /dev/null ; then
+    wget -O "$2" "$1"
+  elif which curl >> /dev/null ; then
+    curl -L -o "$2" "$1"
+  else
+    echo "error: failed to locate curl or wget"
+  fi
+}
+
+run_job_main "$@"
+
+} # end: run-job

--- a/nix/bin/run-bknix-job
+++ b/nix/bin/run-bknix-job
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+{ ## start: run-bknix-job
 
 RUN_BKNIX_HOMER_IMAGES="$HOME/images"
 RUN_BKNIX_CLEANUP_FILES=()
@@ -6,11 +7,17 @@ RUN_BKNIX_CLEANUP_FUNCS=()
 trap run_bknix_cleanup EXIT
 
 function run_bknix_help() {
-  echo "usage: run-bknix-job [--mock] [--loaded] <PROFILE> [<JOB_NAME>]"
+  echo "usage: run-bknix-job [--mock] [<RUN_MODE>] [<PROFILE> [<JOB_NAME>]]"
   echo
-  echo "example: run-bknix-job min CiviRM-Core-Matrix"
-  echo "example: run-bknix-job --mock min CiviRM-Core-Matrix"
-  echo "example: run-bknix-job min"
+  echo "example: run-bknix-job --isolate"
+  echo "example: run-bknix-job --active min shell"
+  echo "example: run-bknix-job --autostart php74m80 CiviRM-Core-Matrix"
+  echo
+  echo "The <RUN_MODE> determines how to access PHP/MySQL/etc. It is one of:"
+  echo "  --active: Use an active, pre-installed copy of the nix profile"
+  echo "  --isolate: Create an isolated container (homerdo; Linux-only)"
+  echo "  --autostart: Start everything (nix-shell, PHP, MySQL) as current user"
+  echo "  --autostart-services: As above, but only start PHP/MySQL"
   echo
   echo "tip: If <JOB_NAME> is omitted, and if you execute within a real Jenkins"
   echo "environment, then it will use the active \$JOB_NAME."
@@ -18,9 +25,6 @@ function run_bknix_help() {
   echo "tip: If <JOB_NAME> is an HTTPS URL, then it will fetch and run the"
   echo "script. This is useful if you want to configure Jenkins to temporarily"
   echo "use a WIP script."
-  echo
-  echo "tip: If you have already loaded the required bknix profile, then pass"
-  echo "option --loaded to prevent double-loading."
 }
 
 function run_bknix_fatal() {
@@ -50,33 +54,6 @@ function run_bknix_cleanup() {
   done
 }
 
-function run_bknix_mock() {
-  echo "Using mock Jenkins environment"
-  export EXECUTOR_NUMBER=0
-  export BUILD_NUMBER=123
-  export WORKSPACE="$HOME/tmp/mock-workspace"
-  if [ ! -d "$WORKSPACE" ]; then
-    mkdir -p "$WORKSPACE"
-  fi
-  cd "$WORKSPACE"
-}
-
-## If there's a redeploy while bash is running, then bash gets stupid.
-## Instead of loading bash scripts directly, we load through a temp file.
-## run_bknix_include <SCRIPT_1> <SCRIPT_2> ...
-function run_bknix_include() {
-  local tmpfile=$(run_bknix_mktemp)
-  touch "$tmpfile"
-  RUN_BKNIX_CLEANUP_FILES+=("$tmpfile")
-
-  for file in "$@" ; do
-    cat "$file" >> "$tmpfile"
-    echo >> "$tmpfile"
-  done
-
-  source "$tmpfile"
-}
-
 function run_bknix_main() {
   if [ -z "$BKNIX_JOBS" ]; then
     BKNIX_JOBS="/opt/buildkit/src/jobs"
@@ -86,97 +63,100 @@ function run_bknix_main() {
   fi
   export BKNIX_JOBS
 
+  if [ -z "$BKIT" ]; then
+    BKIT=$(cd "$BKNIX_JOBS/../.." && pwd)
+  fi
+
   IS_MOCK_JENKINS=
-  LOADED_BKPROF=
+  RUN_MODE=
   while [[ $# -gt 0 ]]; do
     key="$1"
 
     case $key in
-      --mock)
-        IS_MOCK_JENKINS=1
-        shift
-        ;;
-      --loaded)
-        LOADED_BKPROF=1
-        shift
-        ;;
+      --help|-h) run_bknix_help ; exit 0 ; ;;
+      --mock) IS_MOCK_JENKINS=1 ; shift ; ;;
+      --isolate) RUN_MODE=isolate ; shift ; ;;
+      --autostart) RUN_MODE=autostart ; shift ; ;;
+      --autostart-services) RUN_MODE=autostart-services ; shift ; ;;
+      --active) RUN_MODE=active ; shift ; ;;
       *)
         break
         ;;
     esac
   done
 
-  if [ $# -lt 1 ]; then
+  if [ -n "$1" -a "${1:0:1}" != "-" ]; then
+    export BKPROF="$1"
+    shift
+  fi
+  if [ -n "$1" -a "${1:0:1}" != "-" ]; then
+    export JOB_NAME="$1"
+    shift
+  fi
+  if [ $# -gt 1 -o -z "$BKPROF" -o -z "$JOB_NAME" ]; then
     run_bknix_help
     exit 1
   fi
-
-  if [[ $1 =~ ^php[0-9]{2}[mr][0-9]+$ ]]; then
-    BKPROF="$1"
-  else
-    case "$1" in
-      old|min|dfl|max|alt|edge) BKPROF="$1" ; ;;
-      *) run_bknix_fatal "Missing or invalid PROFILE" ; ;;
-    esac
+  if [ -z "$RUN_MODE" ]; then
+    ## Fallback to old behavior
+    if [ -e /etc/bknix-ci/is-runner -a "$USER" != "homer" ]; then
+      RUN_MODE=isolate
+    else
+      RUN_MODE=active
+    fi
   fi
-  export BKPROF
 
-  if [ -n "$LOADED_BKPROF" ]; then
-    LOADED_BKPROF="$BKPROF"
-  fi
+  source "$BKNIX_JOBS/common.sh"
+  assert_common BKPROF JOB_NAME
 
   if [ -n "$IS_MOCK_JENKINS" ]; then
-    run_bknix_mock
+    init_jenkins_mock
   fi
 
   if [ -d "$WORKSPACE/build" ]; then
     rm -rf "$WORKSPACE/build"
   fi
 
-  if [ -e /etc/bknix-ci/is-runner -a "$USER" != "homer" ]; then
-    if [ -z "$JOB_NAME" ]; then
-      export JOB_NAME="$2"
-    fi
-    "$BKNIX_JOBS/homerdo-task.sh" all
-    return
-  fi
+  case "$RUN_MODE" in
+    isolate)
+      ## Create a container in image $RUN_BKNIX_HOMER_IMAGES/bknix-$BKPROF-$N.img
+      assert_common BKPROF
+      "$BKNIX_JOBS/homerdo-runjob.sh" all
+      return
+      ;;
+    autostart)
+      ## Start a nix-shell to get PHP+MySQL binaries. Then start the services.
+      assert_common BKPROF
+      ( cd "$BKIT" && nix-shell -A "$BKPROF" --run 'cd "$WORKSPACE" && run-bknix-job --autostart-services' )
+      return
+      ;;
+    autostart-services)
+      ## Use current PHP+MySQL binaries. Start the services.
+      assert_common BKPROF BKITBLD LOCO_PRJ BKIT
+      LOADED_BKPROF="$BKPROF"
+      (cd "$LOCO_PRJ" && loco clean)
+      (cd "$LOCO_PRJ" && loco start)
+      RUN_BKNIX_CLEANUP_FUNCS+=('run_bknix_stop_loco')
 
-  ## JOB_NAME can be complicated (when using matrix jobs). We want a trimmed-down name.
-  BKNIX_JOB_NAME="$2"
-  if [ -z "$BKNIX_JOB_NAME" ]; then
-    BKNIX_JOB_NAME="$JOB_NAME"
-  fi
-  case "$BKNIX_JOB_NAME" in
-    https:*)
-      BKNIX_JOB_URL="$BKNIX_JOB_NAME"
-      BKNIX_JOB_NAME=$(basename "$BKNIX_JOB_URL")
-      BKNIX_JOB_SCRIPT=$(run_bknix_mktemp)
-      RUN_BKNIX_CLEANUP_FILES+=("$BKNIX_JOB_SCRIPT")
-      run_bknix_download "$BKNIX_JOB_URL" "$BKNIX_JOB_SCRIPT"
+      ## Pin the version of run-job to match the version of run-bknix-job.
+      ## This resolves edge-case where we're writing/evaluating changes to {run-job,run-bknix-job}.
+      ## The local copy will take precedence over the (non-existent/older) copy on Github.
+      "$BKNIX_JOBS/../../bin/run-job"
+      ;;
+    active)
+      ## Use the pre-installed nix profile.
+      use-bknix "$BKPROF" -cr bash -c 'cd "$WORKSPACE" && run-job'
       ;;
     *)
-      BKNIX_JOB_NAME=$(echo "$BKNIX_JOB_NAME" | cut -d '/' -f 1)
-      BKNIX_JOB_SCRIPT="$BKNIX_JOBS/$BKNIX_JOB_NAME.job"
+      run_bknix_fatal "Unrecognized run mode ($RUN_MODE). Please specify one of: --isolate | --autostart | --autostart-services | --active"
       ;;
   esac
-  export BKNIX_JOB_SCRIPT BKNIX_JOB_NAME
-
-  if [ ! -e "$BKNIX_JOB_SCRIPT" ]; then
-    run_bknix_fatal "Missing or invalid JOB_NAME. No such file \"$BKNIX_JOB_SCRIPT\"."
-  fi
-
-  run_bknix_include "$BKNIX_JOBS/common.sh" "$BKNIX_JOB_SCRIPT"
 }
 
-## usage: run_bknix_download <url> <out-file>
-function run_bknix_download() {
-  if which wget >> /dev/null ; then
-    wget -O "$2" "$1"
-  elif which curl >> /dev/null ; then
-    curl -L -o "$2" "$1"
-  else
-    echo "error: failed to locate curl or wget"
-  fi
+function run_bknix_stop_loco() {
+  (cd "$LOCO_PRJ" && loco stop)
 }
 
 run_bknix_main "$@"
+
+} ## end: run-bknix-job

--- a/src/jobs/CiviCRM-Backdrop-Demo.job
+++ b/src/jobs/CiviCRM-Backdrop-Demo.job
@@ -15,4 +15,4 @@ CIVI_REPO="civicrm-backdrop"
 BLDTYPE="backdrop-clean"
 BLDNAME="bd-$ghprbPullId-$(php -r 'echo base_convert(time()%(180*24*60*60), 10, 36);')"
 
-run_bknix_include "$BKNIX_JOBS/Generic-Demo.job"
+run_job_include "$BKNIX_JOBS/Generic-Demo.job"

--- a/src/jobs/CiviCRM-Backdrop-PR.job
+++ b/src/jobs/CiviCRM-Backdrop-PR.job
@@ -26,7 +26,7 @@ assert_testable_version "$CIVIVER"
 #################################################
 ## Main
 
-use_bknix
+assert_bknix_durable
 
 BLDNAME="bd-$ghprbPullId-$(php -r 'echo base_convert(time()%(180*24*60*60), 10, 36);')"
 BLDDIR="$BKITBLD/$BLDNAME"

--- a/src/jobs/CiviCRM-Backdrop-Style.job
+++ b/src/jobs/CiviCRM-Backdrop-Style.job
@@ -8,4 +8,4 @@ set -e
 #################################################
 
 CIVI_REPO=civicrm-backdrop
-run_bknix_include "$BKNIX_JOBS/Generic-Style.job"
+run_job_include "$BKNIX_JOBS/Generic-Style.job"

--- a/src/jobs/CiviCRM-Backdrop-Test.job
+++ b/src/jobs/CiviCRM-Backdrop-Test.job
@@ -13,4 +13,4 @@ SUITES='upgrade phpunit-e2e phpunit-backdrop'
 #SUITES='upgrade karma phpunit-e2e phpunit-backdrop'
 #SUITES='phpunit-backdrop'
 
-run_bknix_include "$BKNIX_JOBS/Generic-Test.job"
+run_job_include "$BKNIX_JOBS/Generic-Test.job"

--- a/src/jobs/CiviCRM-Civix-Matrix.job
+++ b/src/jobs/CiviCRM-Civix-Matrix.job
@@ -17,7 +17,7 @@ assert_common EXECUTOR_NUMBER WORKSPACE BLDTYPE CIVIVER
 #################################################
 ## Main
 
-# use_bknix_tmp
+assert_bknix_temporary
 
 ################################################
 ## Setup environment

--- a/src/jobs/CiviCRM-Civix-Matrix.job
+++ b/src/jobs/CiviCRM-Civix-Matrix.job
@@ -17,7 +17,7 @@ assert_common EXECUTOR_NUMBER WORKSPACE BLDTYPE CIVIVER
 #################################################
 ## Main
 
-use_bknix_tmp
+# use_bknix_tmp
 
 ################################################
 ## Setup environment

--- a/src/jobs/CiviCRM-Civix-PR.job
+++ b/src/jobs/CiviCRM-Civix-PR.job
@@ -20,7 +20,7 @@ assert_regex "^\(run-tests\|make-snapshots\)$" "$SUITE"
 #################################################
 ## Main
 
-# use_bknix_tmp
+assert_bknix_temporary
 
 ################################################
 ## Setup environment

--- a/src/jobs/CiviCRM-Civix-PR.job
+++ b/src/jobs/CiviCRM-Civix-PR.job
@@ -20,7 +20,7 @@ assert_regex "^\(run-tests\|make-snapshots\)$" "$SUITE"
 #################################################
 ## Main
 
-use_bknix_tmp
+# use_bknix_tmp
 
 ################################################
 ## Setup environment

--- a/src/jobs/CiviCRM-Civix-Test.job
+++ b/src/jobs/CiviCRM-Civix-Test.job
@@ -30,7 +30,7 @@ assert_regex '^\(src\|phar\)$' "$CIVIX_TYPE" "Invalid CIVIX_TYPE"
 #################################################
 ## Main
 
-use_bknix_tmp
+# use_bknix_tmp
 
 ################################################
 ## Setup environment

--- a/src/jobs/CiviCRM-Civix-Test.job
+++ b/src/jobs/CiviCRM-Civix-Test.job
@@ -30,7 +30,7 @@ assert_regex '^\(src\|phar\)$' "$CIVIX_TYPE" "Invalid CIVIX_TYPE"
 #################################################
 ## Main
 
-# use_bknix_tmp
+assert_bknix_temporary
 
 ################################################
 ## Setup environment

--- a/src/jobs/CiviCRM-Core-Edge.job
+++ b/src/jobs/CiviCRM-Core-Edge.job
@@ -20,7 +20,7 @@ assert_common EXECUTOR_NUMBER WORKSPACE BLDTYPE CIVIVER SUITES
 #################################################
 ## Main
 
-# use_bknix_tmp
+assert_bknix_temporary
 
 BLDNAME="build-$EXECUTOR_NUMBER"
 

--- a/src/jobs/CiviCRM-Core-Edge.job
+++ b/src/jobs/CiviCRM-Core-Edge.job
@@ -20,7 +20,7 @@ assert_common EXECUTOR_NUMBER WORKSPACE BLDTYPE CIVIVER SUITES
 #################################################
 ## Main
 
-use_bknix_tmp
+# use_bknix_tmp
 
 BLDNAME="build-$EXECUTOR_NUMBER"
 

--- a/src/jobs/CiviCRM-Core-Matrix-PR.job
+++ b/src/jobs/CiviCRM-Core-Matrix-PR.job
@@ -18,7 +18,7 @@ assert_common EXECUTOR_NUMBER WORKSPACE SUITES ghprbPullId ghprbTargetBranch
 
 ## TODO: rethink this env-var. for the moment, setting it duplicates the behavior of "use_bknix_tmp"
 export CIVI_TEST_MODE=
-use_bknix_tmp
+# use_bknix_tmp
 
 civi-test-pr --no-interaction \
   --patch="https://github.com/civicrm/civicrm-core/pull/${ghprbPullId}" \

--- a/src/jobs/CiviCRM-Core-Matrix-PR.job
+++ b/src/jobs/CiviCRM-Core-Matrix-PR.job
@@ -18,7 +18,7 @@ assert_common EXECUTOR_NUMBER WORKSPACE SUITES ghprbPullId ghprbTargetBranch
 
 ## TODO: rethink this env-var. for the moment, setting it duplicates the behavior of "use_bknix_tmp"
 export CIVI_TEST_MODE=
-# use_bknix_tmp
+assert_bknix_temporary
 
 civi-test-pr --no-interaction \
   --patch="https://github.com/civicrm/civicrm-core/pull/${ghprbPullId}" \

--- a/src/jobs/CiviCRM-Core-Matrix-Timing.job
+++ b/src/jobs/CiviCRM-Core-Matrix-Timing.job
@@ -18,7 +18,7 @@ assert_common EXECUTOR_NUMBER WORKSPACE CIVIVER SUITES TIME_FUNC
 #################################################
 ## Main
 
-use_bknix_tmp
+# use_bknix_tmp
 
 BLDNAME="build-$EXECUTOR_NUMBER"
 echo "TIME_FUNC=$TIME_FUNC"

--- a/src/jobs/CiviCRM-Core-Matrix-Timing.job
+++ b/src/jobs/CiviCRM-Core-Matrix-Timing.job
@@ -18,7 +18,7 @@ assert_common EXECUTOR_NUMBER WORKSPACE CIVIVER SUITES TIME_FUNC
 #################################################
 ## Main
 
-# use_bknix_tmp
+assert_bknix_temporary
 
 BLDNAME="build-$EXECUTOR_NUMBER"
 echo "TIME_FUNC=$TIME_FUNC"

--- a/src/jobs/CiviCRM-Core-Matrix.job
+++ b/src/jobs/CiviCRM-Core-Matrix.job
@@ -17,7 +17,7 @@ assert_common EXECUTOR_NUMBER WORKSPACE CIVIVER SUITES
 #################################################
 ## Main
 
-# use_bknix_tmp
+assert_bknix_temporary
 
 BLDNAME="build-$EXECUTOR_NUMBER"
 

--- a/src/jobs/CiviCRM-Core-Matrix.job
+++ b/src/jobs/CiviCRM-Core-Matrix.job
@@ -17,7 +17,7 @@ assert_common EXECUTOR_NUMBER WORKSPACE CIVIVER SUITES
 #################################################
 ## Main
 
-use_bknix_tmp
+# use_bknix_tmp
 
 BLDNAME="build-$EXECUTOR_NUMBER"
 

--- a/src/jobs/CiviCRM-Core-PR.job
+++ b/src/jobs/CiviCRM-Core-PR.job
@@ -14,4 +14,4 @@ CIVI_REPO="civicrm-core"
 BLDTYPE="drupal-clean"
 BLDNAME="core-$ghprbPullId-$(php -r 'echo base_convert(time()%(180*24*60*60), 10, 36);')"
 
-run_bknix_include "$BKNIX_JOBS/Generic-Demo.job"
+run_job_include "$BKNIX_JOBS/Generic-Demo.job"

--- a/src/jobs/CiviCRM-Core-Style.job
+++ b/src/jobs/CiviCRM-Core-Style.job
@@ -8,4 +8,4 @@ set -e
 #################################################
 
 CIVI_REPO=civicrm-core
-run_bknix_include "$BKNIX_JOBS/Generic-Style.job"
+run_job_include "$BKNIX_JOBS/Generic-Style.job"

--- a/src/jobs/CiviCRM-Cv-PR.job
+++ b/src/jobs/CiviCRM-Cv-PR.job
@@ -27,7 +27,7 @@ assert_regex "^\(cv-std\|cv-installer\|cv-null\)$" "$SUITE"
 #################################################
 ## Main
 
-# use_bknix_tmp
+assert_bknix_temporary
 
 ################################################
 ## Skip some configurations

--- a/src/jobs/CiviCRM-Cv-PR.job
+++ b/src/jobs/CiviCRM-Cv-PR.job
@@ -27,7 +27,7 @@ assert_regex "^\(cv-std\|cv-installer\|cv-null\)$" "$SUITE"
 #################################################
 ## Main
 
-use_bknix_tmp
+# use_bknix_tmp
 
 ################################################
 ## Skip some configurations

--- a/src/jobs/CiviCRM-D8-Matrix.job
+++ b/src/jobs/CiviCRM-D8-Matrix.job
@@ -31,7 +31,7 @@ fi
 #################################################
 ## Main
 
-use_bknix_tmp
+# use_bknix_tmp
 
 BLDNAME="build-$EXECUTOR_NUMBER"
 

--- a/src/jobs/CiviCRM-D8-Matrix.job
+++ b/src/jobs/CiviCRM-D8-Matrix.job
@@ -31,7 +31,7 @@ fi
 #################################################
 ## Main
 
-# use_bknix_tmp
+assert_bknix_temporary
 
 BLDNAME="build-$EXECUTOR_NUMBER"
 

--- a/src/jobs/CiviCRM-Drupal-Demo.job
+++ b/src/jobs/CiviCRM-Drupal-Demo.job
@@ -14,4 +14,4 @@ CIVI_REPO="civicrm-drupal"
 BLDTYPE="drupal-clean"
 BLDNAME="d7-$ghprbPullId-$(php -r 'echo base_convert(time()%(180*24*60*60), 10, 36);')"
 
-run_bknix_include "$BKNIX_JOBS/Generic-Demo.job"
+run_job_include "$BKNIX_JOBS/Generic-Demo.job"

--- a/src/jobs/CiviCRM-Drupal-PR.job
+++ b/src/jobs/CiviCRM-Drupal-PR.job
@@ -27,7 +27,7 @@ assert_testable_version "$CIVIVER"
 #################################################
 ## Main
 
-use_bknix
+assert_bknix_durable
 
 BLDNAME="d7-$ghprbPullId-$(php -r 'echo base_convert(time()%(180*24*60*60), 10, 36);')"
 BLDDIR="$BKITBLD/$BLDNAME"

--- a/src/jobs/CiviCRM-Drupal-Style.job
+++ b/src/jobs/CiviCRM-Drupal-Style.job
@@ -8,4 +8,4 @@ set -e
 #################################################
 
 CIVI_REPO=civicrm-drupal
-run_bknix_include "$BKNIX_JOBS/Generic-Style.job"
+run_job_include "$BKNIX_JOBS/Generic-Style.job"

--- a/src/jobs/CiviCRM-Drupal-Test.job
+++ b/src/jobs/CiviCRM-Drupal-Test.job
@@ -13,4 +13,4 @@ SUITES='upgrade phpunit-e2e phpunit-drupal'
 #SUITES='upgrade karma phpunit-e2e phpunit-drupal'
 #SUITES='phpunit-drupal'
 
-run_bknix_include "$BKNIX_JOBS/Generic-Test.job"
+run_job_include "$BKNIX_JOBS/Generic-Test.job"

--- a/src/jobs/CiviCRM-E2E-Edge.job
+++ b/src/jobs/CiviCRM-E2E-Edge.job
@@ -19,7 +19,7 @@ assert_common EXECUTOR_NUMBER WORKSPACE BLDTYPE CIVIVER SUITES
 #################################################
 ## Main
 
-use_bknix_tmp
+# use_bknix_tmp
 
 BLDNAME="build-$EXECUTOR_NUMBER"
 

--- a/src/jobs/CiviCRM-E2E-Edge.job
+++ b/src/jobs/CiviCRM-E2E-Edge.job
@@ -19,7 +19,7 @@ assert_common EXECUTOR_NUMBER WORKSPACE BLDTYPE CIVIVER SUITES
 #################################################
 ## Main
 
-# use_bknix_tmp
+assert_bknix_temporary
 
 BLDNAME="build-$EXECUTOR_NUMBER"
 

--- a/src/jobs/CiviCRM-E2E-Matrix.job
+++ b/src/jobs/CiviCRM-E2E-Matrix.job
@@ -30,7 +30,7 @@ assert_common SUITES
 #################################################
 ## Main
 
-# use_bknix_tmp
+assert_bknix_temporary
 
 BLDNAME="build-$EXECUTOR_NUMBER"
 

--- a/src/jobs/CiviCRM-E2E-Matrix.job
+++ b/src/jobs/CiviCRM-E2E-Matrix.job
@@ -30,7 +30,7 @@ assert_common SUITES
 #################################################
 ## Main
 
-use_bknix_tmp
+# use_bknix_tmp
 
 BLDNAME="build-$EXECUTOR_NUMBER"
 

--- a/src/jobs/CiviCRM-Ext-Edge-Matrix.job
+++ b/src/jobs/CiviCRM-Ext-Edge-Matrix.job
@@ -20,7 +20,7 @@ assert_regex '^[0-9a-z\.-]\+$' "$BUILDTYPE" "Missing or invalid BUILDTYPE"
 #################################################
 ## Main
 
-use_bknix_tmp
+# use_bknix_tmp
 
 # Set ENV for the TMPDIR so that mosaico test and mosaico build don't clobber each other
 npm config set tmp "/home/$USER/npm-tmp/"

--- a/src/jobs/CiviCRM-Ext-Edge-Matrix.job
+++ b/src/jobs/CiviCRM-Ext-Edge-Matrix.job
@@ -20,7 +20,7 @@ assert_regex '^[0-9a-z\.-]\+$' "$BUILDTYPE" "Missing or invalid BUILDTYPE"
 #################################################
 ## Main
 
-# use_bknix_tmp
+assert_bknix_temporary
 
 # Set ENV for the TMPDIR so that mosaico test and mosaico build don't clobber each other
 npm config set tmp "/home/$USER/npm-tmp/"

--- a/src/jobs/CiviCRM-Ext-Matrix.job
+++ b/src/jobs/CiviCRM-Ext-Matrix.job
@@ -22,7 +22,7 @@ assert_regex '^[0-9a-z\.-]\+$' "$BUILDTYPE" "Missing or invalid BUILDTYPE"
 #################################################
 ## Main
 
-# use_bknix_tmp
+assert_bknix_temporary
 
 # Set ENV for the TMPDIR so that mosaico test and mosaico build don't clobber each other
 npm config set tmp "/home/$USER/npm-tmp/"

--- a/src/jobs/CiviCRM-Ext-Matrix.job
+++ b/src/jobs/CiviCRM-Ext-Matrix.job
@@ -22,7 +22,7 @@ assert_regex '^[0-9a-z\.-]\+$' "$BUILDTYPE" "Missing or invalid BUILDTYPE"
 #################################################
 ## Main
 
-use_bknix_tmp
+# use_bknix_tmp
 
 # Set ENV for the TMPDIR so that mosaico test and mosaico build don't clobber each other
 npm config set tmp "/home/$USER/npm-tmp/"

--- a/src/jobs/CiviCRM-Manual-Test.job
+++ b/src/jobs/CiviCRM-Manual-Test.job
@@ -24,7 +24,7 @@ assert_regex '^\(\|https://github.com/civicrm/civicrm-[a-z]*/pull/[0-9]\+/*\)$' 
 #################################################
 ## Bootstrap
 
-use_bknix_tmp
+# use_bknix_tmp
 
 #################################################
 ## Local variables

--- a/src/jobs/CiviCRM-Manual-Test.job
+++ b/src/jobs/CiviCRM-Manual-Test.job
@@ -24,7 +24,7 @@ assert_regex '^\(\|https://github.com/civicrm/civicrm-[a-z]*/pull/[0-9]\+/*\)$' 
 #################################################
 ## Bootstrap
 
-# use_bknix_tmp
+assert_bknix_temporary
 
 #################################################
 ## Local variables

--- a/src/jobs/CiviCRM-Manual.job
+++ b/src/jobs/CiviCRM-Manual.job
@@ -24,7 +24,7 @@ assert_regex '^\(\|https://github.com/civicrm/civicrm-[a-z]*/pull/[0-9]\+/*\)$' 
 #################################################
 ## Main
 
-use_bknix
+assert_bknix_durable
 
 ## Build definition
 ## Note: Suffixes are unique within a period of 180 days.

--- a/src/jobs/CiviCRM-Packages-Demo.job
+++ b/src/jobs/CiviCRM-Packages-Demo.job
@@ -14,4 +14,4 @@ CIVI_REPO="civicrm-packages"
 BLDTYPE="drupal-clean"
 BLDNAME="d7-$ghprbPullId-$(php -r 'echo base_convert(time()%(180*24*60*60), 10, 36);')"
 
-run_bknix_include "$BKNIX_JOBS/Generic-Demo.job"
+run_job_include "$BKNIX_JOBS/Generic-Demo.job"

--- a/src/jobs/CiviCRM-Packages-PR.job
+++ b/src/jobs/CiviCRM-Packages-PR.job
@@ -25,7 +25,7 @@ assert_testable_version "$CIVIVER"
 #################################################
 ## Main
 
-use_bknix
+assert_bknix_durable
 
 BLDNAME="pkg-$ghprbPullId-$(php -r 'echo base_convert(time()%(180*24*60*60), 10, 36);')"
 BLDDIR="$BKITBLD/$BLDNAME"

--- a/src/jobs/CiviCRM-Packages-Test.job
+++ b/src/jobs/CiviCRM-Packages-Test.job
@@ -13,4 +13,4 @@ SUITES='all'
 #SUITES='upgrade karma phpunit-e2e phpunit-drupal'
 #SUITES='phpunit-civi'
 
-run_bknix_include "$BKNIX_JOBS/Generic-Test.job"
+run_job_include "$BKNIX_JOBS/Generic-Test.job"

--- a/src/jobs/CiviCRM-Test.job
+++ b/src/jobs/CiviCRM-Test.job
@@ -28,7 +28,7 @@ assert_regex '^\(disable\|enable\)$' "$ORNERY" "Invalid ORNERY flag"
 #################################################
 ## Bootstrap
 
-use_bknix_tmp
+# use_bknix_tmp
 
 #################################################
 ## Local variables

--- a/src/jobs/CiviCRM-Test.job
+++ b/src/jobs/CiviCRM-Test.job
@@ -28,7 +28,7 @@ assert_regex '^\(disable\|enable\)$' "$ORNERY" "Invalid ORNERY flag"
 #################################################
 ## Bootstrap
 
-# use_bknix_tmp
+assert_bknix_temporary
 
 #################################################
 ## Local variables

--- a/src/jobs/CiviCRM-WordPress-Demo.job
+++ b/src/jobs/CiviCRM-WordPress-Demo.job
@@ -14,4 +14,4 @@ CIVI_REPO="civicrm-wordpress"
 BLDTYPE="wp-demo"
 BLDNAME="wp-$ghprbPullId-$(php -r 'echo base_convert(time()%(180*24*60*60), 10, 36);')"
 
-run_bknix_include "$BKNIX_JOBS/Generic-Demo.job"
+run_job_include "$BKNIX_JOBS/Generic-Demo.job"

--- a/src/jobs/CiviCRM-WordPress-PR.job
+++ b/src/jobs/CiviCRM-WordPress-PR.job
@@ -35,7 +35,7 @@ esac
 #################################################
 ## Main
 
-use_bknix
+assert_bknix_durable
 
 BLDNAME="wp-$ghprbPullId-$(php -r 'echo base_convert(time()%(180*24*60*60), 10, 36);')"
 BLDDIR="$BKITBLD/$BLDNAME"

--- a/src/jobs/CiviCRM-WordPress-Style.job
+++ b/src/jobs/CiviCRM-WordPress-Style.job
@@ -18,4 +18,4 @@ esac
 #################################################
 
 CIVI_REPO=civicrm-wordpress
-run_bknix_include "$BKNIX_JOBS/Generic-Style.job"
+run_job_include "$BKNIX_JOBS/Generic-Style.job"

--- a/src/jobs/CiviCRM-WordPress-Test.job
+++ b/src/jobs/CiviCRM-WordPress-Test.job
@@ -13,4 +13,4 @@ SUITES='upgrade phpunit-e2e phpunit-wordpress'
 #SUITES='upgrade phpunit-e2e karma phpunit-wordpress'
 #SUITES='phpunit-wordpress'
 
-run_bknix_include "$BKNIX_JOBS/Generic-Test.job"
+run_job_include "$BKNIX_JOBS/Generic-Test.job"

--- a/src/jobs/Extension-SHA.job
+++ b/src/jobs/Extension-SHA.job
@@ -55,7 +55,7 @@ BLDNAME="build-$EXECUTOR_NUMBER"
 
 ## TODO: rethink this env-var. for the moment, setting it duplicates the behavior of "use_bknix_tmp"
 export CIVI_TEST_MODE=
-# use_bknix_tmp
+assert_bknix_temporary
 
 #################################################
 ## Run a command, but hide any sensitive environmet variables

--- a/src/jobs/Extension-SHA.job
+++ b/src/jobs/Extension-SHA.job
@@ -55,7 +55,7 @@ BLDNAME="build-$EXECUTOR_NUMBER"
 
 ## TODO: rethink this env-var. for the moment, setting it duplicates the behavior of "use_bknix_tmp"
 export CIVI_TEST_MODE=
-use_bknix_tmp
+# use_bknix_tmp
 
 #################################################
 ## Run a command, but hide any sensitive environmet variables

--- a/src/jobs/Generic-Demo.job
+++ b/src/jobs/Generic-Demo.job
@@ -23,7 +23,7 @@ assert_testable_version "$CIVIVER"
 #################################################
 ## Main
 
-use_bknix
+assert_bknix_durable
 
 BLDDIR="$BKITBLD/$BLDNAME"
 

--- a/src/jobs/Generic-Style.job
+++ b/src/jobs/Generic-Style.job
@@ -23,7 +23,7 @@ assert_testable_version "$CIVIVER"
 #################################################
 ## Main
 
-# use_bknix_tmp
+assert_bknix_temporary
 
 ## Build definition
 assert_common BKITBLD EXECUTOR_NUMBER

--- a/src/jobs/Generic-Style.job
+++ b/src/jobs/Generic-Style.job
@@ -23,7 +23,7 @@ assert_testable_version "$CIVIVER"
 #################################################
 ## Main
 
-use_bknix_tmp
+# use_bknix_tmp
 
 ## Build definition
 assert_common BKITBLD EXECUTOR_NUMBER

--- a/src/jobs/Generic-Test.job
+++ b/src/jobs/Generic-Test.job
@@ -27,7 +27,7 @@ assert_testable_version "$CIVIVER"
 #################################################
 ## Main
 
-use_bknix_tmp
+# use_bknix_tmp
 
 BLDNAME="build-$EXECUTOR_NUMBER"
 BLDDIR="$BKITBLD/$BLDNAME"

--- a/src/jobs/Generic-Test.job
+++ b/src/jobs/Generic-Test.job
@@ -27,7 +27,7 @@ assert_testable_version "$CIVIVER"
 #################################################
 ## Main
 
-# use_bknix_tmp
+assert_bknix_temporary
 
 BLDNAME="build-$EXECUTOR_NUMBER"
 BLDDIR="$BKITBLD/$BLDNAME"

--- a/src/jobs/Hello.job
+++ b/src/jobs/Hello.job
@@ -2,7 +2,7 @@
 set -e
 
 assert_common EXECUTOR_NUMBER WORKSPACE
-# use_bknix_tmp
+assert_bknix_temporary
 init_std_workspace
 
 echo "Hello world! Did you know that HTTPD_PORT=$HTTPD_PORT?"

--- a/src/jobs/Hello.job
+++ b/src/jobs/Hello.job
@@ -2,7 +2,7 @@
 set -e
 
 assert_common EXECUTOR_NUMBER WORKSPACE
-use_bknix_tmp
+# use_bknix_tmp
 init_std_workspace
 
 echo "Hello world! Did you know that HTTPD_PORT=$HTTPD_PORT?"

--- a/src/jobs/README.md
+++ b/src/jobs/README.md
@@ -62,9 +62,9 @@ Suppose you have a job `CiviCRM-Foo-Bar` in Jenkins and want to migrate the scri
 * From https://test.civicrm.org/job/CiviCRM-Foo-Bar/configure, copy the existing shell script
 * Create a file `src/jobs/CiviCRM-Foo-Bar.job`. Paste the script.
 * At the top, add docblocks and assertions for any special environment variables. Common ones might be `CIVIVER`, `ghprbTargetBranch`, or `ghprbPullId`.
-* Decide where/how to start the bknix environment. Add one of these near the top:
-    * `use_bknix` (*load requested bknix profile*)
-    * `use_bknix_tmp` (*as above; additionally, if required, it will transactionally start services in the background*)
+* Do you care if the job runs in a durable/persistent or temporary/isolated environment? Add an assertion like:
+    * `assert_bknix_durable`
+    * `assert_bknix_temporary`
 * (*Optional, if amenable*) Convert to "standard" workspace layout
     * Near the top, add `init_std_workspace`
     * Remove anything that initializes or deletes folders for "junit", "checkstyle", "civibuild html", "build", "dist", or similar.
@@ -73,13 +73,16 @@ Suppose you have a job `CiviCRM-Foo-Bar` in Jenkins and want to migrate the scri
 * Run the job locally. Check `/tmp/mock-workspace-$USER` to ensure that artifacts are placed correctly.
 * Commit, push, deploy
 * In https://test.civicrm.org/job/CiviCRM-Foo-Bar/configure, switch to the new script
+    * Decide where/how to start the bknix environment.
+        * If the environment is durable, you want to run on `label=bknix-durable` and call `run-bknix-job --active`
+        * If the environment is temporary, you want to run on `label=bknix-tmp` and call `run-bknix-job --isolate`
     * The bash script should look like this:
         ```
         #!/usr/bin/env bash
         ## See https://github.com/civicrm/civicrm-buildkit/tree/master/src/jobs
         set -e
         if [ -e $HOME/.profile ]; then . $HOME/.profile; fi
-        run-bknix-job "$BKPROF"
+        run-bknix-job --isolate
         exit $?
         ```
     * If you converted to "standard" workspace layout, then update any "Post-build Actions" to read from the standard locations, e.g.

--- a/src/jobs/Security-Core-Matrix.job
+++ b/src/jobs/Security-Core-Matrix.job
@@ -30,7 +30,7 @@ assert_common CIVIVER
 #################################################
 ## Main
 
-use_bknix_tmp
+# use_bknix_tmp
 
 BLDNAME="build-$EXECUTOR_NUMBER"
 export TIME_FUNC="linear:500"

--- a/src/jobs/Security-Core-Matrix.job
+++ b/src/jobs/Security-Core-Matrix.job
@@ -30,7 +30,7 @@ assert_common CIVIVER
 #################################################
 ## Main
 
-# use_bknix_tmp
+assert_bknix_temporary
 
 BLDNAME="build-$EXECUTOR_NUMBER"
 export TIME_FUNC="linear:500"

--- a/src/jobs/common.sh
+++ b/src/jobs/common.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+{ ## start common.sh
 
 ## Common utilities to include in jobs...
 
@@ -48,6 +49,16 @@ function assert_common() {
           fatal "Failed to find BKITBLD for $BKPROF"
         fi
         ;;
+      BKPROF)
+        if [[ "$BKPROF" =~ ^php[0-9]{2}([mr][0-9]+)?$ ]]; then
+          true
+        else
+          case "$BKPROF" in
+            old|min|dfl|max|alt|edge) true ; ;;
+            *) fatal "Missing or invalid BKPROF" ; ;;
+          esac
+        fi
+        ;;
       BUILD_NUMBER)
         assert_regex '^[0-9]\+$' "$BUILD_NUMBER" "Missing or invalid BUILD_NUMBER"
         ;;
@@ -62,6 +73,9 @@ function assert_common() {
         ;;
       EXECUTOR_NUMBER)
         assert_regex '^[0-9]\+$' "$EXECUTOR_NUMBER" "EXECUTOR_NUMBER must be a number. (If you are running manually, consider using --mock.)"
+        ;;
+      JOB_NAME)
+        if [ -z "$JOB_NAME" ]; then fatal "Missing JOB_NAME" ; fi
         ;;
       PHPUNIT)
         assert_regex '^phpunit[0-9]*$' "$PHPUNIT" "PHPUNIT ($PHPUNIT) should identify a general version (such as phpunit8 or phpunit9)"
@@ -285,3 +299,5 @@ function assert_testable_version() {
   esac
 
 }
+
+} ## end common.sh

--- a/src/jobs/common.sh
+++ b/src/jobs/common.sh
@@ -130,35 +130,24 @@ function assign_smarty() {
   export SMARTY3_ENABLE
 }
 
-## Load the BKPROF into the current shell
-function use_bknix() {
-  if [ -n "$LOADED_BKPROF" ]; then
-    assert_common BKITBLD
-    return
-  fi
-
-  if [ ! -z `which await-bknix` ]; then
-    await-bknix "$USER" "$BKPROF"
-  fi
-
-  case "$BKPROF" in old|min|max|alt|dfl|edge) eval $(use-bknix "$BKPROF") ;; esac
-  assert_common BKITBLD
-}
-
-function use_bknix_tmp() {
-  use_bknix
+function assert_bknix_durable() {
   case "$USER" in
     homer|runner-*)
-      (cd "$LOCO_PRJ" && loco clean)
-      (cd "$LOCO_PRJ" && loco start)
-      RUN_BKNIX_CLEANUP_FUNCS+=('_stop_loco')
+      echo >&2 "WARNING: This job is expected to run in a persistent environment. User $USER suggests it is temporary."
       ;;
-    ## else: This must be a traditional system that runs with system-services.
   esac
+
 }
 
-function _stop_loco() {
-  (cd "$LOCO_PRJ" && loco stop)
+function assert_bknix_temporary() {
+  case "$USER" in
+    homer|runner-*)
+      true
+      ;;
+    *)
+      echo >&2 "WARNING: This job is expected to run in a temporary environment. User $USER suggests it is persistent."
+      ;;
+  esac
 }
 
 ## Setup a mock Jenkins environment

--- a/src/jobs/common.sh
+++ b/src/jobs/common.sh
@@ -68,6 +68,11 @@ function assert_common() {
       BLDNAME)
         assert_regex '^[0-9a-z][0-9a-z\.-]*$' "$BLDTYPE" "Missing or invalid BLDTYPE"
         ;;
+      BKIT)
+        if [ ! -e "$BKIT/bin/civi-download-tools" ]; then
+          echo "BKIT must be a valid buildkit folder. (Missing flag-file bin/civi-download-tools.)"
+        fi
+        ;;
       CIVIVER)
         assert_regex '^[0-9a-z][0-9a-z\.-]*$' "$CIVIVER" "Missing or invalid CIVIVER"
         ;;
@@ -76,6 +81,11 @@ function assert_common() {
         ;;
       JOB_NAME)
         if [ -z "$JOB_NAME" ]; then fatal "Missing JOB_NAME" ; fi
+        ;;
+      LOCO_PRJ)
+        if [ ! -e "$LOCO_PRJ/.loco" ]; then
+          fatal "LOCO_PRJ must be a valid project"
+        fi
         ;;
       PHPUNIT)
         assert_regex '^phpunit[0-9]*$' "$PHPUNIT" "PHPUNIT ($PHPUNIT) should identify a general version (such as phpunit8 or phpunit9)"
@@ -149,6 +159,18 @@ function use_bknix_tmp() {
 
 function _stop_loco() {
   (cd "$LOCO_PRJ" && loco stop)
+}
+
+## Setup a mock Jenkins environment
+function init_jenkins_mock() {
+  echo "Using mock Jenkins environment"
+  export EXECUTOR_NUMBER=0
+  export BUILD_NUMBER=123
+  export WORKSPACE="$HOME/tmp/mock-workspace"
+  if [ ! -d "$WORKSPACE" ]; then
+    mkdir -p "$WORKSPACE"
+  fi
+  cd "$WORKSPACE"
 }
 
 ## Setup the standard build folders within the workspace.

--- a/src/jobs/shell.job
+++ b/src/jobs/shell.job
@@ -18,7 +18,7 @@ assert_common EXECUTOR_NUMBER WORKSPACE
 #################################################
 ## Bootstrap
 
-# use_bknix_tmp
+assert_bknix_temporary
 
 #################################################
 ## Report details about the test environment

--- a/src/jobs/shell.job
+++ b/src/jobs/shell.job
@@ -18,7 +18,7 @@ assert_common EXECUTOR_NUMBER WORKSPACE
 #################################################
 ## Bootstrap
 
-use_bknix_tmp
+# use_bknix_tmp
 
 #################################################
 ## Report details about the test environment


### PR DESCRIPTION
Overview
-------------

This updates the way that the test-runner loads PHP/MySQL. The overarching goal is to allow ephemeral testing with a more fluid mix of environments (PHP/MySQL/etc) - by relaxing a requirement to use a pre-installed permutation.

It's a dependency in the on-going update to the test-matrices, wherein `min`/`max` are replaced by a floating mix of environments like `php74m57`, `php83m80`, etc.

Technical Details
----------------------

A couple ways to look at the change:

* Internally, the job-script is written a little differently:
    * __Before__: The job-script said either `use-bknix` or `use_bknix_tmp`. Under the hood, this implied a call to `eval $(use-bknix $BKPROF)` -- which implied that the binaries were pinned/pre-installed profiles.
    * __Now__: The job-script says `assert_bknix_durable` or `assert_bknix_temporary`. But it doesn't have causal responsibility for finding/starting/stopping anything.
* Externally, the job-runner is invoked a little differently:
    * __Before__: The only way to run a job-script was `run-bknix-job max MyJob`. It used some hidden rules to decide the level isolation to apply to jobs.
    * __Now__: The responsibility is split, with different levels of isolation addressed as:
        * `run-job` simply runs the job-script with your current PHP/MySQL/etc. It has no opinion about the isolation mechanics.
        * `run-bknix-job` uses nix to setup PHP/MySQL/etc. It has a few alternative modes:
            * `run-bknix-job --isolate max` (Run job in a temporary/isolated environment. Use Linux namespaces for isolation.)
            * `run-bknix-job --autostart max` (Run job as the current/local user. Get binaries from nix and start the services.)
            * `run-bknix-job --active max` (Run job in a pre-installed/already-active profile.)