### PR TITLE
app/config - Backdrop profiles should use new installer

### DIFF
--- a/app/config/backdrop-clean/install.sh
+++ b/app/config/backdrop-clean/install.sh
@@ -26,7 +26,7 @@ CIVI_SETTINGS="${CMS_ROOT}/civicrm.settings.php"
 CIVI_FILES="${CMS_ROOT}/files/civicrm"
 CIVI_TEMPLATEC="${CIVI_FILES}/templates_c"
 CIVI_UF="Backdrop"
-civicrm_install
+civicrm_install_transitional
 
 ###############################################################################
 ## Extra configuration

--- a/app/config/backdrop-demo/install.sh
+++ b/app/config/backdrop-demo/install.sh
@@ -26,7 +26,7 @@ CIVI_SETTINGS="${CMS_ROOT}/civicrm.settings.php"
 CIVI_FILES="${CMS_ROOT}/files/civicrm"
 CIVI_TEMPLATEC="${CIVI_FILES}/templates_c"
 CIVI_UF="Backdrop"
-civicrm_install
+civicrm_install_transitional
 
 ###############################################################################
 ## Extra configuration


### PR DESCRIPTION
Overview
----------

Update the build scripts for `backdrop-clean` and `backdrop-demo`.

Before
-------

It sets up the Civi database with `cat sql/mysql.mysql | mysql` (etc).

After
-------

It sets up the Civi database with `cv core:install` (aka `Civi\Setup`).

Comments
-----------

I did a local run of these commands:

```bash
civibuild create delme --type backdrop-clean
civibuild create delme --type  backdrop-demo
```

And it seemed fine.