### PR TITLE
app/config - WordPress profiles should use new installer

### DIFF
--- a/app/config/wp-case/install.sh
+++ b/app/config/wp-case/install.sh
@@ -23,7 +23,7 @@ CIVI_FILES="${WEB_ROOT}/wp-content/uploads/civicrm"
 CIVI_TEMPLATEC="${CIVI_FILES}/templates_c"
 CIVI_UF="WordPress"
 
-civicrm_install
+civicrm_install_transitional
 
 ###############################################################################
 ## Extra configuration

--- a/app/config/wp-clean/install.sh
+++ b/app/config/wp-clean/install.sh
@@ -36,7 +36,7 @@ fi
 CIVI_TEMPLATEC="${CIVI_FILES}/templates_c"
 CIVI_UF="WordPress"
 
-civicrm_install
+civicrm_install_transitional
 
 ###############################################################################
 ## Extra configuration

--- a/app/config/wp-demo/install.sh
+++ b/app/config/wp-demo/install.sh
@@ -36,7 +36,7 @@ fi
 CIVI_TEMPLATEC="${CIVI_FILES}/templates_c"
 CIVI_UF="WordPress"
 
-civicrm_install
+civicrm_install_transitional
 
 ###############################################################################
 ## Extra configuration

--- a/src/civibuild.lib.sh
+++ b/src/civibuild.lib.sh
@@ -696,20 +696,20 @@ function civicrm_install_transitional() {
   cvutil_assertvars civicrm_install CIVI_CORE
 
   ## If installing an older version, provide continuity (for purposes of test matrices/contrib tests/etc).
-  if civicrm_check_ver '<' 5.57.alpha1 ; then
-
-    civicrm_install
+  if civicrm_check_ver '<' 5.57.alpha1 ; then civicrm_install; return; fi
+  if [[ "$CIVI_UF" == "WordPress" ]]; then
+    if civicrm_check_ver '<' 5.78.alpha1 ; then civicrm_install; return; fi
+  fi
 
   ## Newer versions should use 'cv core:install' to match regular web-installer
-  else
-    # If you've switched branches and triggered `reinstall`, then you need to refresh composer deps/autoloader before installing
-    (cd "$CIVI_CORE" && composer install)
 
-    civicrm_install_cv
+  # If you've switched branches and triggered `reinstall`, then you need to refresh composer deps/autoloader before installing
+  (cd "$CIVI_CORE" && composer install)
 
-    ## Generating `civicrm.config.php` is necessary for `extern/*.php` and its E2E tests
-    (cd "$CIVI_CORE" && ./bin/setup.sh -g)
-  fi
+  civicrm_install_cv
+
+  ## Generating `civicrm.config.php` is necessary for `extern/*.php` and its E2E tests
+  (cd "$CIVI_CORE" && ./bin/setup.sh -g)
 }
 
 ###############################################################################


### PR DESCRIPTION
Overview
----------

Update the build scripts for `wp-clean` and `wp-demo`.

Before
-------

It sets up the Civi database with `cat sql/civicrm.mysql sql/civicrm_data.mysql ... | mysql` and `cp civicrm.settings.php.template ...` (etal).

After
-------

It sets up the Civi database with `cv core:install` (aka `Civi\Setup`).

Comments
-----------

(1) During 5.72-alpha/5.72-rc, we had a critical regression get into the Civi-WP installation process. It was only caught during the final run-down. CI should be using `cv core:install` (*which is more representative and which would've caught the problem sooner*).

(2) I did a local run, e.g.

```bash

civibuild create delme --type wp-demo
```

And it seemed to have trouble. (*This is why I split apart the similar changes for WP and BD (#853).*) It's odd - I'm sure it worked at one point, and it's 90% the same as the web-based installer. 

Needs some work to track-down. This was sitting around on my system uncomitted... So for now I'm posting the draft PR to flag that this needs work.