### PR TITLE
backdrop-* - Temporarily set default CMS version to 1.27-stable

### DIFF
--- a/app/config/backdrop-clean/download.sh
+++ b/app/config/backdrop-clean/download.sh
@@ -4,7 +4,7 @@
 
 ###############################################################################
 
-[ -z "$CMS_VERSION" ] && CMS_VERSION="1.x"
+[ -z "$CMS_VERSION" ] && CMS_VERSION="1.27.x" ## FIXME: After 1.28-dev stabilizes, we can switch back to 1.x.
 [ -z "$CIVI_VERSION" ] && CIVI_VERSION=master
 
 backdrop_download

--- a/app/config/backdrop-demo/download.sh
+++ b/app/config/backdrop-demo/download.sh
@@ -4,7 +4,7 @@
 
 ###############################################################################
 
-[ -z "$CMS_VERSION" ] && CMS_VERSION="1.x"
+[ -z "$CMS_VERSION" ] && CMS_VERSION="1.27.x" ## FIXME: After 1.28-dev stabilizes, we can switch back to 1.x.
 [ -z "$CIVI_VERSION" ] && CIVI_VERSION=master
 [ -z "$VOL_VERSION" ] && VOL_VERSION='master'
 [ -z "$NG_PRFL_VERSION" ] && NG_PRFL_VERSION='master'

--- a/app/config/backdrop-empty/download.sh
+++ b/app/config/backdrop-empty/download.sh
@@ -4,7 +4,7 @@
 
 ###############################################################################
 
-[ -z "$CMS_VERSION" ] && CMS_VERSION="1.x"
+[ -z "$CMS_VERSION" ] && CMS_VERSION="1.27.x" ## FIXME: After 1.28-dev stabilizes, we can switch back to 1.x.
 [ -z "$CIVI_VERSION" ] && CIVI_VERSION=none
 
 backdrop_download


### PR DESCRIPTION
The current 1.28-dev has some issues with CLI install process.