### PR TITLE
loco - Add support for launching Chrome services

### DIFF
--- a/.loco/loco.yml
+++ b/.loco/loco.yml
@@ -49,7 +49,8 @@ default_environment:
  ## LOCALHOST: Bind services to a local IP address.
  - LOCALHOST=127.0.0.1
 
- - CHROME_BIN=$(which "chromium")
+ - CHROME_BIN=$(find-chrome)
+ - CHROME_PORT=9222
 
 #### Mandatory environment settings
 environment:

--- a/.loco/loco.yml
+++ b/.loco/loco.yml
@@ -50,6 +50,7 @@ default_environment:
  - LOCALHOST=127.0.0.1
 
  - CHROME_BIN=$(find-chrome)
+ - CHROME_HOST=${LOCALHOST}
  - CHROME_PORT=9222
 
 #### Mandatory environment settings
@@ -128,3 +129,16 @@ services:
     init:
       - 'loco-buildkit-init'
     message: 'Buildkit (<comment>$BKIT</comment>) is configured to use these services. It produces builds in "<comment>$HTTPD_VDROOT</comment>".'
+
+  ## Chrome is trickier - the choice of how to start depends a lot on context.
+  chrome:
+    enabled: false
+    run: 'loco-pid-file "$LOCO_SVC_VAR/chrome.pid" -- "$CHROME_BIN" --remote-debugging-address="$CHROME_HOST" --remote-debugging-port="$CHROME_PORT"'
+    pid_file : '$LOCO_SVC_VAR/chrome.pid'
+    message: 'Chrome (UI) is running on "<comment>http://$CHROME_HOST:$CHROME_PORT</comment>" to support automated testing.'
+
+  chrome-headless:
+    enabled: false
+    run: 'loco-pid-file "$LOCO_SVC_VAR/chrome-headless.pid" -- "$CHROME_BIN" --disable-gpu --headless --remote-debugging-address="$CHROME_HOST" --remote-debugging-port="$CHROME_PORT"'
+    pid_file : '$LOCO_SVC_VAR/chrome-headless.pid'
+    message: 'Chrome (headless) is running on "<comment>http://$CHROME_HOST:$CHROME_PORT</comment>" to support automated testing.'

--- a/.loco/plugin/find-chrome.php
+++ b/.loco/plugin/find-chrome.php
@@ -1,0 +1,42 @@
+<?php
+namespace Loco;
+
+function _find_chrome_which(string $name, array $paths): ?string {
+  foreach ($paths as $path) {
+    if (file_exists("$path/$name")) {
+      return "$path/$name";
+    }
+  }
+  return NULL;
+}
+
+Loco::dispatcher()->addListener('loco.expr.functions', function (LocoEvent $e) {
+
+  $e['functions']['find-chrome'] = function () {
+    $bin = getenv('CHROME_BIN');
+    if ($bin && file_exists($bin)) {
+      return $bin;
+    }
+
+    $paths = explode(PATH_SEPARATOR, getenv('PATH'));
+
+    $bin = _find_chrome_which('chromium', $paths);
+    if ($bin) {
+      return $bin;
+    }
+
+    $bin = _find_chrome_which('google-chrome-stable', $paths);
+    if ($bin) {
+      return $bin;
+    }
+
+    $paths = (array) glob("/Applications/*Chrome*/Contents/MacOS");
+    $bin = _find_chrome_which('Google Chrome', $paths);
+    if ($bin) {
+      return $bin;
+    }
+
+    return '';
+  };
+
+});

--- a/.loco/worker-n.yml
+++ b/.loco/worker-n.yml
@@ -32,6 +32,7 @@ environment:
  - MYSQLD_PORT=$(portnum "$BASE_PORT" "$EXECUTOR_NUMBER" 1)
  - PHPFPM_PORT=$(portnum "$BASE_PORT" "$EXECUTOR_NUMBER" 2)
  - REDIS_PORT=$(portnum "$BASE_PORT" "$EXECUTOR_NUMBER" 5)
+ - CHROME_PORT=$(portnum "$BASE_PORT" "$EXECUTOR_NUMBER" 7)
 
  ## XDEBUG_*: Enable or disable main XDebug options
  - XDEBUG_MODE=off
@@ -60,9 +61,10 @@ environment:
  - NODE_PATH=$BKIT/node_modules:$NODE_PATH
  - PATH=$BKIT/bin:$BKIT/node_modules/.bin:$LOCO_PRJ/.loco/bin:$PATH
  - CIVICRM_L10N_SYMLINK=1
+ - CHROME_HOST=${LOCALHOST}
 
 default_environment:
- - CHROME_BIN=$(which "chromium")
+ - CHROME_BIN=$(find-chrome)
 
 #### Functional service definitions
 services:
@@ -115,6 +117,9 @@ services:
       - 'mysql_tzinfo_to_sql "$TZDIR" | mysql mysql'
     message: 'Buildkit (<comment>$BKIT</comment>) is configured to use these services. It produces builds in "<comment>$HTTPD_VDROOT</comment>".'
 
+  chrome-headless:
+    run: 'loco-pid-file "$LOCO_SVC_VAR/chrome-headless.pid" -- "$CHROME_BIN" --disable-gpu --headless --remote-debugging-address="$CHROME_HOST" --remote-debugging-port="$CHROME_PORT"'
+    pid_file : '$LOCO_SVC_VAR/chrome-headless.pid'
 
 ## Configure the loco=>systemd export
 export:


### PR DESCRIPTION
This branch speaks to two scenarios of running buildkit-nix:

* For desktop usage (*default configuration, `.loco/loco.yml`*), you may want to manage Chrome yourself. (Because it's an interactive thing... and because you may already be using Chrome as your browser...) But this gives examples for how to auto-launch debuggable or headless instances. 
* For continuous-integration (`.loco/worker-n.yml`), always start+stop chrome as part of the test-run.

The main counter-point to this patch... `karma` already uses an autolaunch behavior for Chrome (*assign random port; start as part of the test-suite; end with the test-suite*). It doesn't expect any other process-manager (like `loco`).

* From DX POV, karma's approach a bit friendlier. It gives you something that works "out of the box" in more environments. (*You don't need to manually launch, and the autolaunch works in other environments*)
* From efficiency POV, it's better if phpunit+karma use the same pattern. Either *both* rely on `loco` to start Chrome; or *both*  their own short-lived Chrome instances. Mixing the approaches means (*as in the current PR*) means that we may get two copies of Chrome running at the same time. (*Loco will start its version unconditionally. Then karma will conditionally add another instance.*)