### PR TITLE
civibuild - Add support for option CIVICRM_L10N_SYMLINK

### DIFF
--- a/.loco/loco.yml
+++ b/.loco/loco.yml
@@ -62,6 +62,7 @@ environment:
  - NODE_PATH=$BKIT/node_modules:$NODE_PATH
  - PATH=$BKIT/bin:$BKIT/node_modules/.bin:$LOCO_PRJ/.loco/bin:$PATH
  - CIVICRM_COMPOSER_ASSET=symdir
+ - CIVICRM_L10N_SYMLINK=1
 
 volume:
   ramdisk: $RAMDISK_SIZE

--- a/.loco/worker-n.yml
+++ b/.loco/worker-n.yml
@@ -59,6 +59,7 @@ environment:
  - MYSQL_HOME=$LOCO_VAR/mysql/conf
  - NODE_PATH=$BKIT/node_modules:$NODE_PATH
  - PATH=$BKIT/bin:$BKIT/node_modules/.bin:$LOCO_PRJ/.loco/bin:$PATH
+ - CIVICRM_L10N_SYMLINK=1
 
 default_environment:
  - CHROME_BIN=$(which "chromium")

--- a/app/civibuild.conf.tmpl
+++ b/app/civibuild.conf.tmpl
@@ -57,6 +57,11 @@
 # VERBOSE=1
 
 #############################################################################
+## Example: Make one shared 'l10n' folder, with all builds using symlinks to it
+
+# CIVICRM_L10N_SYMLINK=1
+
+#############################################################################
 ## Example: Update civibuild's $PATH
 
 # PATH="$HOME/src/amp/bin:$PATH"

--- a/app/config/backdrop-clean/download.sh
+++ b/app/config/backdrop-clean/download.sh
@@ -21,7 +21,7 @@ pushd "$WEB_ROOT/web/modules" >> /dev/null
   git_cache_clone civicrm/civicrm-backdrop  -b "1.x-$CIVI_VERSION" civicrm/backdrop
   git_cache_clone civicrm/civicrm-packages  -b "$CIVI_VERSION"     civicrm/packages
 
-  extract-url --cache-ttl 172800 civicrm=http://download.civicrm.org/civicrm-l10n-core/archives/civicrm-l10n-daily.tar.gz
+  civicrm_l10n_setup civicrm
 
   git_set_hooks civicrm-drupal      civicrm/backdrop   "../tools/scripts/git"
   git_set_hooks civicrm-core        civicrm            "tools/scripts/git"

--- a/app/config/backdrop-demo/download.sh
+++ b/app/config/backdrop-demo/download.sh
@@ -29,7 +29,7 @@ pushd "$WEB_ROOT/web/modules" >> /dev/null
   git_cache_clone civicrm/org.civicrm.module.cividiscount     -b "$DISC_VERSION"      civicrm/tools/extensions/cividiscount
   git_cache_clone civicrm/org.civicrm.contactlayout           -b "master"             civicrm/tools/extensions/org.civicrm.contactlayout
   api4_download_conditional civicrm                                           civicrm/ext/api4
-  extract-url --cache-ttl 172800 civicrm=http://download.civicrm.org/civicrm-l10n-core/archives/civicrm-l10n-daily.tar.gz
+  civicrm_l10n_setup civicrm
   git_set_hooks civicrm-drupal      civicrm/backdrop   "../tools/scripts/git"
   git_set_hooks civicrm-core        civicrm            "tools/scripts/git"
   git_set_hooks civicrm-packages    civicrm/packages   "../tools/scripts/git"

--- a/app/config/caches.sh
+++ b/app/config/caches.sh
@@ -13,3 +13,5 @@
 
 ## Setup cache by ID (per git_cache_map)
 #git_cache_setup_id civicrm/civicrm-core civicrm/civicrm-packages
+
+civicrm_l10n_setup

--- a/app/config/drupal-clean/download.sh
+++ b/app/config/drupal-clean/download.sh
@@ -18,8 +18,7 @@ pushd "$WEB_ROOT/web"
     git_cache_clone "civicrm/civicrm-packages"                            -b "$CIVI_VERSION"      civicrm/packages
     api4_download_conditional civicrm                                                                civicrm/ext/api4
 
-    extract-url --cache-ttl 172800 civicrm=http://download.civicrm.org/civicrm-l10n-core/archives/civicrm-l10n-daily.tar.gz
-    ## or https://raw.github.com/civicrm/l10n/master/po/fr_CA/civicrm.mo => civicrm/l10n/fr_CA/LC_MESSAGES/
+    civicrm_l10n_setup civicrm
 
     civibuild_apply_user_extras
     pushd civicrm

--- a/app/config/drupal-demo/download.sh
+++ b/app/config/drupal-demo/download.sh
@@ -25,8 +25,7 @@ pushd "$WEB_ROOT/web"
     git_cache_clone "TechToThePeople/civisualize"                         -b "master"             civicrm/tools/extensions/civisualize
     git_cache_clone "civicrm/org.civicrm.module.cividiscount"             -b "$DISC_VERSION"      civicrm/tools/extensions/cividiscount
     git_cache_clone "civicrm/org.civicrm.contactlayout"                   -b "master"             civicrm/tools/extensions/org.civicrm.contactlayout
-    extract-url --cache-ttl 172800 civicrm=http://download.civicrm.org/civicrm-l10n-core/archives/civicrm-l10n-daily.tar.gz
-    ## or https://raw.github.com/civicrm/l10n/master/po/fr_CA/civicrm.mo => civicrm/l10n/fr_CA/LC_MESSAGES/
+    civicrm_l10n_setup civicrm
 
     civibuild_apply_user_extras
     pushd civicrm

--- a/app/config/drupal10-dev/download.sh
+++ b/app/config/drupal10-dev/download.sh
@@ -31,6 +31,8 @@ pushd "$WEB_ROOT" >> /dev/null
   composer config repositories.civicrm-packages '{"type": "path", "url": "./src/civicrm-packages", "options": { "symlink": false }}'
   ## The symlink:false helps when running the installation step. We should probably fix that...
 
+  civicrm_l10n_setup "src/civicrm-core"
+
   civibuild_apply_user_extras
   civicrm_download_composer_d8
 popd >> /dev/null

--- a/app/config/drupal9-dev/download.sh
+++ b/app/config/drupal9-dev/download.sh
@@ -30,6 +30,8 @@ pushd "$WEB_ROOT" >> /dev/null
   composer config repositories.civicrm-packages '{"type": "path", "url": "./src/civicrm-packages", "options": { "symlink": false }}'
   ## The symlink:false helps when running the installation step. We should probably fix that...
 
+  civicrm_l10n_setup "src/civicrm-core"
+
   civibuild_apply_user_extras
   civicrm_download_composer_d8
 popd >> /dev/null

--- a/app/config/standalone-dev/download.sh
+++ b/app/config/standalone-dev/download.sh
@@ -15,8 +15,7 @@ pushd "$WEB_ROOT"
   git_cache_clone civicrm/civicrm-core                             -b "$CIVI_VERSION" web/core
   git_cache_clone civicrm/civicrm-packages                         -b "$CIVI_VERSION" web/core/packages
 
-  extract-url --cache-ttl 172800 web/core=http://download.civicrm.org/civicrm-l10n-core/archives/civicrm-l10n-daily.tar.gz
-  ## or https://raw.github.com/civicrm/l10n/master/po/fr_CA/civicrm.mo => civicrm/l10n/fr_CA/LC_MESSAGES/
+  civicrm_l10n_setup web/core
 popd
 
 civibuild_apply_user_extras

--- a/app/config/wp-clean/download.sh
+++ b/app/config/wp-clean/download.sh
@@ -23,7 +23,7 @@ pushd "$WEB_ROOT/web/wp-content/plugins" >> /dev/null
   git_cache_clone civicrm/civicrm-packages                         -b "$CIVI_VERSION" civicrm/civicrm/packages
 
   cd civicrm
-  extract-url --cache-ttl 172800 civicrm=http://download.civicrm.org/civicrm-l10n-core/archives/civicrm-l10n-daily.tar.gz
+  civicrm_l10n_setup civicrm
   cd -
 
   git_set_hooks civicrm-wordpress   civicrm                    "../civicrm/tools/scripts/git"

--- a/app/config/wp-demo/download.sh
+++ b/app/config/wp-demo/download.sh
@@ -32,9 +32,9 @@ pushd "$WEB_ROOT/web/wp-content/plugins" >> /dev/null
   git_cache_clone civicrm/org.civicrm.module.cividiscount          -b master          civicrm/civicrm/tools/extensions/cividiscount
   git_cache_clone civicrm/org.civicrm.contactlayout                -b master          civicrm/civicrm/tools/extensions/org.civicrm.contactlayout
 
-  cd civicrm
-  extract-url --cache-ttl 172800 civicrm=http://download.civicrm.org/civicrm-l10n-core/archives/civicrm-l10n-daily.tar.gz
-  cd -
+#  cd civicrm
+  civicrm_l10n_setup civicrm/civicrm
+#  cd -
 
   git_set_hooks civicrm-wordpress   civicrm                    "../civicrm/tools/scripts/git"
   git_set_hooks civicrm-core        civicrm/civicrm            "../tools/scripts/git"

--- a/bin/civicrm-l10n-folder
+++ b/bin/civicrm-l10n-folder
@@ -1,0 +1,119 @@
+#!/usr/bin/env php
+<?php
+
+define('TAR_FILE_TTL', 30 * 60);
+define('TAR_URL', 'http://download.civicrm.org/civicrm-l10n-core/archives/civicrm-l10n-daily.tar.gz');
+main($argv);
+
+function main(array $argv) {
+  if (!isset($argv[1])) {
+    $program = basename($argv[0]);
+    printf("Download/update the l10n folder (if the folder is new or stale)");
+    printf("usage: %s <L10N_FOLDER> [<TTL_SECONDS>]\n", $program);
+    printf("\n");
+    printf("example: %s web/core/civicrm/l10n 86400\n", $program);
+    return 1;
+  }
+
+  $finalDir = $argv[1];
+  $workDir = dirname($finalDir) . '/.work-' . basename($finalDir);
+  $ttl = $argv[2] ?? (3 * 24 * 60 * 60);
+
+  if (!is_dir($workDir)) {
+    mkdir($workDir, 0777, TRUE);
+  }
+  $fp = fopen("$workDir/lock", "w");
+  if (flock($fp, LOCK_EX)) {
+    try {
+      runUpdate($workDir, $finalDir, $ttl);
+    } finally {
+      flock($fp, LOCK_UN);
+      fclose($fp);
+    }
+  }
+  else {
+    echo "Folder is already being updated by another process. Skipping update.\n";
+  }
+}
+
+function runUpdate(string $workDir, string $finalDir, int $ttl) {
+  $lastUpdateFile = "$workDir/last-update";
+  $newDir = "$workDir/new";
+  $archiveDir = "$workDir/old";
+  $tarFile = "$workDir/new.tar.gz";
+
+  if (file_exists($finalDir) && !empty(glob("$finalDir/??_??"))) {
+    if (file_exists($lastUpdateFile) && (time() - filemtime($lastUpdateFile)) < $ttl) {
+      return;
+    }
+    if (!file_exists("$finalDir/.auto-update")) {
+      return;
+    }
+  }
+
+  deleteDirectory($newDir);
+  deleteDirectory($archiveDir);
+
+  if (!file_exists($tarFile) || time() - filemtime($tarFile) > TAR_FILE_TTL) {
+    echo "Downloading " . (TAR_URL) . "...\n";
+    downloadFile(TAR_URL, $tarFile);
+  }
+
+  echo "Extracting to temporary directory...\n";
+  $phar = new PharData($tarFile);
+  if (!$phar->extractTo($newDir)) {
+    unlink($tarFile); /* Might be corrupted. If you re-run, download again. */
+    throw new \RuntimeException("Failed to extract $tarFile to $newDir");
+  }
+
+  if (!file_exists("$newDir/l10n/fr_FR/LC_MESSAGES/civicrm.mo")) {
+    unlink($tarFile); /* Might be corrupted. If you re-run, download again. */
+    throw new \RuntimeException("Malformed archive. Content missing!");
+  }
+  touch("$newDir/l10n/.auto-update");
+
+  echo "Swapping folders to finalize update...\n";
+  mkdir($archiveDir);
+  if (file_exists($finalDir)) {
+    rename($finalDir, "$archiveDir/l10n");
+  }
+  if (rename("$newDir/l10n", $finalDir) && touch($lastUpdateFile)) {
+    touch($lastUpdateFile);
+    echo "Update successful.\n";
+  }
+  else {
+    throw new \RuntimeException("Failed to install new folder!");
+  }
+}
+
+function deleteDirectory($dir) {
+  if (!is_dir($dir)) {
+    return FALSE;
+  }
+
+  $files = array_diff(scandir($dir), array('.', '..'));
+  foreach ($files as $file) {
+    (is_dir("$dir/$file")) ? deleteDirectory("$dir/$file") : unlink("$dir/$file");
+  }
+  return rmdir($dir);
+}
+
+function downloadFile(string $url, string $outputFile): void {
+  $fp = fopen($outputFile, 'w');
+  if (!$fp) {
+    throw new \RuntimeException("Unable to write to file ($outputFile).");
+  }
+
+  $ch = curl_init($url);
+  curl_setopt($ch, CURLOPT_FILE, $fp);
+  curl_setopt($ch, CURLOPT_FOLLOWLOCATION, TRUE); // Follow redirects if any
+  curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, FALSE); // Disable SSL verification for simplicity
+  curl_setopt($ch, CURLOPT_TIMEOUT, 60); // Adjust timeout as needed
+  curl_exec($ch);
+  if (curl_errno($ch)) {
+    throw new \RuntimeException('Error: ' . curl_error($ch));
+  }
+
+  curl_close($ch);
+  fclose($fp);
+}

--- a/src/civibuild.lib.sh
+++ b/src/civibuild.lib.sh
@@ -620,6 +620,33 @@ function civicrm_download_composer_d8() {
 }
 
 ###############################################################################
+## Setup CiviCRM l10n data folder
+##
+## usage: civicrm_l10n_setup [<TARGET_DIR>]
+## example: civicrm_l10n_setup web/sites/all/modules/civicrm
+##
+## Perform some mix of these tasks:
+## - Warmup relevant caches
+## - If "TARGET_DIR" is given, then make an l10n folder.
+##   (If CIVICRM_L10N_SYMLINK is enabled, then it's actually a symlink).
+function civicrm_l10n_setup() {
+  local target="$1"
+  if [ -n "$CIVICRM_L10N_SYMLINK" ]; then
+    civicrm-l10n-folder "$CACHE_DIR/civicrm/l10n"
+  fi
+
+  if [ -n "$target" ]; then
+    if [ -n "$CIVICRM_L10N_SYMLINK" ]; then
+      ln -sf "$CACHE_DIR/civicrm/l10n" "$target/l10n"
+    else
+      ## From refactoring POV, "extract-url" is what we've been using, so it's safer to drop-in this change.
+      ## Cache is also more attuned to non-shared folders.
+      extract-url --cache-ttl 172800 "$target=http://download.civicrm.org/civicrm-l10n-core/archives/civicrm-l10n-daily.tar.gz"
+    fi
+  fi
+}
+
+###############################################################################
 ## Generate config files and setup database
 function civicrm_install() {
   cvutil_assertvars civicrm_install CIVI_CORE CIVI_FILES CIVI_TEMPLATEC

--- a/src/civibuild.lib.sh
+++ b/src/civibuild.lib.sh
@@ -612,8 +612,9 @@ function civicrm_download_composer_d8() {
   ## "head -n1": If you install drupal{9,10}-dev, then there may be mutiple ways to get civicrm-version.php
   if [ -f "$civicrm_version_php" ]; then
     local civi_root=$(dirname "$civicrm_version_php")
-    #extract-url --cache-ttl 172800 vendor/civicrm/civicrm-core=http://download.civicrm.org/civicrm-l10n-core/archives/civicrm-l10n-daily.tar.gz ## Issue: Don't write directly into vendor tree
-    extract-url --cache-ttl 172800 "$civi_root=http://download.civicrm.org/civicrm-l10n-core/archives/civicrm-l10n-daily.tar.gz" ## Issue: Don't write directly into vendor tree
+    civicrm_l10n_setup "$civi_root"
+    ## FIXME: This goes under `vendor/` which can get reset. For something more persistent,
+    ## put it outside of 'vendor/' and update the installer to ensure that 'civicrm.settings.php' retains the alternate location.
   else
     cvutil_fatal "Cannot download l10n data - failed to locate civicrm-core"
   fi


### PR DESCRIPTION
Overview
------------

Adds an option, `CIVICRM_L10N_SYMLINK`. If enabled, new builds will use a shared l10n folder (based on symlinks).

Before
---------

* Most builds make a new copy of the `l10n` folder, which is large.

After
------

* By default, most builds still make a copy of `l10n/`.
* If you opt into `CIVICRM_L10N_SYMLINK`, then `l10n/` will be a symlink.

Comments
-------------

* The build-types `drupal{9,10}-dev` were added recently but accidentally omitted l10n data. This adds support.
* Any builds using bkinx (`nix-shell`/`loco`) will have the default switched to `CIVICRM_L10N_SYMLINK=1`.