### PR TITLE
civibuild - Allow running upgrade-test on Standalone

### DIFF
--- a/src/command/upgrade-test.run.sh
+++ b/src/command/upgrade-test.run.sh
@@ -1,5 +1,5 @@
 ## civicrm-upgrade-test only works with drush right now
-if grep -qi drupal "$CMS_ROOT/index.php" || grep -q backdrop "$CMS_ROOT/index.php" || [ -f "$CMS_ROOT/wp-config.php" ] ; then
+if grep -qi drupal "$CMS_ROOT/index.php" || grep -q backdrop "$CMS_ROOT/index.php" || [ -f "$CMS_ROOT/wp-config.php" ] || [ -f "$CMS_ROOT/civicrm.standalone.php" ] ; then
   cvutil_makeparent "$UPGRADE_LOG_DIR"
   cvutil_mkdir "$UPGRADE_LOG_DIR"
   pushd "$PRJDIR/vendor/civicrm/upgrade-test/databases" > /dev/null
@@ -7,5 +7,5 @@ if grep -qi drupal "$CMS_ROOT/index.php" || grep -q backdrop "$CMS_ROOT/index.ph
     ../bin/civicrm-upgrade-test --db "$CIVI_DB_NAME" --db-args "$CIVI_DB_ARGS" --web "$CMS_ROOT" --out "$UPGRADE_LOG_DIR" --junit-xml "$UPGRADE_LOG_DIR/civicrm-upgrade-test.xml" "${ARGS[@]:2}"
   popd > /dev/null
 else
-  echo "Skipped. civicrm-upgrade-test currently requires Drupal 7 or Backdrop and Drush."
+  echo "Skipped. civicrm-upgrade-test currently requires Drupal, Backdrop, WordPress, or Standalone."
 fi


### PR DESCRIPTION
Overview
------------

Upgrade-tests ensure that you can... run upgrades... in different environments. `civibuild upgrade-test`  (aka `civibuild ut`) can be used like:

```
civibuild create build-0 --type standalone-clean --civi-ver master 
civibuild ut build-0 /home/totten/bknix/vendor/civicrm/upgrade-test/databases/5.47.2-tz.mysql.bz2
```

This is a step toward upgrade-tests on Standalone.

Before
--------

Upgrade tests don't run on standalone. For example [this periodic test](https://test.civicrm.org/duderino/batch/CiviCRM-Dev-Periodic/20868034) fired [this task](https://test.civicrm.org/job/CiviCRM-Test-QLow/33228/console) which outputs:

```
[[Load saved options from /home/homer/buildkit/build/build-0.sh]]
Skipped. civicrm-upgrade-test currently requires Drupal 7 or Backdrop and Drush.
```

After
------

You aren't specifically blocked. But it doesn't actually work, either.

```
[[Load saved options from /home/totten/bknix/build/build-0.sh]]
Identify files: [ "/home/totten/bknix/vendor/civicrm/upgrade-test/databases/5.47.2-tz.mysql.bz2"]
/home/totten/bknix/vendor/civicrm/upgrade-test/databases/5.47.2-tz.mysql.bz2
Web Dir: [/home/totten/bknix/build/build-0/web]
Output Dir: [/home/totten/bknix/build/build-0/.civibuild/debug]
Database Name: [build0civi_7x1h1]

In Standalone.php line 519:
                                              
  Class "Civi\Standalone\Security" not found  
                                              

path [--out OUT] [--flat [FLAT]] [-T|--out=table] [-I|--out=list] [--columns COLUMNS] [-x|--ext EXT] [-c|--config CONFIG] [-d|--dynamic DYNAMIC] [-m|--mkdir] [--level LEVEL] [--hostname HOSTNAME] [-t|--test] [-U|--user USER]
```

Comments
---------------

So... it still doesn't actually work. But it gets a step further!

The next step is going to be trickier. I *think* the problem here is actually about the content of the database:

* The upgrade-tests are based on [a library of database snapshots](https://github.com/civicrm/civicrm-upgrade-test/tree/master/databases).
* For Drupal/WordPress, the process is like this:
    * Install CMS/UF. (This goes into one database, eg `uf_db`).
    * Load snapshot. (This goes into another dbase, eg `civicrm_db`.)
    * Run `cv upgrade:db`
* But for standalone:
    * We only have one database. It contains both UF content and CRM content.
    * Whenever you load the snapshot, it resets the database.
    * Thus, loading `5.47.2-tz.mysql.bz2` destroys UF content (eg `standaloneusers`). You get an unusable system.
* Maintaining a snapshot library is a bit of work. (Which is why we don't update it very often...) So it seems useful for "Standalone" to leverage the same snapshot library as Drupal/WordPress. I suppose that means we need to find some way to splice together DB snapshot along with standalone's distinctive content. (*Maybe support split DB? Or maybe have some kind of filtering based on table-names? With something special for `civicrm_extension?*)
* This isn't the original goal, but there is a similar problem -- migration. You start out with a D7/WP site, backup the database to a file, and then load the database for a new standalone deployment. You need some way to fill-in the standalone pieces.