### PR TITLE
standalone-composer - Fix support for `--civi-ver` flag

### DIFF
--- a/app/config/standalone-composer/download.sh
+++ b/app/config/standalone-composer/download.sh
@@ -4,7 +4,7 @@
 
 ###############################################################################
 
-echo $CMS_VERSION
+[ -z "$CIVI_VERSION" ] && CIVI_VERSION=master
 [ -z "$CMS_VERSION" ] && CMS_VERSION=master
 ## Interpreted as tag/branch of "civicrm-standalone.git".
 ## May use git remotes to referencing Github ("{user}/{branch}").
@@ -20,6 +20,14 @@ pushd "$WEB_ROOT/web"
   git checkout "$CMS_VERSION"
 
   amp datadir "./private" "./public" "./ext"
-  composer install
+
+  ## `civicrm-standalone.git:composer.json` is hard-coded to master. If user requests anything else, then we must update it.
+  if [ "$CIVI_VERSION" == "master" ]; then
+    composer install
+  else
+    CIVI_VERSION_COMP=$(civicrm_composer_ver "$CIVI_VERSION")
+    composer require civicrm/civicrm-{core,packages}:"$CIVI_VERSION_COMP" --prefer-source
+  fi
+
   composer civicrm:publish
 popd


### PR DESCRIPTION
Overview
--------

I was recently surprised to see new test failures on the 5.75-stable test-matrix regarding Standalone... even though there were no relevant changes. The problem? It wasn't actually running tests on 5.75. It was running them on master (regardless of requested version).

This updates `standalone-composer` to respect the requested version.

Steps to Reproduce
------------------

```
civibuild create standalone-composer --civi-ver 5.75`
```

Before
------

It ignores the requested version (5.75) and installs `master`.

After
-----

IT respects the requested version. (But in absence of a version, it preserves the default `master`.)