### PR TITLE
Add MySQL 8.4.1

### DIFF
--- a/.loco/bin/loco-mysql-init
+++ b/.loco/bin/loco-mysql-init
@@ -11,7 +11,7 @@ php "$LOCO_CFG/mysql-common/my.cnf.php" > "$LOCO_SVC_VAR"/conf/common-my.cnf
 if echo "$mysql_version" | grep 'Distrib 5.7' -q; then
   mysqld --defaults-file="$LOCO_SVC_VAR/conf/my.cnf" --initialize-insecure --explicit_defaults_for_timestamp --datadir="$LOCO_SVC_VAR/data"
 
-elif echo "$mysql_version" | grep 'Ver 8.0' -q; then
+elif echo "$mysql_version" | grep 'Ver 8.' -q; then
   #mysqld --no-defaults --initialize-insecure --explicit_defaults_for_timestamp --datadir="$LOCO_SVC_VAR/data"
   mysqld --defaults-file="$LOCO_SVC_VAR/conf/my.cnf" --initialize-insecure --explicit_defaults_for_timestamp --datadir="$LOCO_SVC_VAR/data"
 

--- a/.loco/config/mysql-common/my.cnf.php
+++ b/.loco/config/mysql-common/my.cnf.php
@@ -18,14 +18,14 @@ read_buffer_size = 1M
 read_rnd_buffer_size = 4M
 myisam_sort_buffer_size = 64M
 thread_cache_size = 8
-<?php if (!matchVer('/Ver 8.0/')) { printf("query_cache_size= 16M\n"); } ?>
-<?php if (matchVer('/Ver 8.0/')) { printf("default_authentication_plugin = mysql_native_password\n"); } ?>
+<?php if (!matchVer('/Ver 8.\d/')) { printf("query_cache_size= 16M\n"); } ?>
+<?php if (matchVer('/Ver 8.\d/')) { printf("default_authentication_plugin = mysql_native_password\n"); } ?>
 # Try number of CPU's*2 for thread_concurrency
 #MariaDB?# thread_concurrency = 8
 
 binlog_format	= row
 sync_binlog	= 1
-<?php if (matchVer('/Ver 8.0/')) { printf("skip-log-bin\n"); } ?>
+<?php if (matchVer('/Ver 8.\d/')) { printf("skip-log-bin\n"); } ?>
 
 innodb_file_per_table = 1
 # You can set .._buffer_pool_size up to 50 - 80 %
@@ -39,7 +39,7 @@ innodb_file_per_table = 1
 
 <?php if (matchVer('/Ver 5.6/')) { printf("innodb_large_prefix = 1\n"); } ?>
 <?php if (matchVer('/Ver 5.6/')) { printf("sql_mode=\"STRICT_TRANS_TABLES,NO_ENGINE_SUBSTITUTION\"\n"); } ?>
-<?php if (!matchVer('/Ver 8.0/')) { printf("innodb_file_format = Barracuda\n"); } ?>
+<?php if (!matchVer('/Ver 8.\d/')) { printf("innodb_file_format = Barracuda\n"); } ?>
 
 <?php if (matchVer('/Ver 5.7/')) { ?>
 # https://expressionengine.com/blog/mysql-5.7-server-os-x-has-gone-away

--- a/.loco/config/mysql-common/my.cnf.php
+++ b/.loco/config/mysql-common/my.cnf.php
@@ -19,7 +19,8 @@ read_rnd_buffer_size = 4M
 myisam_sort_buffer_size = 64M
 thread_cache_size = 8
 <?php if (!matchVer('/Ver 8.\d/')) { printf("query_cache_size= 16M\n"); } ?>
-<?php if (matchVer('/Ver 8.\d/')) { printf("default_authentication_plugin = mysql_native_password\n"); } ?>
+<?php if (matchVer('/Ver (8.4|9.\d)/')) { printf("mysql_native_password = ON\n"); } ?>
+<?php if (matchVer('/Ver 8.[0123]/')) { printf("default_authentication_plugin = mysql_native_password\n"); } ?>
 # Try number of CPU's*2 for thread_concurrency
 #MariaDB?# thread_concurrency = 8
 

--- a/nix/pins/24.05.nix
+++ b/nix/pins/24.05.nix
@@ -1,0 +1,12 @@
+/**
+ * v24.05
+ */
+fetchTarball {
+  ## Official backports circa Jul 23, 2024
+  url = "https://github.com/nixos/nixpkgs/archive/4027bf72e183f21cae770e24b467cbc5ce52edd1.tar.gz";
+  sha256 = "18n10x7vcy1x14d37flpxn3nl30sm23jxa060rfajljcc4xw0k02";
+
+  ## Original release
+  #  url = "https://github.com/nixos/nixpkgs/archive/5646423bfac84ec68dfc60f2a322e627ef0d6a95.tar.gz";
+  #  sha256 = "1lr1h35prqkd1mkmzriwlpvxcb34kmhc9dnr48gkm8hh089hifmx";
+}

--- a/nix/pins/default.nix
+++ b/nix/pins/default.nix
@@ -10,6 +10,7 @@ rec {
   v2205 = import (import  ./22.05.nix) {};
   v2305 = import (import  ./23.05.nix) {};
   v2311 = import (import  ./23.11.nix) {};
+  v2405 = import (import  ./24.05.nix) {};
 
   bkit = import ../pkgs;
   default = v2205;

--- a/nix/pkgs/default.nix
+++ b/nix/pkgs/default.nix
@@ -30,6 +30,7 @@ in pharDirectives // rec {
    mysql56 = (import ./mysql56/default.nix).mysql56;
    mysql57 = dists.default.mysql57;
    mysql80 = dists.default.mysql80;
+   mysql84 = dists.v2405.mysql84;
    mariadb105 = dists.v2105.mariadb;
    mariadb106 = dists.default.mariadb;
 

--- a/nix/profiles/default.nix
+++ b/nix/profiles/default.nix
@@ -31,31 +31,37 @@ in rec {
 
    php73m57 = phpXXmXX { php = dists.bkit.php73; dbms = dists.bkit.mysql57; };
    php73m80 = phpXXmXX { php = dists.bkit.php73; dbms = dists.bkit.mysql80; };
+   php73m84 = phpXXmXX { php = dists.bkit.php73; dbms = dists.bkit.mysql84; };
    php73r105 = phpXXmXX { php = dists.bkit.php73; dbms = dists.bkit.mariadb105; };
    php73r106 = phpXXmXX { php = dists.bkit.php73; dbms = dists.bkit.mariadb106; };
 
    php74m57 = phpXXmXX { php = dists.bkit.php74; dbms = dists.bkit.mysql57; };
    php74m80 = phpXXmXX { php = dists.bkit.php74; dbms = dists.bkit.mysql80; };
+   php74m84 = phpXXmXX { php = dists.bkit.php74; dbms = dists.bkit.mysql84; };
    php74r105 = phpXXmXX { php = dists.bkit.php74; dbms = dists.bkit.mariadb105; };
    php74r106 = phpXXmXX { php = dists.bkit.php74; dbms = dists.bkit.mariadb106; };
 
    php80m57 = phpXXmXX { php = dists.bkit.php80; dbms = dists.bkit.mysql57; };
    php80m80 = phpXXmXX { php = dists.bkit.php80; dbms = dists.bkit.mysql80; };
+   php80m84 = phpXXmXX { php = dists.bkit.php80; dbms = dists.bkit.mysql84; };
    php80r105 = phpXXmXX { php = dists.bkit.php80; dbms = dists.bkit.mariadb105; };
    php80r106 = phpXXmXX { php = dists.bkit.php80; dbms = dists.bkit.mariadb106; };
 
    php81m57 = phpXXmXX { php = dists.bkit.php81; dbms = dists.bkit.mysql57; };
    php81m80 = phpXXmXX { php = dists.bkit.php81; dbms = dists.bkit.mysql80; };
+   php81m84 = phpXXmXX { php = dists.bkit.php81; dbms = dists.bkit.mysql84; };
    php81r105 = phpXXmXX { php = dists.bkit.php81; dbms = dists.bkit.mariadb105; };
    php81r106 = phpXXmXX { php = dists.bkit.php81; dbms = dists.bkit.mariadb106; };
 
    php82m57 = phpXXmXX { php = dists.bkit.php82; dbms = dists.bkit.mysql57; };
    php82m80 = phpXXmXX { php = dists.bkit.php82; dbms = dists.bkit.mysql80; };
+   php82m84 = phpXXmXX { php = dists.bkit.php82; dbms = dists.bkit.mysql84; };
    php82r105 = phpXXmXX { php = dists.bkit.php82; dbms = dists.bkit.mariadb105; };
    php82r106 = phpXXmXX { php = dists.bkit.php82; dbms = dists.bkit.mariadb106; };
 
    php83m57 = phpXXmXX { php = dists.bkit.php83; dbms = dists.bkit.mysql57; };
    php83m80 = phpXXmXX { php = dists.bkit.php83; dbms = dists.bkit.mysql80; };
+   php83m84 = phpXXmXX { php = dists.bkit.php83; dbms = dists.bkit.mysql84; };
    php83r105 = phpXXmXX { php = dists.bkit.php83; dbms = dists.bkit.mariadb105; };
    php83r106 = phpXXmXX { php = dists.bkit.php83; dbms = dists.bkit.mariadb106; };
 


### PR DESCRIPTION
Changes
----------
Add the package `mysql84` (8.4.1) from nixpkgs v24.05. 

Declare additional profiles:

* php74m84
* php80m84
* php81m84
* php82m84
* php83m84

Comments
-----------

@seamuslee001 In 8.4, they're phasing-out `default_authentication_plugin = mysql_native_password`. This doc (https://dev.mysql.com/doc/refman/8.4/en/mysql-nutshell.html#mysql-nutshell-deprecations) indicates that you can continue with another option (`mysql_native_password = ON`), so I put that in to get going.

But that seems like it's just overriding the deprecation. It's not clear what you're actually *supposed* to do instead...