### PR TITLE
nix-shell - Update default prompt

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -10,6 +10,8 @@ let
       name = "bknix";
       buildInputs = packageList ++ [ pkgs.makeWrapper ];
       shellHook = ''
+        PS1='\n\[\033[1;32m\][${profileName}:\w]\$\[\033[0m\] '
+
         if [ ! -f ".loco/loco.yml" -a -f "../.loco/loco.yml" ]; then
           cd ..
         fi


### PR DESCRIPTION
__Before__

```
me@host:~/buildkit$ nix-shell -A php84m80
[nix-shell:~/buildkit]$
```

__After__

```
me@host:~/buildkit$ nix-shell -A php84m80
[php84m80:~/buildkit]$
```

__Comment__

This patch is primarily about using `nix-shell` (real-time loading of config).

I also tested `install-developer.sh` / `use-bknix` (where profiles are installed durably) -- because that has its own `PS1`. In my testing, this change did not affect that prompt. Which seems just as well.