### PR TITLE
drupal10-dev (etal) - Fix conflict re:psr/simple-cache

### DIFF
--- a/src/civibuild.lib.sh
+++ b/src/civibuild.lib.sh
@@ -608,7 +608,7 @@ function civicrm_download_composer_d8() {
     *) echo 'No Extra Patch required' ; ;;
   esac
 
-  composer require "${EXTRA_COMPOSER[@]}" civicrm/civicrm-{core,packages,drupal-8}:"$CIVI_VERSION_COMP" --prefer-source
+  composer require "${EXTRA_COMPOSER[@]}" civicrm/civicrm-{core,packages,drupal-8}:"$CIVI_VERSION_COMP" --prefer-source -W
   [ -n "$EXTRA_PATCH" ] && git scan am -N "${EXTRA_PATCH[@]}"
 
   if [ -z "$CIVI_ROOT" ]; then


### PR DESCRIPTION
There was a new major update of `drush` (v13) which brings in different dependencies. The dependencies should still be compatible (at the end of the day), but they're more sensitive about installation order. This affects builds like:

```
civibuild download tmp --type drupal10-dev
```

Before
------

After install Drupal and Drush, it next tries to install CiviCRM (civicrm_download_composer_d8). This fails:

```

Running composer update civicrm/civicrm-core civicrm/civicrm-packages civicrm/civicrm-drupal-8
Loading composer repositories with package information
Updating dependencies
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Root composer.json requires civicrm/civicrm-core 5.75.x-dev -> satisfiable by civicrm/civicrm-core[5.75.x-dev].
    - civicrm/civicrm-core 5.75.x-dev requires psr/simple-cache ~1.0.1 -> found psr/simple-cache[1.0.1] but the package is fixed to 3.0.0 (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command.
  Problem 2
    - civicrm/civicrm-core 5.75.x-dev requires psr/simple-cache ~1.0.1 -> found psr/simple-cache[1.0.1] but the package is fixed to 3.0.0 (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command.
    - civicrm/civicrm-drupal-8 5.75.x-dev requires civicrm/civicrm-core >=5.21.0 || dev-master -> satisfiable by civicrm/civicrm-core[5.75.x-dev].
    - Root composer.json requires civicrm/civicrm-drupal-8 5.75.x-dev -> satisfiable by civicrm/civicrm-drupal-8[5.75.x-dev].

Use the option --with-all-dependencies (-W) to allow upgrades, downgrades and removals for packages currently locked to specific versions.

Installation failed, reverting ./composer.json and ./composer.lock to their original content.
```

After
-----

It works. Less sensitive about order-of-operations.