### PR TITLE
civi-test-run - Send PHPUnit notes to STDERR. Fix garbage output on Backdrop.

### DIFF
--- a/bin/civi-test-run
+++ b/bin/civi-test-run
@@ -6,15 +6,15 @@ function getPhpunitVer() {
   if [ -n "$PHPUNIT" ]; then
     case "$PHPUNIT" in
       phpunit5)
-        echo "$PHPUNIT --tap"
+        echo "$PHPUNIT --stderr --tap"
         return
         ;;
       phpunit6|phpunit7|phpunit8)
-        echo "$PHPUNIT --printer \Civi\Test\TAP"
+        echo "$PHPUNIT --stderr --printer \Civi\Test\TAP"
         return
         ;;
       phpunit9)
-        echo "$PHPUNIT --printer \Civi\Test\TAP"
+        echo "$PHPUNIT --stderr --printer \Civi\Test\TAP"
         return
         ;;
     esac
@@ -22,13 +22,13 @@ function getPhpunitVer() {
 
   CIVIVER=$(getCiviVer)
   if [ $(php -r "echo version_compare('$CIVIVER', '5.65', '>=');") ]; then
-    echo "phpunit9 --printer \Civi\Test\TAP"
+    echo "phpunit9 --stderr --printer \Civi\Test\TAP"
   elif [ $(php -r "echo version_compare('$CIVIVER', '5.39', '>=');") ]; then
-    echo "phpunit8 --printer \Civi\Test\TAP"
+    echo "phpunit8 --stderr --printer \Civi\Test\TAP"
   elif [ $(php -r "echo version_compare('$CIVIVER', '5.28', '>=');") ]; then
-    echo "phpunit7 --printer \Civi\Test\TAP"
+    echo "phpunit7 --stderr --printer \Civi\Test\TAP"
   elif [ $(php -r "echo version_compare('$CIVIVER', '5.22', '>=');") ]; then
-    echo "phpunit6 --printer \Civi\Test\TAP"
+    echo "phpunit6 --stderr --printer \Civi\Test\TAP"
   else
     echo 'phpunit5 --tap'
   fi


### PR DESCRIPTION
Overview
--------

This fixes a bunch of long warnings that arise when testing on Backdrop.

Before
------

When phpunit first starts up, it sends some initial notifications (such as version/copyright) to STDOUT.

Internally, PHP interprets this as *the beginning of a session*.

When Backdrop is subsequently loaded into the same process (for E2E testing), it tries to configure session/cookie policies (`ini_set(...)`). This leads to warnings:

```
Warning: ini_set(): Session ini settings cannot be changed after headers have already been sent in /home/homer/buildkit/build/build-1/web/core/includes/bootstrap.inc on line 749

Warning: ini_set(): Session ini settings cannot be changed after headers have already been sent in /home/homer/buildkit/build/build-1/web/core/includes/bootstrap.inc on line 750

Warning: ini_set(): Session ini settings cannot be changed after headers have already been sent in /home/homer/buildkit/build/build-1/web/core/includes/bootstrap.inc on line 751

Warning: ini_set(): Session ini settings cannot be changed after headers have already been sent in /home/homer/buildkit/build/build-1/web/core/includes/bootstrap.inc on line 754

Warning: ini_set(): Session ini settings cannot be changed after headers have already been sent in /home/homer/buildkit/build/build-1/web/core/includes/bootstrap.inc on line 756

Warning: ini_set(): Session ini settings cannot be changed after headers have already been sent in /home/homer/buildkit/build/build-1/web/settings.php on line 188

Warning: ini_set(): Session ini settings cannot be changed after headers have already been sent in /home/homer/buildkit/build/build-1/web/settings.php on line 189

Warning: ini_set(): Session ini settings cannot be changed after headers have already been sent in /home/homer/buildkit/build/build-1/web/settings.php on line 197

Warning: ini_set(): Session ini settings cannot be changed after headers have already been sent in /home/homer/buildkit/build/build-1/web/settings.php on line 204
```

In some arrangements, these warnings may produce long backtraces.

After
-----

When phpunit first starts up, it sends the initial notifications to STDERR.

Backdrop is able to run `ini_set()` without errors or warnings.

Comments
--------------

Running full suite can be a bit slow. Here's what I've used to get quicker feedback:

```bash
cd ~/bknix/build/bcmaster/web/modules/civicrm/ext/afform/mock

phpunit9 tests/phpunit/E2E/AfformMock/MockPublicFormTest.php --filter testGetPage 

phpunit9 --stderr tests/phpunit/E2E/AfformMock/MockPublicFormTest.php --filter testGetPage 
```

On its own, this patch doesn't quite resolve *all* warnings. There's also https://github.com/civicrm/cv/pull/205