### PR TITLE
Update `cv` test. Relax PATH precedence. Allow quicker deployments.

### DIFF
--- a/bin/civibuild
+++ b/bin/civibuild
@@ -18,8 +18,10 @@ PRJDIR=$(dirname "$BINDIR")
 [ -z "$CIVIBUILD_HOME" ] && TMPDIR="$PRJDIR/app/tmp" || TMPDIR="$CIVIBUILD_HOME/.civibuild/tmp"
 [ -z "$CIVIBUILD_HOME" ] && BLDDIR="$PRJDIR/build" || BLDDIR="$CIVIBUILD_HOME"
 
-## Make sure bundled utilities are available, regardless of local config
-export PATH="$BINDIR:$PATH"
+## Make sure bundled utilities are available
+if [[ ":$PATH:" != *":$BINDIR:"* ]]; then
+  export PATH="$BINDIR:$PATH"
+fi
 
 if [ -z "$OFFLINE" ]; then
   civi-download-tools --quiet

--- a/bin/civihydra
+++ b/bin/civihydra
@@ -17,8 +17,10 @@ PRJDIR=$(dirname "$BINDIR")
 [ -z "$CIVIBUILD_HOME" ] && TMPDIR="$PRJDIR/app/tmp" || TMPDIR="$CIVIBUILD_HOME/.civibuild/tmp"
 [ -z "$CIVIBUILD_HOME" ] && BLDDIR="$PRJDIR/build" || BLDDIR="$CIVIBUILD_HOME"
 
-## Make sure bundled utilities are available, regardless of local config
-export PATH="$BINDIR:$PATH"
+## Make sure bundled utilities are available
+if [[ ":$PATH:" != *":$BINDIR:"* ]]; then
+  export PATH="$BINDIR:$PATH"
+fi
 
 source "$PRJDIR/src/civibuild.lib.sh"
 

--- a/src/jobs/CiviCRM-Cv-Test.job
+++ b/src/jobs/CiviCRM-Cv-Test.job
@@ -57,6 +57,21 @@ case "$CIVIVER" in
   *) civibuild download "$BLDNAME" --civi-ver "$CIVIVER" --type "$BLDTYPE" ; ;;
 esac
 
+## Setup cv and run tests
+## TODO: Try downloading cv before building the site. Figure a way to override the live cv.phar.
+mkdir -p "$BKITBLD/$BLDNAME/src"
+git clone "https://github.com/civicrm/cv" "$BKITBLD/$BLDNAME/src/cv"
+pushd "$BKITBLD/$BLDNAME/src/cv"
+  if [ -n "$PATCH" ]; then
+    echo "Apply patch ($PATCH)"
+    git scan am -N "$PATCH"
+  fi
+  nix-shell --run ./scripts/build.sh ## Must use PHP version as required by `box`
+  mkdir -p dist/bin
+  cp bin/cv.phar dist/bin/cv
+  PATH="$PWD/dist/bin:$PATH"
+popd
+
 ## Install application (with civibuild)
 civibuild install "$BLDNAME" \
   --admin-pass "n0ts3cr3t"
@@ -67,19 +82,6 @@ civibuild show "$BLDNAME" \
   --last-scan "$WORKSPACE_BUILD/last-scan.json" \
   --new-scan "$WORKSPACE_BUILD/new-scan.json"
 cp "$WORKSPACE_BUILD/new-scan.json" "$WORKSPACE_BUILD/last-scan.json"
-
-## Setup cv and run tests
-## TODO: Try downloading cv before building the site. Figure a way to override the live cv.phar.
-mkdir -p "$BKITBLD/$BLDNAME/src"
-
-git clone "https://github.com/civicrm/cv" "$BKITBLD/$BLDNAME/src/cv"
-
-pushd "$BKITBLD/$BLDNAME/src/cv"
-  if [ -n "$PATCH" ]; then
-    echo "Apply patch ($PATCH)"
-    git scan am -N "$PATCH"
-  fi
-popd
 
 pushd "$BKITBLD/$BLDNAME/src/cv"
   composer install


### PR DESCRIPTION
The last `cv` update introduced a regression with a cascade affect -- where it prevents other tests on `cv.git` from running. This branches has a few changes to deal with that:

1. Update the `cv` tests. The initial setup (*before running actual test-suite*) depends on the old version `cv`. It should use the new flavor of `cv`.
2. To facilitate ^^^, relax the rules on when `civibuild` will force you to use the bundled binaries.
3. Add an option to help deploy ^^^ to CI nodes more quickly.