### PR TITLE
standalone-clean - Flipperoo el directorio à son époque

### DIFF
--- a/app/config/standalone-clean/download.sh
+++ b/app/config/standalone-clean/download.sh
@@ -15,7 +15,7 @@ pushd "$WEB_ROOT/web"
   git_cache_clone civicrm/civicrm-core                             -b "$CIVI_VERSION" core
   git_cache_clone civicrm/civicrm-packages                         -b "$CIVI_VERSION" core/packages
 
-  civicrm_l10n_setup core
+  civicrm_l10n_setup private
 popd
 
 civibuild_apply_user_extras


### PR DESCRIPTION
Overview
----------

Fix test failures involving `testLocalizedData` on Standalone.

Technical Details
------------------

Follow-up to civicrm/civicrm-core#29960. 29960 changed *all* standalone deployments to use `private/l10n` instead of `core/l10n`. This is probably a better default for localized/self-managed sites (*e.g. it should fit in better with `uplang`*) but not universal good (*e.g. encouraging multiple copies of 60mb archive*). Still, for `civibuild`, it's fine to match that kind of deployment (*and symlinks mitigate size*). 

In any event, we didn't catch the change as part of 29960 / #860, so tests have been failing.

I also tested `cv core:install` in this layout with some alternate locales and confirmed that it does pick up translations.