### PR TITLE
update wp-demo to include missing extensions

### DIFF
--- a/app/config/wp-demo/download.sh
+++ b/app/config/wp-demo/download.sh
@@ -27,6 +27,8 @@ pushd "$WEB_ROOT/web/wp-content/plugins" >> /dev/null
   git_cache_clone civicrm/civicrm-packages                         -b "$CIVI_VERSION" civicrm/civicrm/packages
   api4_download_conditional civicrm/civicrm                                              civicrm/civicrm/ext/api4
   git_cache_clone civicrm/civicrm-demo-wp                          -b master          civicrm-demo-wp
+  git clone ${CACHE_DIR}/civicrm/civivolunteer.git                    -b "$VOL_VERSION"  civicrm/civicrm/tools/extensions/civivolunteer
+  git clone ${CACHE_DIR}/ginkgostreet/org.civicrm.angularprofiles.git -b "$NG_PRFL_VERSION" civicrm/civicrm/tools/extensions/org.civicrm.angularprofiles
   git_cache_clone civicrm/org.civicoop.civirules                   -b master          civicrm/civicrm/tools/extensions/org.civicoop.civirules
   git_cache_clone TechToThePeople/civisualize                      -b master          civicrm/civicrm/tools/extensions/civisualize
   git_cache_clone civicrm/org.civicrm.module.cividiscount          -b master          civicrm/civicrm/tools/extensions/cividiscount

--- a/app/config/wp-demo/install.sh
+++ b/app/config/wp-demo/install.sh
@@ -157,6 +157,17 @@ wp eval '$c=[civi_wp()->users->set_wp_user_capabilities()];if (is_callable($c)) 
 ## Force basepage
 wp eval '$c=[civi_wp()->basepage->create_wp_basepage()];if (is_callable($c)) $c();'
 
+## Setup demo extensions
+cv en --ignore-missing $CIVI_DEMO_EXTS
+if [[ "$CIVI_DEMO_EXTS" =~ volunteer ]]; then
+  wp cap add civicrm_admin \
+    register to volunteer \
+    log own hours \
+    create volunteer projects \
+    edit own volunteer projects \
+    delete own volunteer projects
+fi
+
 ## Demo sites always disable email and often disable cron
 wp civicrm api StatusPreference.create ignore_severity=critical name=checkOutboundMail
 wp civicrm api StatusPreference.create ignore_severity=critical name=checkLastCron


### PR DESCRIPTION
Add changes to wp-demo to ignore missing ext dependencies and add back missing extensions.

@totten `git_cache_clone` did not work for me, do I need to update a different file to use that?

These are changes in my local environment that I think should be in the repo. 
