### PR TITLE
drupal{9,10}-dev - Enable symlink for core code

### DIFF
--- a/app/config/drupal10-dev/download.sh
+++ b/app/config/drupal10-dev/download.sh
@@ -26,10 +26,11 @@ pushd "$WEB_ROOT" >> /dev/null
   git_cache_clone "civicrm/civicrm-core"                                -b "$CIVI_VERSION"      src/civicrm-core
   git_cache_clone "civicrm/civicrm-drupal-8"                            -b "$CIVI_VERSION"      src/civicrm-drupal-8
   git_cache_clone "civicrm/civicrm-packages"                            -b "$CIVI_VERSION"      src/civicrm-packages
-  composer config repositories.civicrm-core '{"type": "path", "url": "./src/civicrm-core", "options": { "symlink": false } }'
-  composer config repositories.civicrm-drupal-8 '{"type": "path", "url": "./src/civicrm-drupal-8", "options": { "symlink": false }}'
-  composer config repositories.civicrm-packages '{"type": "path", "url": "./src/civicrm-packages", "options": { "symlink": false }}'
-  ## The symlink:false helps when running the installation step. We should probably fix that...
+
+  if civicrm_check_requested_ver '<' 5.81.alpha1 ; then _composer_symlink=false ; else _composer_symlink=true ; fi
+  composer config repositories.civicrm-core '{"type": "path", "url": "./src/civicrm-core", "options": { "symlink": '$_composer_symlink' } }'
+  composer config repositories.civicrm-drupal-8 '{"type": "path", "url": "./src/civicrm-drupal-8", "options": { "symlink": '$_composer_symlink' }}'
+  composer config repositories.civicrm-packages '{"type": "path", "url": "./src/civicrm-packages", "options": { "symlink": '$_composer_symlink' }}'
 
   civibuild_apply_user_extras
   civicrm_download_composer_d8 vendor/civicrm/civicrm-core

--- a/app/config/drupal9-dev/download.sh
+++ b/app/config/drupal9-dev/download.sh
@@ -25,10 +25,11 @@ pushd "$WEB_ROOT" >> /dev/null
   git_cache_clone "civicrm/civicrm-core"                                -b "$CIVI_VERSION"      src/civicrm-core
   git_cache_clone "civicrm/civicrm-drupal-8"                            -b "$CIVI_VERSION"      src/civicrm-drupal-8
   git_cache_clone "civicrm/civicrm-packages"                            -b "$CIVI_VERSION"      src/civicrm-packages
-  composer config repositories.civicrm-core '{"type": "path", "url": "./src/civicrm-core", "options": { "symlink": false } }'
-  composer config repositories.civicrm-drupal-8 '{"type": "path", "url": "./src/civicrm-drupal-8", "options": { "symlink": false }}'
-  composer config repositories.civicrm-packages '{"type": "path", "url": "./src/civicrm-packages", "options": { "symlink": false }}'
-  ## The symlink:false helps when running the installation step. We should probably fix that...
+
+  if civicrm_check_requested_ver '<' 5.81.alpha1 ; then _composer_symlink=false ; else _composer_symlink=true ; fi
+  composer config repositories.civicrm-core '{"type": "path", "url": "./src/civicrm-core", "options": { "symlink": '$_composer_symlink' } }'
+  composer config repositories.civicrm-drupal-8 '{"type": "path", "url": "./src/civicrm-drupal-8", "options": { "symlink": '$_composer_symlink' }}'
+  composer config repositories.civicrm-packages '{"type": "path", "url": "./src/civicrm-packages", "options": { "symlink": '$_composer_symlink' }}'
 
   civibuild_apply_user_extras
   civicrm_download_composer_d8 vendor/civicrm/civicrm-core

--- a/src/civibuild.lib.sh
+++ b/src/civibuild.lib.sh
@@ -608,7 +608,8 @@ function civicrm_download_composer_d8() {
     *) echo 'No Extra Patch required' ; ;;
   esac
 
-  composer require "${EXTRA_COMPOSER[@]}" civicrm/civicrm-{core,packages,drupal-8}:"$CIVI_VERSION_COMP" --prefer-source -W
+  composer config 'preferred-install.civicrm/*' source
+  composer require "${EXTRA_COMPOSER[@]}" civicrm/civicrm-{core,packages,drupal-8}:"$CIVI_VERSION_COMP" -W
   [ -n "$EXTRA_PATCH" ] && git scan am -N "${EXTRA_PATCH[@]}"
 
   if [ -z "$CIVI_ROOT" ]; then
@@ -997,6 +998,23 @@ function civicrm_get_ver() {
 function civicrm_check_ver() {
   cvutil_assertvars civicrm_check_ver CIVI_CORE
   local ver=$( civicrm_get_ver "$CIVI_CORE" )
+  if env ACTUAL="$ver" OP="$1" EXPECT="$2" php -r 'exit(version_compare(getenv("ACTUAL"), getenv("EXPECT"), getenv("OP"))?0:1);'; then
+    return 0
+  else
+    return 1
+  fi
+}
+
+###############################################################################
+## Check if the requested version of CiviCRM (*not yet downloaded*) matches some condition.
+## usage: civicrm_check_ver <op> <target>
+## example: if civicrm_check_ver '>=' '5.43' ; then echo NEW; else echo OLD; fi
+function civicrm_check_requested_ver() {
+  cvutil_assertvars civicrm_check_requested_ver CIVI_VERSION
+  local ver="$CIVI_VERSION"
+  if [[ "$ver" == "master" ]]; then
+    ver=9999999.9999.9999
+  fi
   if env ACTUAL="$ver" OP="$1" EXPECT="$2" php -r 'exit(version_compare(getenv("ACTUAL"), getenv("EXPECT"), getenv("OP"))?0:1);'; then
     return 0
   else


### PR DESCRIPTION
# Overview

Changes the way that `drupal9-dev` and `drupal10-dev` load patched code.

# Before

* Create `./src/civicrm-core` and apply patches
* When installing dependencies, `composer` identifies `./src/civicrm-core`
* And then it copies the files (`./src/civicrm/core` ==> `./vendor/civicrm/civicrm-core`)

# After

* Create `./src/civicrm-core` and apply patches
* When installing dependencies, `composer` identifies `./src/civicrm-core`
* And then it makes one big symlink (`./src/civicrm/core` <=> `./vendor/civicrm/civicrm-core`)

# Comments

This is a generally appealing behavior. However, the immediate issue is that (if we apply civicrm/civicrm-core#31498) then the "copy" mode will no longer copy the test-suite. And so we can't run tests.

The symlink ensures we have access to the test files.

This is a draft because symlink mode doesn't actually work right now. At least, it makes the symlink... but then `cv core:install` fails with that file-layout.

```
...
[Setup:info] [InstallSettingsFile.civi-setup.php] Handle installFiles
Creating civicrm_* database tables in tmpd10civi_970dj
[Setup:info] [Preboot.civi-setup.php] Load minimal (non-DB) services
[Setup:info] [InstallSchema.civi-setup.php] Install database schema
[Setup:info] [InstallSchema.civi-setup.php] Load basic tables
[Setup:info] [InstallSchema.civi-setup.php] Load sample data

In DbUtil.php line 211:
                                                                                                                                                                                              
  [Civi\Setup\Exception\SqlException]                                                                                                                                                         
  Cannot execute INSERT INTO `civicrm_option_value` (`id`, `option_group_id`, `label`, `value`, `name`, `grouping`, `filter`, `is_default`, `weight`, `description`, `is_optgroup`, `is_rese  
  rved`, `is_active`, `component_id`, `domain_id`, `visibility_id`, `icon`, `color`) VALUES                                                                                                   
   (1,1,'Phone','1','Phone',NULL,0,0,1,NULL,0,0,1,NULL,NULL,NULL,NULL,NULL),                                                                                                                  
   (2,1,'Email','2','Email',NULL,0,0,2,NULL,0,0,1,NULL,NULL,NULL,NULL,NULL),                                                                                                                  
   (3,1,'Postal Mail','3','Postal Mail',NULL,0,0,3,NULL,0,0,1,NULL,NULL,NULL,NULL,NULL),         

...

Exception trace:
  at /home/totten/bknix/build/tmpd10/src/civicrm-core/setup/src/Setup/DbUtil.php:211
 Civi\Setup\DbUtil::sourceSQL() at /home/totten/bknix/build/tmpd10/src/civicrm-core/setup/plugins/installDatabase/InstallSchema.civi-setup.php:76
 InstallSchemaPlugin->installDatabase() at /home/totten/bknix/build/tmpd10/vendor/symfony/event-dispatcher/EventDispatcher.php:220
 Symfony\Component\EventDispatcher\EventDispatcher->callListeners() at /home/totten/bknix/build/tmpd10/vendor/symfony/event-dispatcher/EventDispatcher.php:56
 Symfony\Component\EventDispatcher\EventDispatcher->dispatch() at /home/totten/bknix/build/tmpd10/src/civicrm-core/Civi/Core/CiviEventDispatcher.php:263
 Civi\Core\CiviEventDispatcher->dispatch() at /home/totten/bknix/build/tmpd10/src/civicrm-core/setup/src/Setup.php:230
 Civi\Setup->installDatabase() at phar:///home/totten/bknix/bin/cv/src/Command/CoreInstallCommand.php:131
 Civi\Cv\Command\CoreInstallCommand->runSetup() at phar:///home/totten/bknix/bin/cv/src/Command/CoreInstallCommand.php:66
 Civi\Cv\Command\CoreInstallCommand->execute() at phar:///home/totten/bknix/bin/cv/vendor/symfony/console/Command/Command.php:155
 Cvphar\Symfony\Component\Console\Command\Command->run() at phar:///home/totten/bknix/bin/cv/vendor/symfony/console/Application.php:680
 Cvphar\Symfony\Component\Console\Application->doRunCommand() at phar:///home/totten/bknix/bin/cv/vendor/symfony/console/Application.php:218
 Cvphar\Symfony\Component\Console\Application->doRun() at phar:///home/totten/bknix/bin/cv/lib/src/BaseApplication.php:98
 Civi\Cv\BaseApplication->doRun() at phar:///home/totten/bknix/bin/cv/vendor/symfony/console/Application.php:124
 Cvphar\Symfony\Component\Console\Application->run() at phar:///home/totten/bknix/bin/cv/lib/src/BaseApplication.php:65
 Civi\Cv\BaseApplication->run() at phar:///home/totten/bknix/bin/cv/lib/src/BaseApplication.php:27
 Civi\Cv\BaseApplication::main() at phar:///home/totten/bknix/bin/cv/bin/cv:29
 require() at /home/totten/bknix/bin/cv:15
```
