### PR TITLE
Fix joomla-empty, add joomla5-empty

### DIFF
--- a/app/config/README.md
+++ b/app/config/README.md
@@ -40,5 +40,6 @@ including:
 
  * `backdrop_install` - Create Backdrop config files, tables, and data dirs (using `core/scripts/install.sh`)
  * `drupal_install` - Create Drupal config files, tables, and data dirs (using `drush site-install` and `sites/default`)
+ * `joomla_install` - Create Joomla config files, tables, and data dirs (using `installation/joomla.php`)
  * `wp_install` - Create WordPress config files, tables, and data dirs (using wp-cli)
  * `civicrm_install` - Create CiviCRM config files, tables, and data dirs

--- a/app/config/joomla-demo/install.sh
+++ b/app/config/joomla-demo/install.sh
@@ -13,8 +13,7 @@ amp_install
 joomla_install
 
 pushd "$CMS_ROOT" >> /dev/null
-  joomla_reset_user 'admin' "$ADMIN_USER" "$ADMIN_PASS" "$ADMIN_EMAIL"
-  joomla_reset_user 'user' "$DEMO_USER" "$DEMO_PASS" "$DEMO_EMAIL"
+  joomla_cli user:add --name="$DEMO_USER" --username="$DEMO_USER" --password="$DEMO_PASS" --email="$DEMO_EMAIL" --usergroup="Registered,Manager"
 popd >>/dev/null
 
 ###############################################################################

--- a/app/config/joomla-empty/download.sh
+++ b/app/config/joomla-empty/download.sh
@@ -9,23 +9,4 @@ CMS_VERSION=${CMS_VERSION:-latest}
 ## Joomla has strong expectation of writeable web-root -- eg can't run Civi installer otherwise. :(
 amp datadir "$WEB_ROOT" "$WEB_ROOT/web"
 
-pushd "$WEB_ROOT/web" >> /dev/null
-
-if [ "$CMS_VERSION" = 'latest' ]; then
-  http_download "https://update.joomla.org/core/j4/default.xml" j4.xml
-  # slightly brittle as <version> could include mutliple lines ... but it doesn't now
-  CMS_VERSION=$(grep -m1 '<version>' j4.xml | sed -E -e 's/<\/?version>//g'  -e 's/\s*//g')
-  rm j4.xml
-fi
-
-VERSION_DASHES=$(echo $CMS_VERSION | tr '.' '-')
-http_download "https://downloads.joomla.org/cms/joomla4/$VERSION_DASHES/Joomla_$VERSION_DASHES-Stable-Full_Package.zip" joomla.zip
-
-unzip -q joomla.zip
-rm joomla.zip
-
-# Save a copy of the installation directory for re-installation
-zip -q -r installation.zip installation
-
-popd >> /dev/null
-
+joomla4_download "$WEB_ROOT/web"

--- a/app/config/joomla-empty/install.sh
+++ b/app/config/joomla-empty/install.sh
@@ -17,6 +17,5 @@ amp_install
 joomla_install
 
 pushd "$CMS_ROOT" >> /dev/null
-  joomla_reset_user 'admin' "$ADMIN_USER" "$ADMIN_PASS" "$ADMIN_EMAIL"
-  joomla_reset_user 'user' "$DEMO_USER" "$DEMO_PASS" "$DEMO_EMAIL"
+  joomla_cli user:add --name="$DEMO_USER" --username="$DEMO_USER" --password="$DEMO_PASS" --email="$DEMO_EMAIL" --usergroup="Registered,Manager"
 popd >>/dev/null

--- a/app/config/joomla5-empty/download.sh
+++ b/app/config/joomla5-empty/download.sh
@@ -9,22 +9,4 @@ CMS_VERSION=${CMS_VERSION:-latest}
 ## Joomla has strong expectation of writeable web-root -- eg can't run Civi installer otherwise. :(
 amp datadir "$WEB_ROOT" "$WEB_ROOT/web"
 
-pushd "$WEB_ROOT/web" >> /dev/null
-
-if [ "$CMS_VERSION" = 'latest' ]; then
-  http_download "https://update.joomla.org/core/j5/default.xml" j5.xml
-  # slightly brittle as <version> could include mutliple lines ... but it doesn't now
-  CMS_VERSION=$(grep '<version>' j5.xml | sed -E -e 's/<\/?version>//g'  -e 's/\s*//g')
-  rm j5.xml
-fi
-
-VERSION_DASHES=$(echo $CMS_VERSION | tr '.' '-')
-http_download "https://downloads.joomla.org/cms/joomla5/$VERSION_DASHES/Joomla_$VERSION_DASHES-Stable-Full_Package.zip" joomla.zip
-
-unzip -q joomla.zip
-rm joomla.zip
-
-# Save a copy of the installation directory for re-installation
-zip -q -r installation.zip installation
-
-popd >> /dev/null
+joomla5_download "$WEB_ROOT/web"

--- a/app/config/joomla5-empty/download.sh
+++ b/app/config/joomla5-empty/download.sh
@@ -12,14 +12,14 @@ amp datadir "$WEB_ROOT" "$WEB_ROOT/web"
 pushd "$WEB_ROOT/web" >> /dev/null
 
 if [ "$CMS_VERSION" = 'latest' ]; then
-  http_download "https://update.joomla.org/core/j4/default.xml" j4.xml
+  http_download "https://update.joomla.org/core/j5/default.xml" j5.xml
   # slightly brittle as <version> could include mutliple lines ... but it doesn't now
-  CMS_VERSION=$(grep -m1 '<version>' j4.xml | sed -E -e 's/<\/?version>//g'  -e 's/\s*//g')
-  rm j4.xml
+  CMS_VERSION=$(grep '<version>' j5.xml | sed -E -e 's/<\/?version>//g'  -e 's/\s*//g')
+  rm j5.xml
 fi
 
 VERSION_DASHES=$(echo $CMS_VERSION | tr '.' '-')
-http_download "https://downloads.joomla.org/cms/joomla4/$VERSION_DASHES/Joomla_$VERSION_DASHES-Stable-Full_Package.zip" joomla.zip
+http_download "https://downloads.joomla.org/cms/joomla5/$VERSION_DASHES/Joomla_$VERSION_DASHES-Stable-Full_Package.zip" joomla.zip
 
 unzip -q joomla.zip
 rm joomla.zip
@@ -28,4 +28,3 @@ rm joomla.zip
 zip -q -r installation.zip installation
 
 popd >> /dev/null
-

--- a/app/config/joomla5-empty/install.sh
+++ b/app/config/joomla5-empty/install.sh
@@ -17,6 +17,5 @@ amp_install
 joomla_install
 
 pushd "$CMS_ROOT" >> /dev/null
-  joomla_reset_user 'admin' "$ADMIN_USER" "$ADMIN_PASS" "$ADMIN_EMAIL"
-  joomla_reset_user 'user' "$DEMO_USER" "$DEMO_PASS" "$DEMO_EMAIL"
+  joomla_cli user:add --name="$DEMO_USER" --username="$DEMO_USER" --password="$DEMO_PASS" --email="$DEMO_EMAIL" --usergroup="Registered,Manager"
 popd >>/dev/null

--- a/app/config/joomla5-empty/install.sh
+++ b/app/config/joomla5-empty/install.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+## install.sh -- Create config files and databases; fill the databases
+
+## Transition: Old builds don't have "web/" folder. New builds do.
+## TODO: Simplify sometime after Dec 2019
+[ -d "$WEB_ROOT/web" ] && CMS_ROOT="$WEB_ROOT/web"
+
+###############################################################################
+## Create virtual-host and databases
+
+amp_install
+
+###############################################################################
+## Setup Joomla (config files, database tables)
+
+joomla_install
+
+pushd "$CMS_ROOT" >> /dev/null
+  joomla_reset_user 'admin' "$ADMIN_USER" "$ADMIN_PASS" "$ADMIN_EMAIL"
+  joomla_reset_user 'user' "$DEMO_USER" "$DEMO_PASS" "$DEMO_EMAIL"
+popd >>/dev/null

--- a/app/config/joomla5-empty/uninstall.sh
+++ b/app/config/joomla5-empty/uninstall.sh
@@ -6,4 +6,3 @@
 
 joomla_uninstall
 amp_uninstall
-

--- a/src/civibuild.lib.sh
+++ b/src/civibuild.lib.sh
@@ -1737,6 +1737,7 @@ function joomla_uninstall() {
 
 
 ###############################################################################
+## (DEPRECATED: Use joomla_cli)
 ## Reset all the key details (username, password, email) for one of the
 ## Joomla user accounts.
 ##
@@ -1747,6 +1748,19 @@ UPDATE j_users
 SET username=@ENV[NEWUSER], password=md5(@ENV[NEWPASS]), email=@ENV[NEWMAIL]
 WHERE username=@ENV[OLDUSER];
 EOSQL
+}
+
+###############################################################################
+## Call a subcommand in the Joomla CLI (CMS_ROOT/cli/joomla.php)
+##
+## NOTE: As this is primarily intended for scripting, it implies `--no-interaction`.
+##
+## Ex: joomla_cli user:add --name=demo --username=demo --password=demo --email='demo@example.com'
+function joomla_cli() {
+  cvutil_assertvars joomla_install CMS_ROOT
+  pushd "$CMS_ROOT/cli" >> /dev/null
+    php joomla.php --no-interaction "$@"
+  popd >> /dev/null
 }
 
 ###############################################################################

--- a/src/civibuild.lib.sh
+++ b/src/civibuild.lib.sh
@@ -38,10 +38,19 @@ function cvutil_assertvars() {
 
 ###############################################################################
 ## Run a PHP program and explicitly disable debugging.
-## usage: cvutil_php_nodbg <program name> [<args>...]
+## usage: cvutil_php_nodbg <program-name> [<args>...]
+## usage: cvutil_php_nodbg <relative-path> [<args>...]
+##
+## If the program name begins with './', then it is treated as a local file-path.
+## Otherwise, it is located on PATH.
 function cvutil_php_nodbg() {
-  local cmd=$(which "$1")
-  [ -z "$cmd" ] && cvutil_fatal "Failed to locate $cmd"
+  local cmd="$1"
+  if [[ ${cmd:0:2} == "./" ]]; then
+    true
+  else
+    cmd=$(which "$1")
+    [ -z "$cmd" ] && cvutil_fatal "Failed to locate $cmd"
+  fi
   shift
   XDEBUG_PORT= XDEBUG_MODE=off php -d xdebug.remote_enable=off "$cmd" "$@"
 }
@@ -1745,7 +1754,7 @@ function joomla_install() {
   pushd "$CMS_ROOT" >> /dev/null
 
     CMS_DB_HOSTPORT=$(cvutil_build_hostport "$CMS_DB_HOST" "$CMS_DB_PORT")
-    php "installation/joomla.php" install -n -v \
+    cvutil_php_nodbg "./installation/joomla.php" install -n -v \
       --site-name="$CMS_TITLE" \
       --admin-user="CiviCRM Admin" \
       --admin-username="$ADMIN_USER" \
@@ -1799,7 +1808,7 @@ EOSQL
 function joomla_cli() {
   cvutil_assertvars joomla_install CMS_ROOT
   pushd "$CMS_ROOT/cli" >> /dev/null
-    php joomla.php --no-interaction "$@"
+    cvutil_php_nodbg ./joomla.php --no-interaction "$@"
   popd >> /dev/null
 }
 

--- a/src/civibuild.lib.sh
+++ b/src/civibuild.lib.sh
@@ -1700,10 +1700,9 @@ function git_cache_deref_remotes() {
 function joomla_install() {
   cvutil_assertvars joomla_install CMS_ROOT CMS_TITLE CMS_DB_USER CMS_DB_PASS CMS_DB_HOST CMS_DB_NAME ADMIN_USER ADMIN_PASS
 
-  if [ $(echo "$ADMIN_PASS" | wc -m) -le 12 ]; then
-    echo "Joomla password must be at least 12 characters long"
-    exit 1
-  fi
+  ## install.php has its own password-validation that seems a bit quirkier
+  local tmp_pass=$(cvutil_makepasswd 16)
+
   pushd "$CMS_ROOT" >> /dev/null
 
     CMS_DB_HOSTPORT=$(cvutil_build_hostport "$CMS_DB_HOST" "$CMS_DB_PORT")
@@ -1711,13 +1710,15 @@ function joomla_install() {
       --site-name="$CMS_TITLE" \
       --admin-user="CiviCRM Admin" \
       --admin-username="$ADMIN_USER" \
-      --admin-password="$ADMIN_PASS" \
+      --admin-password="$tmp_pass" \
       --admin-email="$ADMIN_EMAIL" \
       --db-host="$CMS_DB_HOSTPORT" \
       --db-user="$CMS_DB_USER" \
       --db-pass="$CMS_DB_PASS" \
       --db-name="$CMS_DB_NAME" \
       --db-prefix='j_'
+
+    joomla_cli user:reset-password --username="$ADMIN_USER" --password="$ADMIN_PASS"
 
     cvutil_php_nodbg amp datadir "$CMS_ROOT/logs" "$CMS_ROOT/tmp" "$CMS_ROOT/administrator/cache"
 

--- a/src/civibuild.lib.sh
+++ b/src/civibuild.lib.sh
@@ -1705,13 +1705,15 @@ function joomla_install() {
     exit 1
   fi
   pushd "$CMS_ROOT" >> /dev/null
+
+  CMS_DB_HOSTPORT=$(cvutil_build_hostport "$CMS_DB_HOST" "$CMS_DB_PORT")
   php "installation/joomla.php" install -n -v \
     --site-name="$CMS_TITLE" \
     --admin-user="CiviCRM Admin" \
     --admin-username="$ADMIN_USER" \
     --admin-password="$ADMIN_PASS" \
     --admin-email="$ADMIN_EMAIL" \
-    --db-host="$CMS_DB_HOST" \
+    --db-host="$CMS_DB_HOSTPORT" \
     --db-user="$CMS_DB_USER" \
     --db-pass="$CMS_DB_PASS" \
     --db-name="$CMS_DB_NAME" \

--- a/src/civibuild.lib.sh
+++ b/src/civibuild.lib.sh
@@ -1706,20 +1706,21 @@ function joomla_install() {
   fi
   pushd "$CMS_ROOT" >> /dev/null
 
-  CMS_DB_HOSTPORT=$(cvutil_build_hostport "$CMS_DB_HOST" "$CMS_DB_PORT")
-  php "installation/joomla.php" install -n -v \
-    --site-name="$CMS_TITLE" \
-    --admin-user="CiviCRM Admin" \
-    --admin-username="$ADMIN_USER" \
-    --admin-password="$ADMIN_PASS" \
-    --admin-email="$ADMIN_EMAIL" \
-    --db-host="$CMS_DB_HOSTPORT" \
-    --db-user="$CMS_DB_USER" \
-    --db-pass="$CMS_DB_PASS" \
-    --db-name="$CMS_DB_NAME" \
-    --db-prefix='j_'
+    CMS_DB_HOSTPORT=$(cvutil_build_hostport "$CMS_DB_HOST" "$CMS_DB_PORT")
+    php "installation/joomla.php" install -n -v \
+      --site-name="$CMS_TITLE" \
+      --admin-user="CiviCRM Admin" \
+      --admin-username="$ADMIN_USER" \
+      --admin-password="$ADMIN_PASS" \
+      --admin-email="$ADMIN_EMAIL" \
+      --db-host="$CMS_DB_HOSTPORT" \
+      --db-user="$CMS_DB_USER" \
+      --db-pass="$CMS_DB_PASS" \
+      --db-name="$CMS_DB_NAME" \
+      --db-prefix='j_'
 
-  cvutil_php_nodbg amp datadir "$CMS_ROOT/logs" "$CMS_ROOT/tmp" "$CMS_ROOT/administrator/cache"
+    cvutil_php_nodbg amp datadir "$CMS_ROOT/logs" "$CMS_ROOT/tmp" "$CMS_ROOT/administrator/cache"
+
   popd >> /dev/null
 }
 ###############################################################################


### PR DESCRIPTION
This is a revision of @aydun's #882. It adds a few more fixes on top, e.g.

* Support for MySQL on alternative port
* Enable caching of the Joomla ZIP downloads. (Change `http_download` to the higher level `extract-url`.)
* Create `demo` user.
* Enable full support for customized values in `CIVIBUILD_ADMIN_PASS`.
