### PR TITLE
Drop phpunit5, phpunit6

### DIFF
--- a/bin/civi-download-tools
+++ b/bin/civi-download-tools
@@ -694,7 +694,11 @@ pushd $PRJDIR >> /dev/null
   [ -f "$PRJDIR/bin/_codecept-php5.phar" ] && rm -f "$PRJDIR/bin/_codecept-php5.phar"
   [ -f "$PRJDIR/bin/_codecept-php7.phar" ] && rm -f "$PRJDIR/bin/_codecept-php7.phar"
   [ -L "$PRJDIR/bin/phpunit4" ] && rm -f "$PRJDIR/bin/phpunit4"
+  [ -L "$PRJDIR/bin/phpunit5" ] && rm -f "$PRJDIR/bin/phpunit5"
+  [ -L "$PRJDIR/bin/phpunit6" ] && rm -f "$PRJDIR/bin/phpunit6"
   [ -f "$PRJDIR/extern/phpunit4/phpunit4.phar" ] && rm -f "$PRJDIR/extern/phpunit4/phpunit4.phar"
+  [ -f "$PRJDIR/extern/phpunit5/phpunit5.phar" ] && rm -f "$PRJDIR/extern/phpunit5/phpunit5.phar"
+  [ -f "$PRJDIR/extern/phpunit6/phpunit6.phar" ] && rm -f "$PRJDIR/extern/phpunit6/phpunit6.phar"
 
   ## Cleanup misnamed files from past
   [ -f "$PRJDIR/extern/phpunit4/phpunit6.phar" ] && rm -f "$PRJDIR/extern/phpunit4/phpunit6.phar" "$PRJDIR/extern/phpunit4/phpunit6.phar"
@@ -772,8 +776,6 @@ pushd $PRJDIR >> /dev/null
 
   ## Setup phpunit aliases for CLI usage
   make_link "$PRJDIR/bin" "drush8" "drush"
-  make_link "$PRJDIR/bin" "../extern/phpunit5/phpunit5.phar" "phpunit5"
-  make_link "$PRJDIR/bin" "../extern/phpunit6/phpunit6.phar" "phpunit6"
   make_link "$PRJDIR/bin" "../extern/phpunit7/phpunit7.phar" "phpunit7"
   make_link "$PRJDIR/bin" "../extern/phpunit8/phpunit8.phar" "phpunit8"
   make_link "$PRJDIR/bin" "../extern/phpunit9/phpunit9.phar" "phpunit9"

--- a/phars.json
+++ b/phars.json
@@ -68,18 +68,6 @@
      "sha256": "2bb076753ec5d672f5e2f96a97a0fe7e8e9ec24a439eed00fd29ef942c7905f9"
    },
 
-   "phpunit5":  {
-     "url": "https://phar.phpunit.de/phpunit-5.7.27.phar",
-     "sha256": "f0300a13f2653bee10b0ce24dbc8d94e65dc9be8966d822b9e455b6b294be16e",
-     "buildkit-path": "extern/phpunit5/phpunit5.phar"
-   },
-
-   "phpunit6":  {
-     "url": "https://phar.phpunit.de/phpunit-6.5.14.phar",
-     "sha256": "3ac5d3234ed2b2dd9aaaa1b33e5c275ce5d7d8f2e07ec7fa930f5036894cc689",
-     "buildkit-path": "extern/phpunit6/phpunit6.phar"
-   },
-
    "phpunit7":  {
      "url": "https://phar.phpunit.de/phpunit-7.5.15.phar",
      "sha256": "ae9c1fb46c61106c6835e905e3e0b23f565103d8bfcc311279c9599971349486",

--- a/src/command/env-info.run.sh
+++ b/src/command/env-info.run.sh
@@ -49,8 +49,6 @@ env_report_cmd mysqldump --version
 env_report_cmd node --version
 env_report_cmd php --version
 env_report_cmd php-fpm --version
-#env_report_cmd phpunit5 --version
-#env_report_cmd phpunit6 --version
 #env_report_cmd phpunit7 --version
 env_report_cmd phpunit8 --version
 env_report_cmd phpunit9 --version

--- a/src/command/phpunit-info.run.sh
+++ b/src/command/phpunit-info.run.sh
@@ -67,7 +67,7 @@ function phpunit_info_cli_core() {
   echo "Next, pick a version of PHPUnit (eg $(echo $PHPUNITS)), and then"
   echo "run an example test (eg CRM_Core_RegionTest):"
   echo
-  echo_cmd "env CIVICRM_UF=UnitTests phpunit5 tests/phpunit/CRM/Core/RegionTest.php"
+  echo_cmd "env CIVICRM_UF=UnitTests phpunit9 tests/phpunit/CRM/Core/RegionTest.php"
   echo
   echo "Most tests require specifying \"env CIVICRM_UF=UnitTests\". Some do not."
   echo "If you get this wrong, that's OK - there will be an error message describing"
@@ -91,7 +91,7 @@ function phpunit_info_cli_ext() {
   echo "Finally, pick a version of PHPUnit (eg $(echo $PHPUNITS)) and"
   echo "an example test (eg CRM_Myext_FooTest). Run it:"
   echo
-  echo_cmd "phpunit5 tests/phpunit/CRM/Myext/FooTest.php"
+  echo_cmd "phpunit9 tests/phpunit/CRM/Myext/FooTest.php"
   echo
 }
 

--- a/src/jobs/CiviCRM-Ext-Edge-Matrix.job
+++ b/src/jobs/CiviCRM-Ext-Edge-Matrix.job
@@ -155,11 +155,6 @@ pushd "$EXTBASE"
   pushd "$EXTDIR"
     civibuild restore "$BLDNAME"
     cv en "$EXTKEY"
-#    if [ "$EXTKEY" = "org.civicrm.api4" ]; then cv flush; fi ## FIX+REMOVE ME
-#    phpunit5 --tap --group e2e --log-junit="$WORKSPACE_JUNIT/junit-e2e.xml"
-#    phpunit5 --tap --group headless --log-junit="$WORKSPACE_JUNIT/junit-headless.xml"
-#    phpunit6 --printer='Civi\Test\TAP' --group e2e --log-junit="$WORKSPACE_JUNIT/junit-e2e.xml"
- #   phpunit6 --printer='Civi\Test\TAP' --group headless --log-junit="$WORKSPACE_JUNIT/junit-headless.xml"
  if [ $BUILDTYPE != "git" ]; then
    if [ "$BKPROF" != "max" ]; then
       if [ "$EXTKEY" != "uk.co.vedaconsulting.mosaico" ]; then

--- a/src/jobs/CiviCRM-Ext-Matrix.job
+++ b/src/jobs/CiviCRM-Ext-Matrix.job
@@ -161,11 +161,6 @@ pushd "$EXTBASE"
   pushd "$EXTDIR"
     civibuild restore "$BLDNAME"
     cv en "$EXTKEY"
-#    if [ "$EXTKEY" = "org.civicrm.api4" ]; then cv flush; fi ## FIX+REMOVE ME
-#    phpunit5 --tap --group e2e --log-junit="$WORKSPACE_JUNIT/junit-e2e.xml"
-#    phpunit5 --tap --group headless --log-junit="$WORKSPACE_JUNIT/junit-headless.xml"
-#    phpunit6 --printer='Civi\Test\TAP' --group e2e --log-junit="$WORKSPACE_JUNIT/junit-e2e.xml"
- #   phpunit6 --printer='Civi\Test\TAP' --group headless --log-junit="$WORKSPACE_JUNIT/junit-headless.xml"
  if [ $BUILDTYPE != "git" ]; then
    if [ "$BKPROF" != "max" ]; then
       if [ "$EXTKEY" != "uk.co.vedaconsulting.mosaico" ]; then


### PR DESCRIPTION
Motivations
-----------

* For the past week, we've seen random download failures affecting phpunit5.phar. ([Notes on MM](https://chat.civicrm.org/civicrm/pl/u618tq4n7tffuezte7k1y8xnec))
* `phpunit5` and `phpunit6` are not useful for testing on the range of PHP 7.2-8.x (https://phpunit.de/supported-versions.html), so it's no longer used by civicrm.org CI. (Arguably, when debugging some edge-case issue from the past few years, you might still have a use-case for phpunit8... But it's really hard to imagine use-case for phpunit5.)

Affect on universe
------------

I searched for projects that might reference this copy of `phpunit5`. I think there may be a couple, so just a heads-up @bjendres re: 

* https://github.com/systopia/de.systopia.committees/blob/137598ef9fb2e15a931133858086adcf3ebad75a/.circleci/config.yml#L69
* https://github.com/systopia/de.systopia.contract/blob/933405d1a662a5546d524f84344093ad7bf304e2/.circleci/config.yml#L75

My sense is that `phpunit5.phar` itself is causing trouble in those tests right now ([example 1](https://app.circleci.com/pipelines/github/systopia/de.systopia.committees/148/workflows/84d7be83-70e5-4edc-ba64-0c7f3411302a/jobs/199), [example 2](https://app.circleci.com/pipelines/github/systopia/de.systopia.contract/330/workflows/6c3ad641-b210-4086-ba82-f8b4c11703e9/jobs/913)).  So this change is no real breakage.

Switching that to `phpunit8` or `phpunit9` should get you past the current fatal.

(*Note, though, that switching to phpunit9 may require some other minor updates -- for example,`$this->assertRegexp()` was renamed to `$this->assertMatchesRegularExpression()`. But generally the increments from phpunit5=>6=>7=>8=>9 have been smaller than phpunit4=>5. Just let `phpunit9` print its complaints and then react to them.*)
