### PR TITLE
php84: Update to 8.4.1 (etal)

### DIFF
--- a/nix/pins/24.05.nix
+++ b/nix/pins/24.05.nix
@@ -2,9 +2,9 @@
  * v24.05
  */
 fetchTarball {
-  ## Unofficial backports circa Jul 31, 2024; totten/v2405-p84m90
-  url = "https://github.com/nixos/nixpkgs/archive/44c8e39eb1fcc3906fcab5b0f971028d72f9e219.tar.gz";
-  sha256 = "0vvj64r69fp6x3wxyrcz2csbx6i4jlas9q5rl44nn5bhhhj8i9sh";
+  ## Unofficial backports circa Dec 9, 2024; totten/v2405-p84m90
+  url = "https://github.com/nixos/nixpkgs/archive/87c0d2dbcbc2837309a837c8e97e56dbe05ad737.tar.gz";
+  sha256 = "1lnhq3d8cwkssvp1kjcxlv4fkaby62ybpiwb9kaawbdsfns53qc2";
 
   ## Official backports circa Jul 23, 2024
   # url = "https://github.com/nixos/nixpkgs/archive/4027bf72e183f21cae770e24b467cbc5ce52edd1.tar.gz";

--- a/nix/pins/default.nix
+++ b/nix/pins/default.nix
@@ -11,6 +11,14 @@ rec {
   v2311 = import (import  ./23.11.nix) {};
   v2405 = import (import  ./24.05.nix) {};
 
+  ## Example: If you want to test with your own copy of nixpkgs, then setup your local source-tree:
+  ##
+  ##   git clone https://EXAMPLE.COM/NIXPKGS.GIT /home/myuser/src/nixpkgs
+  ##
+  ## And set buildkit to use that:
+  #
+  # v2405 = import /home/myuser/src/nixpkgs/default.nix {};
+
   bkit = import ../pkgs;
   default = v2205;
 }

--- a/nix/pkgs/php84/default.nix
+++ b/nix/pkgs/php84/default.nix
@@ -16,8 +16,8 @@ let
 in pkgs.php84.buildEnv {
 
   ## EVALUATE: apcu_bc
-  ## TODO: imap redis phpExtras.runkit7_4
-  extensions = { all, enabled }: with all; enabled++ [ phpExtras.xdebug34 tidy yaml memcached imagick opcache apcu ];
+  ## TODO: imap phpExtras.runkit7_4
+  extensions = { all, enabled }: with all; enabled++ [ phpExtras.xdebug34 tidy yaml memcached imagick opcache apcu redis ];
   extraConfig = phpIniSnippet1 + phpIniSnippet2;
 
 }

--- a/nix/pkgs/php84/default.nix
+++ b/nix/pkgs/php84/default.nix
@@ -16,8 +16,8 @@ let
 in pkgs.php84.buildEnv {
 
   ## EVALUATE: apcu_bc
-  ## TODO: imap phpExtras.runkit7_4
-  extensions = { all, enabled }: with all; enabled++ [ phpExtras.xdebug34 tidy yaml memcached imagick opcache apcu redis ];
+  ## TODO: phpExtras.runkit7_4
+  extensions = { all, enabled }: with all; enabled++ [ phpExtras.xdebug34 tidy yaml memcached imagick opcache apcu redis imap ];
   extraConfig = phpIniSnippet1 + phpIniSnippet2;
 
 }

--- a/nix/pkgs/phpExtras/default.nix
+++ b/nix/pkgs/phpExtras/default.nix
@@ -111,11 +111,11 @@ in rec {
 
   xdebug34 = buildPecl {
     ## XDebug 3.4 supports php81, php82, php83, php84 (https://xdebug.org/docs/compat)
-    version = "3.4.0alpha1";
+    version = "3.4.0";
     pname = "xdebug";
     src = pkgs.fetchurl {
-      url = "https://github.com/xdebug/xdebug/archive/refs/tags/3.4.0alpha1.tar.gz";
-      sha256 = "sha256-kHTKNoIBVbMZ2HLbSjXb0odBtdNb/yYQtEZVbxs6O1g=";
+      url = "https://xdebug.org/files/xdebug-3.4.0.tgz";
+      sha256 = "sha256-iWZ7jQSq8EwCPrEJkA4czpfKOfl/Lz8kGZYwzA4cx30";
     };
     doCheck = true;
     checkTarget = "test";

--- a/nix/scripts/try-profiles.sh
+++ b/nix/scripts/try-profiles.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env ebash
+
+#for PHP in php73 php84 ; do
+#  for DB in m57 ; do
+for PHP in php73 php74 php80 php81 php82 php83 php84 ; do
+  for DB in m57 m84 m90 r106 ; do
+    BKPROF="${PHP}${DB}"
+    echo -n "$BKPROF: "
+    nix-shell -A "$BKPROF" --run 'echo $( php --version | head -n1 ) $(mysql --version | head -n1)'
+  done
+done


### PR DESCRIPTION
Update php84 from 8.4.alpha to 8.4.1. Add updates for various PECLs that now work in 8.4.1.