### PR TITLE
nix/profiles - Various updates

### DIFF
--- a/nix/bin/install-developer.sh
+++ b/nix/bin/install-developer.sh
@@ -58,3 +58,12 @@ for PROFILE in $PROFILES ; do
   do_as_dev "$(declare -f setup_buildkit)" setup_buildkit ".loco/loco.yml"
   break
 done
+
+echo
+echo "COMPLETED: Installed profiles: $PROFILES"
+echo
+echo "TIP: To persistently customize the profile list, set the PROFILES variable in /etc/bknix-ci/install-developer.conf and re-run."
+echo
+echo "  Example: PROFILES='min max edge'"
+echo "  Example: PROFILES='php74 php80 php81 php82'"
+echo "  Example: PROFILES='php80m57 php84m90'"

--- a/nix/bin/use-bknix
+++ b/nix/bin/use-bknix
@@ -32,6 +32,14 @@ TXT_CYAN='\[\033[0;36m\]'
 TXT_WHITE='\[\033[0;37m\]'
 
 ###########################################################
+## Helpers
+
+function fatal() {
+  echo >&2 "$@"
+  exit 1
+}
+
+###########################################################
 ## Input parsing
 
 function use_worker_n() {
@@ -41,8 +49,7 @@ function use_worker_n() {
   fi
 
   if [[ "x$EXECUTOR_NUMBER" = "x" ]]; then
-    echo "Error: The --worker-n option requires EXECUTOR_NUMBER" 1>&2
-    exit 1
+    fatal "Error: The --worker-n option requires EXECUTOR_NUMBER"
   fi
 }
 
@@ -61,7 +68,13 @@ while [ -n "$1" ]; do
   while [[ "$OPT" != "" ]]; do
 
     case "$OPT" in
-      old|min|dfl|max|alt|edge) PROFILE="$OPT" ; OPT="" ;;
+      old|min|dfl|max|alt|edge|php7*|php8*)
+        if [ -z "$PROFILE" ]; then
+          PROFILE="$OPT" ; OPT=""
+        else
+          fatal "Bad options: Too many profiles requested ($PROFILE $OPT). Choose one."
+        fi
+        ;;
       --shell) MODE=shell     ; OPT="" ;;
       --env) MODE=env         ; OPT="" ;;
       --run) MODE=run         ; OPT="" ;;
@@ -76,7 +89,7 @@ while [ -n "$1" ]; do
       -N*) use_worker_n ; OPT="-${OPT:2}" ;;
 
       -) OPT="" ; ;;
-      *) echo "Unrecognized option: $OPT" ; exit 1 ; ;;
+      *) fatal "Unrecognized option: $OPT" ; ;;
     esac
 
   done

--- a/nix/profiles/default.nix
+++ b/nix/profiles/default.nix
@@ -20,9 +20,6 @@ let
 
   ## Some older packages aren't buildable on Apple M1, so we use closest match.
   stdenv = dists.default.stdenv;
-  isAppleM1 = stdenv.isDarwin && stdenv.isAarch64;
-
-  oldestAvailableMysql = (if isAppleM1 then dists.bkit.mysql80 else dists.bkit.mysql57);
 
   attrsets = dists.default.lib;
 
@@ -81,9 +78,9 @@ let
     *   - dfl: A typical default. Corresponds to PR testing.
     *   - alt: An alternative version. Basically, with MariaDB and middle-of-the-road PHP.
     */
-   old = phpXXmXX { php = dists.bkit.php73; dbms = oldestAvailableMysql; };
-   min = phpXXmXX { php = dists.bkit.php80; dbms = oldestAvailableMysql; };
-   dfl = phpXXmXX { php = dists.bkit.php82; dbms = oldestAvailableMysql; };
+   old = combinations.php74m57;
+   min = combinations.php80m57;
+   dfl = combinations.php82m57; /* Test suites run faster on MySQL 5.7 */
    alt = combinations.php80r105;
    max = combinations.php82m80;
    edge = combinations.php84m80;

--- a/nix/profiles/default.nix
+++ b/nix/profiles/default.nix
@@ -82,7 +82,7 @@ let
     *   - alt: An alternative version. Basically, with MariaDB and middle-of-the-road PHP.
     */
    old = phpXXmXX { php = dists.bkit.php73; dbms = oldestAvailableMysql; };
-   min = phpXXmXX { php = dists.bkit.php74; dbms = oldestAvailableMysql; };
+   min = phpXXmXX { php = dists.bkit.php80; dbms = oldestAvailableMysql; };
    dfl = phpXXmXX { php = dists.bkit.php82; dbms = oldestAvailableMysql; };
    alt = combinations.php80r105;
    max = combinations.php82m80;


### PR DESCRIPTION
1. For `min` profile, raise PHP from php74 to php80.
    * This will be good for demo servers.
2. For `old` / `min` / `dfl`, remove an old deviation for Apple M1.
    * When nix support for M1 was first released, it had MySQL 8.0 but not 5.7.
    * Now-a-days, it does have both.
    * So we don't need a policy deviation - Mac+Linux can have the same default versions.
3. For `install-developer.sh` and `use-bknix`, make it easier to work other other profiles.
    * Originally, these were strictly limited to symbolic profiles like `old min dfl max edge`
    * Now, they can also use numbered profiles like `php80 php81 php82...` or `php80m57 php84m90 ...`
    * The main upshot is better offline access to numbered profiles.
    * Numbered profiles are still an opt-in, eg
        ```bash
        mkdir -p /etc/bknix-ci
        echo 'PROFILES="min max php81 php84"' >> /etc/bknix-ci/install-developer.conf
        ./nix/bin/install-developer.sh
        ```