### PR TITLE
drupal-* - Update drush download commands

### DIFF
--- a/app/config/drupal-clean/download.sh
+++ b/app/config/drupal-clean/download.sh
@@ -9,7 +9,7 @@
 drupal_download
 
 pushd "$WEB_ROOT/web"
-  drush dl -y libraries-1.0 views-3.7
+  drush dl -y libraries-1.x views-3.x
   drupal7_po_download "${CIVICRM_LOCALES:-de_DE}" drupal-7.x views-7.x-3.x
 
   pushd sites/all/modules

--- a/app/config/drupal-demo/download.sh
+++ b/app/config/drupal-demo/download.sh
@@ -13,7 +13,7 @@
 drupal_download
 
 pushd "$WEB_ROOT/web"
-  drush8 dl -y libraries-1 redirect-1 webform-4 options_element-1 webform_civicrm-4 views-3 login_destination-1 userprotect-1
+  drush8 dl -y libraries-1.x redirect-1.x webform-4.x options_element-1.x webform_civicrm-4.x views-3.x login_destination-1.x userprotect-1.x
   drupal7_po_download "${CIVICRM_LOCALES:-de_DE}" drupal-7.x webform-7.x-4.x webform_civicrm-7.x-4.x views-7.x-3.x login_destination-7.x-1.x userprotect-7.x-1.x
 
   pushd sites/all/modules

--- a/app/config/drupal-empty/download.sh
+++ b/app/config/drupal-empty/download.sh
@@ -9,6 +9,6 @@
 drupal_download
 
 pushd "$WEB_ROOT/web"
-  drush dl -y libraries-1.0 views-3.7
+  drush dl -y libraries-1.x views-3.x
   drupal7_po_download "${CIVICRM_LOCALES:-de_DE}" drupal-7.x views-7.x-3.x
 popd


### PR DESCRIPTION
Since D7-core is EOL, the version constraints for `drush dl` are more picky. Here's what I'm seeing:

* `drush dl foo-1.x` ==> Indicates floating dev build; still works the same
* `drush dl foo-1.2` ==> Indicates specific release; still works the same
* `drush dl foo-1` ==> Indicates "last stable starting with 1". This now provokes a prompt because of D7 EOL. The prompt kills scripted builds.

The D7 build-types were a bit mixed in which constraints they used, but there's no particular logic that I see. This makes them all match and all work.