### PR TITLE
Avoid unnecessary timeouts to gitlab causing drupal 10 public demo build fails

### DIFF
--- a/app/config/drupal10-demo/install.sh
+++ b/app/config/drupal10-demo/install.sh
@@ -69,7 +69,7 @@ pushd "${CMS_ROOT}/sites/${DRUPAL_SITE_DIR}" >> /dev/null
   if [ -d "$CIVI_CORE/tools/extensions/org.civicrm.contactlayout" ]; then
     mv $CIVI_CORE/tools/extensions/org.civicrm.contactlayout files/civicrm/ext
   fi
-  cv api extension.refresh
+  cv api extension.refresh local=1 remote=0
 
   ## Demo sites always disable email and often disable cron
   cv api StatusPreference.create ignore_severity=critical name=checkOutboundMail


### PR DESCRIPTION
The drupal 10 demo build has been failing the last 4 days timing out while connecting to gitlab. See https://chat.civicrm.org/civicrm/pl/nhwn4775y7gfpfwpgsepeaebih

In the line just above, it moves a local extension from one folder to another, so I assume the purpose of this refresh line is to pick up that change. It doesn't need to contact gitlab for that.