### PR TITLE
Update buildkit for use with new site_email_address table

### DIFF
--- a/app/config/backdrop-clean/install.sh
+++ b/app/config/backdrop-clean/install.sh
@@ -20,7 +20,7 @@ backdrop_install
 ## Setup CiviCRM (config files, database tables)
 
 CIVI_DOMAIN_NAME="Demonstrators Anonymous"
-CIVI_DOMAIN_EMAIL="\"Demonstrators Anonymous\" <info@example.org>"
+CIVI_DOMAIN_EMAIL="info@example.org"
 CIVI_CORE="${CMS_ROOT}/modules/civicrm"
 CIVI_SETTINGS="${CMS_ROOT}/civicrm.settings.php"
 CIVI_FILES="${CMS_ROOT}/files/civicrm"

--- a/app/config/backdrop-demo/install.sh
+++ b/app/config/backdrop-demo/install.sh
@@ -20,7 +20,7 @@ backdrop_install
 ## Setup CiviCRM (config files, database tables)
 
 CIVI_DOMAIN_NAME="Demonstrators Anonymous"
-CIVI_DOMAIN_EMAIL="\"Demonstrators Anonymous\" <info@example.org>"
+CIVI_DOMAIN_EMAIL="info@example.org"
 CIVI_CORE="${CMS_ROOT}/modules/civicrm"
 CIVI_SETTINGS="${CMS_ROOT}/civicrm.settings.php"
 CIVI_FILES="${CMS_ROOT}/files/civicrm"

--- a/app/config/d8leg-clean/install.sh
+++ b/app/config/d8leg-clean/install.sh
@@ -24,7 +24,7 @@ popd >> /dev/null
 ## Setup CiviCRM (config files, database tables)
 
 CIVI_DOMAIN_NAME="Demonstrators Anonymous"
-CIVI_DOMAIN_EMAIL="\"Demonstrators Anonymous\" <info@example.org>"
+CIVI_DOMAIN_EMAIL="info@example.org"
 CIVI_CORE="${CMS_ROOT}/vendor/civicrm/civicrm-core"
 CIVI_UF="Drupal8"
 GENCODE_CONFIG_TEMPLATE="${CMS_ROOT}/modules/contrib/civicrm/civicrm.config.php.drupal"

--- a/app/config/d8prj-clean/install.sh
+++ b/app/config/d8prj-clean/install.sh
@@ -24,7 +24,7 @@ popd >> /dev/null
 ## Setup CiviCRM (config files, database tables)
 
 CIVI_DOMAIN_NAME="Demonstrators Anonymous"
-CIVI_DOMAIN_EMAIL="\"Demonstrators Anonymous\" <info@example.org>"
+CIVI_DOMAIN_EMAIL="info@example.org"
 CIVI_CORE="${WEB_ROOT}/vendor/civicrm/civicrm-core"
 CIVI_UF="Drupal8"
 GENCODE_CONFIG_TEMPLATE="${CMS_ROOT}/modules/contrib/civicrm/civicrm.config.php.drupal"

--- a/app/config/d8rec-clean/install.sh
+++ b/app/config/d8rec-clean/install.sh
@@ -24,7 +24,7 @@ popd >> /dev/null
 ## Setup CiviCRM (config files, database tables)
 
 CIVI_DOMAIN_NAME="Demonstrators Anonymous"
-CIVI_DOMAIN_EMAIL="\"Demonstrators Anonymous\" <info@example.org>"
+CIVI_DOMAIN_EMAIL="info@example.org"
 CIVI_CORE="${WEB_ROOT}/vendor/civicrm/civicrm-core"
 CIVI_UF="Drupal8"
 GENCODE_CONFIG_TEMPLATE="${CMS_ROOT}/modules/contrib/civicrm/civicrm.config.php.drupal"

--- a/app/config/drupal-case/install.sh
+++ b/app/config/drupal-case/install.sh
@@ -21,7 +21,7 @@ drupal_install
 
 DRUPAL_SITE_DIR=$(_drupal_multisite_dir "$CMS_URL" "$SITE_ID")
 CIVI_DOMAIN_NAME="Demonstrators Anonymous"
-CIVI_DOMAIN_EMAIL="\"Demonstrators Anonymous\" <info@example.org>"
+CIVI_DOMAIN_EMAIL="info@example.org"
 CIVI_CORE="${CMS_ROOT}/sites/all/modules/civicrm"
 CIVI_SETTINGS="${CMS_ROOT}/sites/${DRUPAL_SITE_DIR}/civicrm.settings.php"
 CIVI_FILES="${CMS_ROOT}/sites/${DRUPAL_SITE_DIR}/files/civicrm"

--- a/app/config/drupal-clean/install.sh
+++ b/app/config/drupal-clean/install.sh
@@ -21,7 +21,7 @@ drupal_install
 
 DRUPAL_SITE_DIR=$(_drupal_multisite_dir "$CMS_URL" "$SITE_ID")
 CIVI_DOMAIN_NAME="Demonstrators Anonymous"
-CIVI_DOMAIN_EMAIL="\"Demonstrators Anonymous\" <info@example.org>"
+CIVI_DOMAIN_EMAIL="info@example.org"
 CIVI_CORE="${CMS_ROOT}/sites/all/modules/civicrm"
 CIVI_SETTINGS="${CMS_ROOT}/sites/${DRUPAL_SITE_DIR}/civicrm.settings.php"
 CIVI_FILES="${CMS_ROOT}/sites/${DRUPAL_SITE_DIR}/files/civicrm"

--- a/app/config/drupal-demo/install.sh
+++ b/app/config/drupal-demo/install.sh
@@ -21,7 +21,7 @@ drupal_install
 
 DRUPAL_SITE_DIR=$(_drupal_multisite_dir "$CMS_URL" "$SITE_ID")
 CIVI_DOMAIN_NAME="Demonstrators Anonymous"
-CIVI_DOMAIN_EMAIL="\"Demonstrators Anonymous\" <info@example.org>"
+CIVI_DOMAIN_EMAIL="info@example.org"
 CIVI_CORE="${CMS_ROOT}/sites/all/modules/civicrm"
 CIVI_SETTINGS="${CMS_ROOT}/sites/${DRUPAL_SITE_DIR}/civicrm.settings.php"
 CIVI_FILES="${CMS_ROOT}/sites/${DRUPAL_SITE_DIR}/files/civicrm"

--- a/app/config/drupal-sym1/install.sh
+++ b/app/config/drupal-sym1/install.sh
@@ -21,7 +21,7 @@ drupal_install
 
 DRUPAL_SITE_DIR=$(_drupal_multisite_dir "$CMS_URL" "$SITE_ID")
 CIVI_DOMAIN_NAME="Demonstrators Anonymous"
-CIVI_DOMAIN_EMAIL="\"Demonstrators Anonymous\" <info@example.org>"
+CIVI_DOMAIN_EMAIL="info@example.org"
 CIVI_CORE="${CMS_ROOT}/sites/all/modules/civicrm"
 CIVI_SETTINGS="${CMS_ROOT}/sites/${DRUPAL_SITE_DIR}/civicrm.settings.php"
 CIVI_FILES="${CMS_ROOT}/sites/${DRUPAL_SITE_DIR}/files/civicrm"

--- a/app/config/drupal-sym2/install.sh
+++ b/app/config/drupal-sym2/install.sh
@@ -21,7 +21,7 @@ drupal_install
 
 DRUPAL_SITE_DIR=$(_drupal_multisite_dir "$CMS_URL" "$SITE_ID")
 CIVI_DOMAIN_NAME="Demonstrators Anonymous"
-CIVI_DOMAIN_EMAIL="\"Demonstrators Anonymous\" <info@example.org>"
+CIVI_DOMAIN_EMAIL="info@example.org"
 CIVI_CORE="${CMS_ROOT}/sites/all/modules/civicrm"
 CIVI_SETTINGS="${CMS_ROOT}/sites/${DRUPAL_SITE_DIR}/civicrm.settings.php"
 CIVI_FILES="${CMS_ROOT}/sites/${DRUPAL_SITE_DIR}/files/civicrm"

--- a/app/config/drupal10-clean/install.sh
+++ b/app/config/drupal10-clean/install.sh
@@ -21,7 +21,7 @@ popd >> /dev/null
 ## Setup CiviCRM (config files, database tables)
 
 CIVI_DOMAIN_NAME="Demonstrators Anonymous"
-CIVI_DOMAIN_EMAIL="\"Demonstrators Anonymous\" <info@example.org>"
+CIVI_DOMAIN_EMAIL="info@example.org"
 CIVI_CORE="${WEB_ROOT}/vendor/civicrm/civicrm-core"
 CIVI_UF="Drupal8"
 GENCODE_CONFIG_TEMPLATE="${CMS_ROOT}/modules/contrib/civicrm/civicrm.config.php.drupal"

--- a/app/config/drupal10-demo/install.sh
+++ b/app/config/drupal10-demo/install.sh
@@ -21,7 +21,7 @@ popd >> /dev/null
 ## Setup CiviCRM (config files, database tables)
 
 CIVI_DOMAIN_NAME="Demonstrators Anonymous"
-CIVI_DOMAIN_EMAIL="\"Demonstrators Anonymous\" <info@example.org>"
+CIVI_DOMAIN_EMAIL="info@example.org"
 CIVI_CORE="${WEB_ROOT}/vendor/civicrm/civicrm-core"
 CIVI_UF="Drupal8"
 GENCODE_CONFIG_TEMPLATE="${CMS_ROOT}/modules/contrib/civicrm/civicrm.config.php.drupal"

--- a/app/config/drupal10-dev/install.sh
+++ b/app/config/drupal10-dev/install.sh
@@ -21,7 +21,7 @@ popd >> /dev/null
 ## Setup CiviCRM (config files, database tables)
 
 CIVI_DOMAIN_NAME="Demonstrators Anonymous"
-CIVI_DOMAIN_EMAIL="\"Demonstrators Anonymous\" <info@example.org>"
+CIVI_DOMAIN_EMAIL="info@example.org"
 CIVI_CORE="${WEB_ROOT}/vendor/civicrm/civicrm-core"
 CIVI_UF="Drupal8"
 GENCODE_CONFIG_TEMPLATE="${CMS_ROOT}/modules/contrib/civicrm/civicrm.config.php.drupal"

--- a/app/config/drupal10-dod/install.sh
+++ b/app/config/drupal10-dod/install.sh
@@ -21,7 +21,7 @@ popd >> /dev/null
 ## Setup CiviCRM (config files, database tables)
 
 CIVI_DOMAIN_NAME="Demonstrators Anonymous"
-CIVI_DOMAIN_EMAIL="\"Demonstrators Anonymous\" <info@example.org>"
+CIVI_DOMAIN_EMAIL="info@example.org"
 CIVI_CORE="${CMS_ROOT}/vendor/civicrm/civicrm-core"
 CIVI_UF="Drupal8"
 GENCODE_CONFIG_TEMPLATE="${CMS_ROOT}/modules/contrib/civicrm/civicrm.config.php.drupal"

--- a/app/config/drupal11-dev/install.sh
+++ b/app/config/drupal11-dev/install.sh
@@ -21,7 +21,7 @@ popd >> /dev/null
 ## Setup CiviCRM (config files, database tables)
 
 CIVI_DOMAIN_NAME="Demonstrators Anonymous"
-CIVI_DOMAIN_EMAIL="\"Demonstrators Anonymous\" <info@example.org>"
+CIVI_DOMAIN_EMAIL="info@example.org"
 CIVI_CORE="${WEB_ROOT}/vendor/civicrm/civicrm-core"
 CIVI_UF="Drupal8"
 GENCODE_CONFIG_TEMPLATE="${CMS_ROOT}/modules/contrib/civicrm/civicrm.config.php.drupal"

--- a/app/config/drupal8-clean/install.sh
+++ b/app/config/drupal8-clean/install.sh
@@ -22,7 +22,7 @@ popd >> /dev/null
 ## Setup CiviCRM (config files, database tables)
 
 CIVI_DOMAIN_NAME="Demonstrators Anonymous"
-CIVI_DOMAIN_EMAIL="\"Demonstrators Anonymous\" <info@example.org>"
+CIVI_DOMAIN_EMAIL="info@example.org"
 CIVI_CORE="${CMS_ROOT}/vendor/civicrm/civicrm-core"
 CIVI_UF="Drupal8"
 GENCODE_CONFIG_TEMPLATE="${CMS_ROOT}/modules/contrib/civicrm/civicrm.config.php.drupal"

--- a/app/config/drupal8-demo/install.sh
+++ b/app/config/drupal8-demo/install.sh
@@ -21,7 +21,7 @@ popd >> /dev/null
 ## Setup CiviCRM (config files, database tables)
 
 CIVI_DOMAIN_NAME="Demonstrators Anonymous"
-CIVI_DOMAIN_EMAIL="\"Demonstrators Anonymous\" <info@example.org>"
+CIVI_DOMAIN_EMAIL="info@example.org"
 CIVI_CORE="${WEB_ROOT}/vendor/civicrm/civicrm-core"
 CIVI_UF="Drupal8"
 GENCODE_CONFIG_TEMPLATE="${CMS_ROOT}/modules/contrib/civicrm/civicrm.config.php.drupal"

--- a/app/config/drupal9-clean/install.sh
+++ b/app/config/drupal9-clean/install.sh
@@ -21,7 +21,7 @@ popd >> /dev/null
 ## Setup CiviCRM (config files, database tables)
 
 CIVI_DOMAIN_NAME="Demonstrators Anonymous"
-CIVI_DOMAIN_EMAIL="\"Demonstrators Anonymous\" <info@example.org>"
+CIVI_DOMAIN_EMAIL="info@example.org"
 CIVI_CORE="${WEB_ROOT}/vendor/civicrm/civicrm-core"
 CIVI_UF="Drupal8"
 GENCODE_CONFIG_TEMPLATE="${CMS_ROOT}/modules/contrib/civicrm/civicrm.config.php.drupal"

--- a/app/config/drupal9-demo/install.sh
+++ b/app/config/drupal9-demo/install.sh
@@ -21,7 +21,7 @@ popd >> /dev/null
 ## Setup CiviCRM (config files, database tables)
 
 CIVI_DOMAIN_NAME="Demonstrators Anonymous"
-CIVI_DOMAIN_EMAIL="\"Demonstrators Anonymous\" <info@example.org>"
+CIVI_DOMAIN_EMAIL="info@example.org"
 CIVI_CORE="${WEB_ROOT}/vendor/civicrm/civicrm-core"
 CIVI_UF="Drupal8"
 GENCODE_CONFIG_TEMPLATE="${CMS_ROOT}/modules/contrib/civicrm/civicrm.config.php.drupal"

--- a/app/config/drupal9-dev/install.sh
+++ b/app/config/drupal9-dev/install.sh
@@ -21,7 +21,7 @@ popd >> /dev/null
 ## Setup CiviCRM (config files, database tables)
 
 CIVI_DOMAIN_NAME="Demonstrators Anonymous"
-CIVI_DOMAIN_EMAIL="\"Demonstrators Anonymous\" <info@example.org>"
+CIVI_DOMAIN_EMAIL="info@example.org"
 CIVI_CORE="${WEB_ROOT}/vendor/civicrm/civicrm-core"
 CIVI_UF="Drupal8"
 GENCODE_CONFIG_TEMPLATE="${CMS_ROOT}/modules/contrib/civicrm/civicrm.config.php.drupal"

--- a/app/config/joomla-demo/install.sh
+++ b/app/config/joomla-demo/install.sh
@@ -20,7 +20,7 @@ popd >>/dev/null
 ## Setup CiviCRM (config files, database tables)
 
 CIVI_DOMAIN_NAME="Demonstrators Anonymous"
-CIVI_DOMAIN_EMAIL="\"Demonstrators Anonymous\" <info@example.org>"
+CIVI_DOMAIN_EMAIL="info@example.org"
 CIVI_CORE="${CMS_ROOT}/administrator/components/com_civicrm/civicrm"
 CIVI_SETTINGS="${CMS_ROOT}/components/com_civicrm/civicrm.settings.php"
 CIVI_ADMSETTINGS="${CMS_ROOT}/administrator/components/com_civicrm/civicrm.settings.php"

--- a/app/config/standalone-clean/install.sh
+++ b/app/config/standalone-clean/install.sh
@@ -12,7 +12,7 @@ amp_install
 ## Setup CiviCRM (config files, database tables)
 
 CIVI_DOMAIN_NAME="Demonstrators Anonymous"
-CIVI_DOMAIN_EMAIL="\"Demonstrators Anonymous\" <info@example.org>"
+CIVI_DOMAIN_EMAIL="info@example.org"
 CIVI_CORE="${WEB_ROOT}/web/core"
 CIVI_UF="Standalone"
 CIVI_SETTINGS="${WEB_ROOT}/web/private/civicrm.settings.php"

--- a/app/config/standalone-composer/install.sh
+++ b/app/config/standalone-composer/install.sh
@@ -12,7 +12,7 @@ amp_install
 ## Setup CiviCRM (config files, database tables)
 
 CIVI_DOMAIN_NAME="Demonstrators Anonymous"
-CIVI_DOMAIN_EMAIL="\"Demonstrators Anonymous\" <info@example.org>"
+CIVI_DOMAIN_EMAIL="info@example.org"
 CIVI_CORE="${CMS_ROOT}/vendor/civicrm/civicrm-core"
 CIVI_UF="Standalone"
 CIVI_SETTINGS="${CMS_ROOT}/private/civicrm.settings.php"

--- a/app/config/starterkit/install.sh
+++ b/app/config/starterkit/install.sh
@@ -12,7 +12,7 @@ amp_install
 
 DRUPAL_SITE_DIR=$(_drupal_multisite_dir "$CMS_URL" "$SITE_ID")
 CIVI_DOMAIN_NAME="Demonstrators Anonymous"
-CIVI_DOMAIN_EMAIL="\"Demonstrators Anonymous\" <info@example.org>"
+CIVI_DOMAIN_EMAIL="info@example.org"
 CIVI_CORE="${WEB_ROOT}/profiles/civicrm_starterkit/modules/civicrm"
 CIVI_SETTINGS="${WEB_ROOT}/sites/${DRUPAL_SITE_DIR}/civicrm.settings.php"
 CIVI_FILES="${WEB_ROOT}/sites/${DRUPAL_SITE_DIR}/files/civicrm"

--- a/app/config/wmff/install.sh
+++ b/app/config/wmff/install.sh
@@ -24,7 +24,7 @@ drupal_install
 ## Setup CiviCRM (config files, database tables)
 
 CIVI_DOMAIN_NAME="Demonstrators Anonymous"
-CIVI_DOMAIN_EMAIL="\"Demonstrators Anonymous\" <info@example.org>"
+CIVI_DOMAIN_EMAIL="info@example.org"
 CIVI_CORE="${CMS_ROOT}/sites/all/modules/civicrm"
 CIVI_SETTINGS="${CMS_ROOT}/sites/default/civicrm.settings.php"
 CIVI_FILES="${CMS_ROOT}/sites/default/files/civicrm"

--- a/app/config/wp-case/install.sh
+++ b/app/config/wp-case/install.sh
@@ -16,7 +16,7 @@ wp_install
 ## Setup CiviCRM (config files, database tables)
 
 CIVI_DOMAIN_NAME="Demonstrators Anonymous"
-CIVI_DOMAIN_EMAIL="\"Demonstrators Anonymous\" <info@example.org>"
+CIVI_DOMAIN_EMAIL="info@example.org"
 CIVI_CORE="${WEB_ROOT}/wp-content/plugins/civicrm/civicrm"
 CIVI_SETTINGS="${WEB_ROOT}/wp-content/uploads/civicrm/civicrm.settings.php"
 CIVI_FILES="${WEB_ROOT}/wp-content/uploads/civicrm"

--- a/app/config/wp-clean/install.sh
+++ b/app/config/wp-clean/install.sh
@@ -20,7 +20,7 @@ wp_install
 ## Setup CiviCRM (config files, database tables)
 
 CIVI_DOMAIN_NAME="Demonstrators Anonymous"
-CIVI_DOMAIN_EMAIL="\"Demonstrators Anonymous\" <info@example.org>"
+CIVI_DOMAIN_EMAIL="info@example.org"
 CIVI_CORE="${CMS_ROOT}/wp-content/plugins/civicrm/civicrm"
 
 if [[ "$CIVI_VERSION" =~ ^4.[0123456](\.([0-9]|alpha|beta)+)?$ ]] ; then

--- a/app/config/wp-demo/install.sh
+++ b/app/config/wp-demo/install.sh
@@ -20,7 +20,7 @@ wp_install
 ## Setup CiviCRM (config files, database tables)
 
 CIVI_DOMAIN_NAME="Demonstrators Anonymous"
-CIVI_DOMAIN_EMAIL="\"Demonstrators Anonymous\" <info@example.org>"
+CIVI_DOMAIN_EMAIL="info@example.org"
 CIVI_CORE="${CMS_ROOT}/wp-content/plugins/civicrm/civicrm"
 
 if [[ "$CIVI_VERSION" =~ ^4.[0123456](\.([0-9]|alpha|beta)+)?$ ]] ; then


### PR DESCRIPTION
This complements https://github.com/civicrm/civicrm-core/pull/31909 by installing site email in the appropriate table depending on version.