### PR TITLE
Drupal 10/11 - Remove work-around from drush 13.3.2

### DIFF
--- a/app/config/drupal10-clean/download.sh
+++ b/app/config/drupal10-clean/download.sh
@@ -13,7 +13,7 @@ composer create-project drupal/recommended-project:"$CMS_VERSION" "$WEB_ROOT" --
 pushd "$WEB_ROOT" >> /dev/null
   composer_allow_common_plugins
   composer require drupal/userprotect
-  composer require drush/drush:13.3.1 ## FIXME: Unlock constraint. Pending drush #6154
+  composer require drush/drush
   ## Some D8 builds include a specific revision of phpunit, but Civi uses standalone phpunit (PHAR)
   if composer info | grep -q ^phpunit/phpunit\ ; then
     composer config "discard-changes" true ## Weird. phpcs has changes which interfere with other work.

--- a/app/config/drupal10-dev/download.sh
+++ b/app/config/drupal10-dev/download.sh
@@ -13,7 +13,7 @@ composer create-project drupal/recommended-project:"$CMS_VERSION" "$WEB_ROOT" --
 pushd "$WEB_ROOT" >> /dev/null
   composer_allow_common_plugins
   composer require drupal/userprotect
-  composer require drush/drush:13.3.1 ## FIXME: Unlock constraint. Pending drush #6154
+  composer require drush/drush
   ## Some D8 builds include a specific revision of phpunit, but Civi uses standalone phpunit (PHAR)
   if composer info | grep -q ^phpunit/phpunit\ ; then
     composer config "discard-changes" true ## Weird. phpcs has changes which interfere with other work.

--- a/app/config/drupal11-dev/download.sh
+++ b/app/config/drupal11-dev/download.sh
@@ -13,7 +13,7 @@ composer create-project drupal/recommended-project:"$CMS_VERSION" "$WEB_ROOT" --
 pushd "$WEB_ROOT" >> /dev/null
   composer_allow_common_plugins
   composer require drupal/userprotect
-  composer require drush/drush:13.3.1 ## FIXME: Unlock constraint. Pending drush #6154
+  composer require drush/drush
   ## Some D8 builds include a specific revision of phpunit, but Civi uses standalone phpunit (PHAR)
   if composer info | grep -q ^phpunit/phpunit\ ; then
     composer config "discard-changes" true ## Weird. phpcs has changes which interfere with other work.


### PR DESCRIPTION
The problem in 13.3.2 was fixed by 13.3.3. Keeping this constraint causes trouble when testing some configurations where drush 13.x isn't compatible.