### PR TITLE
Update php8.5.27 to 8.5.41

### DIFF
--- a/phars.json
+++ b/phars.json
@@ -75,8 +75,8 @@
    },
 
    "phpunit8":  {
-     "url": "https://phar.phpunit.de/phpunit-8.5.27.phar",
-     "sha256": "04e65b8b2cb0465302f3d0115ad0a77411ba8d5c03be2607d58265da54f972e2",
+     "url": "https://phar.phpunit.de/phpunit-8.5.41.phar",
+     "sha256": "df3a284a28ef7eee387707b6cfd6e569f27698c557281c440addaee165c64c16",
      "buildkit-path": "extern/phpunit8/phpunit8.phar"
    },
 


### PR DESCRIPTION
Not sure if this will get us past the deprecation notices but makes sense to do even if not

https://phar.phpunit.de/

> Deprecated: PHPUnitFrameworkTest::run(): Implicitly marking parameter  as nullable is deprecated, the explicit nullable type must be used instead in phar:///home/homer/buildkit/extern/phpunit8/phpunit8.phar/phpunit/Framework/Test.php on line 23

@totten @seamuslee001 not sure why we are using phpunit8 against php edge ... but this seems like a sane first step towards looking at the deprecations

https://test.civicrm.org/job/CiviCRM-Test-QLow/134517/console