### PR TITLE
skip chromium for nix on all Apples, not just M1

### DIFF
--- a/nix/profiles/phpXXmXX/default.nix
+++ b/nix/profiles/phpXXmXX/default.nix
@@ -9,7 +9,7 @@
 let
     dists = import ../../pins;
     stdenv = dists.default.stdenv;
-    isAppleM1 = stdenv.isDarwin && stdenv.isAarch64;
+    isApple = stdenv.isDarwin;
 
     isValidPackage = pkg: (builtins.tryEval pkg).success && pkg != null && pkg.type == "derivation";
 
@@ -25,6 +25,6 @@ in if (isValidPackage php) && (isValidPackage dbms)
     dists.default.redis
     dists.bkit.transifexClient
 
-  ] ++ (if isAppleM1 then [] else [dists.default.chromium])
+  ] ++ (if isApple then [] else [dists.default.chromium])
 
   else throw "Unsupported: Some dependencies for this combination of PHP/MySQL are not available in this environment."


### PR DESCRIPTION
It seems like Chromium builds aren't available for Intel Macs either, so I think the opt out here should be broaden.

As is, it caused quite a lot of headaches trying to setup on a fresh install of Nix on one of the last Intel MacBook Pros this morning. Skipping chromium it worked nicely.

There seem to be various closed PRs relating to adding/reinstating Chromium package for Darwin. The last mentions a `flake` that could maybe be used, though I don't know how that would work! https://github.com/NixOS/nixpkgs/pull/324701 ?
