### PR TITLE
Fix find error on macOS

### DIFF
--- a/src/civibuild.lib.sh
+++ b/src/civibuild.lib.sh
@@ -622,7 +622,7 @@ function civicrm_download_composer_d8() {
   [ -n "$EXTRA_PATCH" ] && git scan am -N "${EXTRA_PATCH[@]}"
 
   if [ -z "$CIVI_ROOT" ]; then
-    local civicrm_version_php=$(find -name civicrm-version.php | head -n1)
+    local civicrm_version_php=$(find . -name civicrm-version.php | head -n1)
     if [ -f "$civicrm_version_php" ]; then
       CIVI_ROOT=$(dirname "$civicrm_version_php")
     else


### PR DESCRIPTION
Apparently, whether or not `find` works without specifying a path depends on the implementation. On macOS, it does not work and civibuild fails with error `Failed to locate civicrm-core`. This fixes it.