### PR TITLE
Update wp-cli to 2.12

### DIFF
--- a/app/config/wp-case/install.sh
+++ b/app/config/wp-case/install.sh
@@ -39,6 +39,7 @@ wp plugin install wordpress-importer --activate
 wp import "$SITE_CONFIG_DIR/civicrm-wordpress.xml" --authors=create
 wp search-replace 'http://civicrm-wordpress.ex' "$SITE_URL"
 wp theme install twentythirteen --activate
+wp theme install twentytwentyone
 wp eval '$home = get_page_by_title("Welcome to CiviCRM with WordPress"); update_option("page_on_front", $home->ID); update_option("show_on_front", "page");'
 
 wp plugin activate civicrm

--- a/app/config/wp-clean/install.sh
+++ b/app/config/wp-clean/install.sh
@@ -49,6 +49,7 @@ wp option set timezone_string $TZ
 wp rewrite structure '/%postname%/'
 wp rewrite flush --hard
 wp theme install twentythirteen --activate
+wp theme install twentytwentyone
 
 wp plugin activate civicrm
 wp eval '$c=[civi_wp(), "add_wpload_setting"]; if (is_callable($c)) $c();' ## Temporary workaround, init wpLoadPh

--- a/app/config/wp-demo/install.sh
+++ b/app/config/wp-demo/install.sh
@@ -54,6 +54,7 @@ wp plugin install wordpress-importer --activate
 wp import "$SITE_CONFIG_DIR/civicrm-wordpress.xml" --authors=create
 wp search-replace 'http://civicrm-wordpress.ex' "$SITE_URL"
 wp theme install twentythirteen --activate
+wp theme install twentytwentyone
 wp eval '$home = get_page_by_title("Welcome to CiviCRM with WordPress"); update_option("page_on_front", $home->ID); update_option("show_on_front", "page");'
 
 wp plugin activate civicrm

--- a/app/config/wp-empty/install.sh
+++ b/app/config/wp-empty/install.sh
@@ -29,6 +29,7 @@ wp post delete 2
 wp rewrite structure '/%postname%/'
 wp rewrite flush --hard
 wp theme install twentythirteen --activate
+wp theme install twentytwentyone
 
 wp user create "$DEMO_USER" "$DEMO_EMAIL" --user_pass="$DEMO_PASS"
 

--- a/phars.json
+++ b/phars.json
@@ -99,8 +99,8 @@
    },
 
    "wp":  {
-     "url": "https://github.com/wp-cli/wp-cli/releases/download/v2.10.0/wp-cli-2.10.0.phar",
-     "sha256": "4c6a93cecae7f499ca481fa7a6d6d4299c8b93214e5e5308e26770dbfd3631df",
+     "url": "https://github.com/wp-cli/wp-cli/releases/download/v2.12.0/wp-cli-2.12.0.phar",
+     "sha256": "ce34ddd838f7351d6759068d09793f26755463b4a4610a5a5c0a97b68220d85c",
      "buildkit-path": "bin/wp"
    },
 


### PR DESCRIPTION
Latest wp-cli is v 2.12.   Backwards Compatible to php 5.6 and WP 4.1 and adds php 8.4 compatibility - https://make.wordpress.org/cli/2025/05/07/wp-cli-v2-12-0-release-notes/

