### PR TITLE
PHP `imap` (PECL) is not really required

### DIFF
--- a/bin/civi-download-tools
+++ b/bin/civi-download-tools
@@ -388,7 +388,7 @@ function get_system_installer() {
 
 function do_system_xenial() { # LTS Removal Oct 2021
   set -e
-    PACKAGES="acl git wget unzip zip mysql-server mysql-client php7.3-cli php7.3-imap php7.3-ldap php7.3-curl php7.3-mysql php7.3-intl php7.3-gd php7.3-mcrypt php7.3-bcmath php7.3-mbstring php7.3-soap php7.3-zip php7.3-xml apache2 libapache2-mod-php7.3 nodejs"
+    PACKAGES="acl git wget unzip zip mysql-server mysql-client php7.3-cli php7.3-ldap php7.3-curl php7.3-mysql php7.3-intl php7.3-gd php7.3-mcrypt php7.3-bcmath php7.3-mbstring php7.3-soap php7.3-zip php7.3-xml apache2 libapache2-mod-php7.3 nodejs"
     UBUNTU_VERSION=$(lsb_release -ds)
     echo "Detected $UBUNTU_VERSION."
     echo ""
@@ -403,7 +403,6 @@ function do_system_xenial() { # LTS Removal Oct 2021
       sudo apt-get -y install $PACKAGES
       sudo phpenmod bcmath
       sudo phpenmod curl
-      sudo phpenmod imap
       sudo phpenmod xml
       sudo a2enmod rewrite
       sudo apache2ctl restart
@@ -418,7 +417,7 @@ function do_system_xenial() { # LTS Removal Oct 2021
 
 function do_system_bionic() { # LTS Removal October 2023
   set -e
-    PACKAGES="acl git wget unzip zip mysql-server mysql-client php7.4-cli php7.4-imap php7.4-ldap php7.4-curl php7.4-mysql php7.4-intl php7.4-gd php7.4-dev php7.4-bcmath php7.4-mbstring php7.4-soap php7.4-zip php7.4-xml apache2 libapache2-mod-php7.4 nodejs php-pear libmcrypt-dev libreadline-dev curl"
+    PACKAGES="acl git wget unzip zip mysql-server mysql-client php7.4-cli php7.4-ldap php7.4-curl php7.4-mysql php7.4-intl php7.4-gd php7.4-dev php7.4-bcmath php7.4-mbstring php7.4-soap php7.4-zip php7.4-xml apache2 libapache2-mod-php7.4 nodejs php-pear libmcrypt-dev libreadline-dev curl"
     UBUNTU_VERSION=$(lsb_release -ds)
     echo "Detected $UBUNTU_VERSION."
     echo ""
@@ -432,7 +431,6 @@ function do_system_bionic() { # LTS Removal October 2023
       sudo apt-get -y install $PACKAGES
       sudo phpenmod bcmath
       sudo phpenmod curl
-      sudo phpenmod imap
       sudo phpenmod xml
       sudo a2enmod rewrite
       sudo apache2ctl restart
@@ -447,7 +445,7 @@ function do_system_bionic() { # LTS Removal October 2023
 
 function do_system_jammy() { # LTS Removal October 2027
   set -e
-    PACKAGES="acl git wget unzip zip mysql-server mysql-client php7.4-cli php7.4-imap php7.4-ldap php7.4-curl php7.4-mysql php7.4-intl php7.4-gd php7.4-dev php7.4-bcmath php7.4-mbstring php7.4-soap php7.4-zip php7.4-xml apache2 libapache2-mod-php7.4 nodejs php-pear libreadline-dev curl"
+    PACKAGES="acl git wget unzip zip mysql-server mysql-client php7.4-cli php7.4-ldap php7.4-curl php7.4-mysql php7.4-intl php7.4-gd php7.4-dev php7.4-bcmath php7.4-mbstring php7.4-soap php7.4-zip php7.4-xml apache2 libapache2-mod-php7.4 nodejs php-pear libreadline-dev curl"
     UBUNTU_VERSION=$(lsb_release -ds)
     echo "Detected $UBUNTU_VERSION."
     echo ""
@@ -461,7 +459,6 @@ function do_system_jammy() { # LTS Removal October 2027
       sudo apt-get -y install $PACKAGES
       sudo phpenmod bcmath
       sudo phpenmod curl
-      sudo phpenmod imap
       sudo phpenmod xml
       sudo a2enmod rewrite
       sudo apache2ctl restart
@@ -476,7 +473,7 @@ function do_system_jammy() { # LTS Removal October 2027
 
 function do_system_focal() { # LTS Removal October 2025
   set -e
-    PACKAGES="acl git wget unzip zip mysql-server mysql-client php7.4-cli php7.4-imap php7.4-ldap php7.4-curl php7.4-mysql php7.4-intl php7.4-gd php7.4-dev php7.4-bcmath php7.4-mbstring php7.4-soap php7.4-zip php7.4-xml apache2 libapache2-mod-php7.4 nodejs php-pear libreadline-dev curl"
+    PACKAGES="acl git wget unzip zip mysql-server mysql-client php7.4-cli php7.4-ldap php7.4-curl php7.4-mysql php7.4-intl php7.4-gd php7.4-dev php7.4-bcmath php7.4-mbstring php7.4-soap php7.4-zip php7.4-xml apache2 libapache2-mod-php7.4 nodejs php-pear libreadline-dev curl"
     UBUNTU_VERSION=$(lsb_release -ds)
     echo "Detected $UBUNTU_VERSION."
     echo ""
@@ -490,7 +487,6 @@ function do_system_focal() { # LTS Removal October 2025
       sudo apt-get -y install $PACKAGES
       sudo phpenmod bcmath
       sudo phpenmod curl
-      sudo phpenmod imap
       sudo phpenmod xml
       sudo a2enmod rewrite
       sudo apache2ctl restart
@@ -505,7 +501,7 @@ function do_system_focal() { # LTS Removal October 2025
 
 function do_system_stretch() {
   set -e
-    PACKAGES="acl git wget unzip zip mysql-server mysql-client php7.3-cli php7.3-imap php7.3-ldap php7.3-curl php7.3-mysql php7.3-intl php7.3-gd php7.3-dev php7.3-bcmath php7.3-mbstring php7.3-soap php7.3-zip php7.3-xml apache2 libapache2-mod-php7.3 nodejs"
+    PACKAGES="acl git wget unzip zip mysql-server mysql-client php7.3-cli php7.3-ldap php7.3-curl php7.3-mysql php7.3-intl php7.3-gd php7.3-dev php7.3-bcmath php7.3-mbstring php7.3-soap php7.3-zip php7.3-xml apache2 libapache2-mod-php7.3 nodejs"
     echo "Detected \"Debian Stretch\"."
     echo ""
     echo "Installing nodejs Debian repository."
@@ -520,7 +516,6 @@ function do_system_stretch() {
       sudo echo "deb https://packages.sury.org/php/ stretch main" | tee /etc/apt/sources.list.d/php.list
       wget -O- https://deb.nodesource.com/setup_14.x | sudo -E bash -
       sudo apt-get -y install $PACKAGES
-      sudo phpenmod imap
       sudo a2enmod rewrite
       sudo apache2ctl restart
     else
@@ -534,7 +529,7 @@ function do_system_stretch() {
 
 function do_system_buster() {
   set -e
-    PACKAGES="acl git wget unzip zip default-mysql-server default-mysql-client php7.4-cli php7.4-imap php7.4-ldap php7.4-curl php7.4-mysql php7.4-intl php7.4-gd php7.4-dev php7.4-bcmath php7.4-mbstring php7.4-soap php7.4-zip php7.4-xml apache2 libapache2-mod-php7.4 nodejs php-pear"
+    PACKAGES="acl git wget unzip zip default-mysql-server default-mysql-client php7.4-cli php7.4-ldap php7.4-curl php7.4-mysql php7.4-intl php7.4-gd php7.4-dev php7.4-bcmath php7.4-mbstring php7.4-soap php7.4-zip php7.4-xml apache2 libapache2-mod-php7.4 nodejs php-pear"
     echo "Detected \"Debian Buster\"."
     echo ""
     echo "Recommended packages: $PACKAGES"
@@ -545,7 +540,6 @@ function do_system_buster() {
       sudo echo "deb https://packages.sury.org/php/ buster main" | tee /etc/apt/sources.list.d/php.list
       wget -O- https://deb.nodesource.com/setup_14.x | sudo -E bash -
       sudo apt-get -y install $PACKAGES
-      sudo phpenmod imap
       sudo a2enmod rewrite
       sudo apache2ctl restart
     else
@@ -559,7 +553,7 @@ function do_system_buster() {
 
 function do_system_bullseye() {
   set -e
-    PACKAGES="acl git wget unzip zip default-mysql-server default-mysql-client php7.4-cli php7.4-imap php7.4-ldap php7.4-curl php7.4-mysql php7.4-intl php7.4-gd php7.4-dev php7.4-bcmath php7.4-mbstring php7.4-soap php7.4-zip php7.4-xml apache2 libapache2-mod-php7.4 nodejs php-pear"
+    PACKAGES="acl git wget unzip zip default-mysql-server default-mysql-client php7.4-cli php7.4-ldap php7.4-curl php7.4-mysql php7.4-intl php7.4-gd php7.4-dev php7.4-bcmath php7.4-mbstring php7.4-soap php7.4-zip php7.4-xml apache2 libapache2-mod-php7.4 nodejs php-pear"
     echo "Detected \"Debian Bullseye\"."
     echo ""
     echo "Recommended packages: $PACKAGES"
@@ -570,7 +564,6 @@ function do_system_bullseye() {
       sudo echo "deb https://packages.sury.org/php/ bullseye main" | sudo tee /etc/apt/sources.list.d/php.list
       wget -O- https://deb.nodesource.com/setup_14.x | sudo -E bash -
       sudo apt-get -y install $PACKAGES
-      sudo phpenmod imap
       sudo a2enmod rewrite
       sudo apache2ctl restart
     else
@@ -834,7 +827,6 @@ check_php_ext bcmath recommended
 check_php_ext gd recommended
 check_php_ext gettext recommended
 check_php_ext hash recommended
-check_php_ext imap recommended
 check_php_ext intl recommended
 check_php_ext mbstring recommended
 

--- a/nix/README.md
+++ b/nix/README.md
@@ -170,10 +170,6 @@ FIXME: rewrite this for master-loco branch
 
 Some of these policies/opinions can be changed, as described below ("Extended installation")
 
-## TODO/Issues
-
-* Sort out php-imap
-
 ## Tips
 
 (**Stale**: These tips should be rewritten to match the new "Quick Start" approach)

--- a/nix/pkgs/php81/default.nix
+++ b/nix/pkgs/php81/default.nix
@@ -16,7 +16,7 @@ let
 in pkgs.php81.buildEnv {
 
   ## EVALUATE: apcu_bc
-  extensions = { all, enabled}: with all; enabled++ [ phpExtras.xdebug3 redis tidy apcu imap yaml memcached imagick opcache phpExtras.runkit7_4 ];
+  extensions = { all, enabled}: with all; enabled++ [ phpExtras.xdebug3 redis tidy apcu yaml memcached imagick opcache phpExtras.runkit7_4 ];
   extraConfig = phpIniSnippet1 + phpIniSnippet2;
 
 }

--- a/nix/pkgs/php82/default.nix
+++ b/nix/pkgs/php82/default.nix
@@ -16,7 +16,7 @@ let
 in pkgs.php82.buildEnv {
 
   ## EVALUATE: apcu_bc
-  extensions = { all, enabled }: with all; enabled++ [ phpExtras.xdebug32 redis tidy apcu imap yaml memcached imagick opcache phpExtras.runkit7_4 ];
+  extensions = { all, enabled }: with all; enabled++ [ phpExtras.xdebug32 redis tidy apcu yaml memcached imagick opcache phpExtras.runkit7_4 ];
   extraConfig = phpIniSnippet1 + phpIniSnippet2;
 
 }

--- a/nix/pkgs/php83/default.nix
+++ b/nix/pkgs/php83/default.nix
@@ -16,7 +16,7 @@ let
 in pkgs.php83.buildEnv {
 
   ## EVALUATE: apcu_bc
-  extensions = { all, enabled }: with all; enabled++ [ phpExtras.xdebug33 redis tidy apcu imap yaml memcached imagick opcache phpExtras.runkit7_4 ];
+  extensions = { all, enabled }: with all; enabled++ [ phpExtras.xdebug33 redis tidy apcu yaml memcached imagick opcache phpExtras.runkit7_4 ];
   extraConfig = phpIniSnippet1 + phpIniSnippet2;
 
 }

--- a/nix/pkgs/php84/default.nix
+++ b/nix/pkgs/php84/default.nix
@@ -17,7 +17,7 @@ in pkgs.php84.buildEnv {
 
   ## EVALUATE: apcu_bc
   ## TODO: phpExtras.runkit7_4
-  extensions = { all, enabled }: with all; enabled++ [ phpExtras.xdebug34 tidy yaml memcached imagick opcache apcu redis imap ];
+  extensions = { all, enabled }: with all; enabled++ [ phpExtras.xdebug34 tidy yaml memcached imagick opcache apcu redis ];
   extraConfig = phpIniSnippet1 + phpIniSnippet2;
 
 }


### PR DESCRIPTION
I'm seeing this path: Civi uses Zeta's `ezcMailImapTransport` (which does some file/socket-style interaction) and doesn't call `imap_*()` or `IMAP\Connection`.