### PR TITLE
joomlatools-console - Drop from buildkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ For installation instructions and other documentation, see [CiviCRM Developer Gu
     * [`civibuild`](https://docs.civicrm.org/dev/en/latest/tools/civibuild/) - Build a complete source tree (with CMS+Civi+addons), provision httpd/sql, etc.
     * `civihydra` - Create a series test sites for several CMSs. (Extends `civibuild`.)
     * [`drush` and `drush8`](https://www.drush.org/) - Administer a Drupal site.
-    * [`joomla`](https://www.joomlatools.com/developer/tools/console/) (joomla-console) - Administer a Joomla site.
     * [`wp`](https://wp-cli.org/) (wp-cli) - Administer a WordPress site.
 * Testing
     * [`civicrm-upgrade-test`](https://github.com/civicrm/civicrm-upgrade-test) - Scripts and data files for testing upgrades.

--- a/app/config/joomla-demo/download.sh
+++ b/app/config/joomla-demo/download.sh
@@ -5,11 +5,11 @@
 ###############################################################################
 
 CMS_VERSION=${CMS_VERSION:-latest}
-CMS_ROOT="$WEB_ROOT/joomla"
 
-cvutil_mkdir "$WEB_ROOT" "$WEB_ROOT/src"
+## Joomla has strong expectation of writeable web-root -- eg can't run Civi installer otherwise. :(
+amp datadir "$WEB_ROOT" "$WEB_ROOT/web"
 
-joomla site:download joomla --release="$CMS_VERSION" --www="$WEB_ROOT"
+joomla4_download "$WEB_ROOT/web"
 
 pushd "$WEB_ROOT" >> /dev/null
   git_cache_clone civicrm/civicrm-joomla            -b "$CIVI_VERSION" src/civicrm

--- a/app/config/joomla-demo/install.sh
+++ b/app/config/joomla-demo/install.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 ## install.sh -- Create config files and databases; fill the databases
+[ -d "$WEB_ROOT/web" ] && CMS_ROOT="$WEB_ROOT/web"
 
 ###############################################################################
 ## Create virtual-host and databases

--- a/bin/civi-download-tools
+++ b/bin/civi-download-tools
@@ -21,7 +21,6 @@ PRJDIR=$(dirname "$BINDIR")
 LOCKFILE="$TMPDIR/civi-download-tools.lock"
 LOCKTIMEOUT=90
 HUB_VERSION="2.14.2"
-JOOMLATOOLS_CONSOLE_VERSION="v1.5.9"
 COMPOSER_VERSION="2.8.4"
 COMPOSER_URL="https://github.com/composer/composer/releases/download/${COMPOSER_VERSION}/composer.phar"
 IS_QUIET=
@@ -317,50 +316,6 @@ function install_composer() {
   fi
 }
 
-###############################################################################
-## Install the project 'joomlatools/console' in 'extern/joomlatools-console'
-## Note that this uses a separate folder becuase:
-##  1. Some of the dependencies don't agree with other top-level packages.
-##  2. The file structure allows writing data to funny places.
-##
-## usage: install_joomlatools_console <version-tag-branch>
-function install_joomlatools_console() {
-  local VERSION="$1"
-  local WRAPPER="$PRJDIR/bin/joomla"
-  local SRC="$PRJDIR/extern/joomlatools-console"
-  local MARKER="$PRJDIR/extern/joomlatools-console.txt"
-
-  ## Create/update wrapper script
-  ## Note: joomla was previously downloaded via other means (and gitignored). This "cp" ensures we overwrite without git conflicts.
-  if [ ! -f "$WRAPPER" -o "$PRJDIR/src/joomlatools-console.tmpl" -nt  "$WRAPPER" ]; then
-    echo "[[joomlatools-console ($WRAPPER): Generate wrapper]]"
-    cp "$PRJDIR/src/joomlatools-console.tmpl" "$WRAPPER"
-  fi
-
-  ## Do we need to download?
-  touch "$MARKER"
-  if [ -z "$IS_FORCE" -a -e "$SRC/bin/joomla" -a "$(cat $MARKER)" == "$VERSION" ]; then
-    echo_comment "[[joomla ($PRJDIR/extern/joomlatools-console) already exists. Skipping.]]"
-    return
-  fi
-  echo "[[Install joomlatools-console $VERSION]]"
-
-  ## Cleanup any previous downloads
-  [ -e "$SRC" ] && rm -rf "$SRC"
-
-  ## Download
-  git clone -b "$VERSION" --depth 1 https://github.com/joomlatools/joomlatools-console "$SRC"
-  pushd "$SRC" >> /dev/null
-    ## In 1.5.9, the lock file is pegged to libraries that aren't compatible with our env. Resolve dependencies anew.
-    rm -f composer.lock
-    "$PRJDIR/bin/composer" update --prefer-lowest
-    "$PRJDIR/bin/composer" install
-  popd >> /dev/null
-
-  ## Mark as downloaded
-  echo "$VERSION" > "$MARKER"
-}
-
 ##################################################
 ## Validation
 check_command php required
@@ -436,6 +391,8 @@ pushd $PRJDIR >> /dev/null
   [ -f "$PRJDIR/extern/wp-cli.txt" ] && rm -f "$PRJDIR/bin/wp" "$PRJDIR/extern/wp-cli.txt"
   [ -f "$PRJDIR/extern/civici.txt" ] && rm -f  "$PRJDIR/bin/civici" "$PRJDIR/extern/civici.txt"
   [ -f "$PRJDIR/extern/joomla.txt" ] && rm -f "$PRJDIR/bin/joomla" "$PRJDIR/extern/joomla.txt"
+  [ -f "$PRJDIR/extern/joomlatools-console.txt" ] && rm -f "$PRJDIR/bin/joomla" "$PRJDIR/extern/joomlatools-console.txt"
+  [ -d "$PRJDIR/extern/joomlatools-console" ] && rm -rf "$PRJDIR/extern/joomlatools-console"
   [ -f "$PRJDIR/extern/codecept-php5.txt" ] && rm -f "$PRJDIR/bin/_codecept-php5.phar" "$PRJDIR/extern/codecept-php5.txt"
   [ -f "$PRJDIR/extern/codecept-php7.txt" ] && rm -f "$PRJDIR/bin/_codecept-php7.phar" "$PRJDIR/extern/codecept-php7.txt"
   [ -f "$PRJDIR/extern/drush-lib-backdrop.txt" ] && rm -rf "$PRJDIR/extern/drush-lib/backdrop" "$PRJDIR/extern/drush-lib-backdrop.txt"
@@ -528,9 +485,6 @@ pushd $PRJDIR >> /dev/null
   make_link "$PRJDIR/bin" "../extern/phpunit8/phpunit8.phar" "phpunit8"
   make_link "$PRJDIR/bin" "../extern/phpunit9/phpunit9.phar" "phpunit9"
   make_link "$PRJDIR/bin" "../extern/phpunit10/phpunit10.phar" "phpunit10"
-
-  ## Download joomlatools-console
-  install_joomlatools_console "$JOOMLATOOLS_CONSOLE_VERSION"
 
   ## Download "hub"
   touch "$PRJDIR/extern/hub.txt"


### PR DESCRIPTION
Now that we have `joomlaX_download()` functions, `civibuild` doesn't need `joomlatools-console`. And it appears to be unmaintained (*no commits for 2 years*). And it's awkward to download.

cc @aydun @seamuslee001 