### PR TITLE
hub - Partially remove support for partially orphaned package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,7 +54,6 @@ bin/git-php-symbol-diff
 bin/git-scan
 bin/git-scan.bat
 bin/grunt
-bin/hub
 bin/import-rn
 bin/jshint
 bin/karma

--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ For installation instructions and other documentation, see [CiviCRM Developer Gu
 * Source code management
     * [`git-scan`](https://github.com/totten/git-scan/) - Manage a large number of git repositories.
     * `gitify` - Convert a CiviCRM installation to a git repo.
-    * [`hub`](https://hub.github.com/) - Send commands to `github.com`.
 * Source code quality
     * `civilint` - Check the syntax of uncommitted files using `phpcs`, `jshint`, etc.
     * [`jshint`](http://jshint.com/) - Check the syntax of Javascript files.

--- a/bin/civi-download-tools
+++ b/bin/civi-download-tools
@@ -20,7 +20,6 @@ PRJDIR=$(dirname "$BINDIR")
 [ -z "$CIVIBUILD_HOME" ] && TMPDIR="$PRJDIR/app/tmp" || TMPDIR="$CIVIBUILD_HOME/.civibuild/tmp"
 LOCKFILE="$TMPDIR/civi-download-tools.lock"
 LOCKTIMEOUT=90
-HUB_VERSION="2.14.2"
 COMPOSER_VERSION="2.8.4"
 COMPOSER_URL="https://github.com/composer/composer/releases/download/${COMPOSER_VERSION}/composer.phar"
 IS_QUIET=
@@ -265,42 +264,6 @@ function cvutil_confirm() {
   esac
 }
 
-###############################################################################
-## usage: get_hub_url <version>
-
-# Examples:
-# https://github.com/github/hub/releases/download/v2.2.3/hub-darwin-amd64-2.2.3.tgz
-# https://github.com/github/hub/releases/download/v2.2.3/hub-linux-386-2.2.3.tgz
-# https://github.com/github/hub/releases/download/v2.2.3/hub-linux-amd64-2.2.3.tgz
-# https://github.com/github/hub/releases/download/v2.2.3/hub-windows-386-2.2.3.zip
-# https://github.com/github/hub/releases/download/v2.2.3/hub-windows-amd64-2.2.3.zip
-
-function get_hub_url() {
-  local VERSION="$1"
-  local PLATFORM=
-  local FORMAT=
-
-  case $(uname -a) in
-    *Darwin*x86_64*)
-      PLATFORM=darwin-amd64
-      FORMAT=tgz
-      ;;
-    *Linux*x86_64*)
-      PLATFORM=linux-amd64
-      FORMAT=tgz
-      ;;
-    *Linux*i386*|*Linux*i686*)
-      PLATFORM=linux-386
-      FORMAT=tgz
-      ;;
-    *)
-      echo ""
-      return
-  esac
-
-  echo https://github.com/github/hub/releases/download/v${VERSION}/hub-${PLATFORM}-${VERSION}.${FORMAT}
-}
-
 function install_composer() {
   if [ -z "$IS_FORCE" -a -e "$PRJDIR/bin/composer" -a "$(cat $PRJDIR/extern/composer.txt)" == "$COMPOSER_VERSION" ]; then
     echo_comment "[[composer ($PRJDIR/bin/composer) already exists. Skipping.]]"
@@ -404,6 +367,8 @@ pushd $PRJDIR >> /dev/null
   [ -f "$PRJDIR/extern/phpunit4/phpunit4.phar" ] && rm -f "$PRJDIR/extern/phpunit4/phpunit4.phar"
   [ -f "$PRJDIR/extern/phpunit5/phpunit5.phar" ] && rm -f "$PRJDIR/extern/phpunit5/phpunit5.phar"
   [ -f "$PRJDIR/extern/phpunit6/phpunit6.phar" ] && rm -f "$PRJDIR/extern/phpunit6/phpunit6.phar"
+  [ -f "$PRJDIR/extern/hub.txt" ] && rm -f "$PRJDIR/bin/hub" "$PRJDIR/extern/hub.txt"
+  [ -d "$PRJDIR/extern/hub" ] && rm -rf "$PRJDIR/extern/hub"
 
   ## Cleanup misnamed files from past
   [ -f "$PRJDIR/extern/phpunit4/phpunit6.phar" ] && rm -f "$PRJDIR/extern/phpunit4/phpunit6.phar" "$PRJDIR/extern/phpunit4/phpunit6.phar"
@@ -485,43 +450,6 @@ pushd $PRJDIR >> /dev/null
   make_link "$PRJDIR/bin" "../extern/phpunit8/phpunit8.phar" "phpunit8"
   make_link "$PRJDIR/bin" "../extern/phpunit9/phpunit9.phar" "phpunit9"
   make_link "$PRJDIR/bin" "../extern/phpunit10/phpunit10.phar" "phpunit10"
-
-  ## Download "hub"
-  touch "$PRJDIR/extern/hub.txt"
-  if [ -z "$IS_FORCE" -a -e "$PRJDIR/extern/hub/bin/hub" -a -e "$PRJDIR/bin/hub" -a "$(cat $PRJDIR/extern/hub.txt)" == "$HUB_VERSION" ]; then
-    echo_comment "[[hub ($PRJDIR/extern/hub) already exists. Skipping.]]"
-  else
-    HUBURL=$(get_hub_url $HUB_VERSION)
-    if [ -z "$HUBURL" ]; then
-      echo "[[Skip hub. Could not determine binary.]]"
-    else
-      echo "[[Install hub]]"
-
-      ## Cleanup
-      [ -e app/tmp/hub ] && rm -rf app/tmp/hub
-      [ -e extern/hub ] && rm -rf extern/hub
-      [ -e "$TMPDIR/hub.tgz" ] && rm -f "$TMPDIR/hub.tgz"
-      mkdir -p app/tmp extern/hub
-
-      ## Download
-      download_url "$HUBURL" "$TMPDIR/hub.tgz"
-
-      ## Build
-      pushd extern/hub >> /dev/null
-        tar --strip-components=1 -xvzf "$TMPDIR/hub.tgz"
-      popd >> /dev/null
-
-      ## Setup a relative symlink
-      pushd bin >> /dev/null
-        [ -f hub ] && rm -f hub
-        ln -s ../extern/hub/bin/hub hub
-      popd >> /dev/null
-
-      ## Mark as downloaded
-      echo "$HUB_VERSION" > "$PRJDIR/extern/hub.txt"
-
-    fi
-  fi
 
 popd >> /dev/null
 set +e


### PR DESCRIPTION
# Motivation

I'm trying to cleanup `civi-download-tools`. The download step for `hub` is a bit convoluted, and `hub` is getting a bit obsolete.

# Background

The `hub` command provides a CLI interface to Github.com.  It was originally developed and maintained by Github.com, but they eventually replaced it with "Github CLI" (`gh`).

The last release of `hub` was 2.14.2 (Mar 2020).

There appears to be a fork at `mislav/hub`, but it's status is mixed:

* nixpkgs is currently shipping that fork (https://github.com/NixOS/nixpkgs/blob/25.05/pkgs/by-name/hu/hub/package.nix). So it must better than 2.14.2...
* But the fork hasn't been updated in a while, and it hasn't had its own release.

To my recollection, we haven't really been advertising/teaching people about the `hub` command for a few years.  Github stopped advertising it.  I've stopped using it (in favor of `givi` and `git-scan`). There's only one (oblique) reference to it in devdocs.

# Change

This change drops `hub` from `civi-download-tools`.

However, I've left the other reference to `hub` in `nix/profiles/base/` -- it appears that nixpkgs has someone thinking about `hub`, and I don't really believe it's bad or expensive tool. (*It's not important enough to work hard to keep it; but if it's easy, it's fine.*)