### PR TITLE
civi-download-tools - Remove unused functions

### DIFF
--- a/bin/civi-download-tools
+++ b/bin/civi-download-tools
@@ -225,36 +225,6 @@ function check_php_ext() {
   fi
 }
 
-###############################################################################
-## Prompt user for confirmation
-## (In automated scripts or blank response, use default)
-##
-## usage: cvutil_confirm <message> <interactive-default> <script-default>
-## example: cvutil_confirm "Are you sure? [Y/n] " y y
-function cvutil_confirm() {
-  local msg="$1"
-  local i_default="$2"
-  local s_default="$3"
-  if tty -s ; then
-    echo -n "$msg"
-    read _cvutil_confirm
-    if [ "x$_cvutil_confirm" == "x" ]; then
-      _cvutil_confirm="$i_default"
-    fi
-  else
-    echo "${msg}${s_default}"
-    _cvutil_confirm="$s_default"
-  fi
-  case "$_cvutil_confirm" in
-    y|Y|1)
-      return 0
-      ;;
-    *)
-      return 1
-      ;;
-  esac
-}
-
 function install_composer() {
   if [ -z "$IS_FORCE" -a -e "$PRJDIR/bin/composer" -a "$(cat $PRJDIR/extern/composer.txt)" == "$COMPOSER_VERSION" ]; then
     echo_comment "[[composer ($PRJDIR/bin/composer) already exists. Skipping.]]"


### PR DESCRIPTION
These became unnecessary after dropping support for `--full` (#936).