### PR TITLE
composer.json - Bump PHP minimum (php72=>php73). Drop paratest.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,8 +55,6 @@ bin/grunt
 bin/import-rn
 bin/jshint
 bin/karma
-bin/paratest
-bin/paratest.bat
 bin/phantomjs
 bin/phive
 bin/php-symbol-diff

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Breaking changes:
 
 * `civi-download-tools`: Drop support for `hub` (#941) and `joomlatools-console` (#940)
 * `civi-download-tools`: Drop support for the `--full` option (#936)
+* `composer.json`: Drop support for PHP 7.2. Drop unused `paratest`. (#944)
 * __Nix__: Drop ancient packages `php71`, `php72`, `mysql56`, `mariadb105` (#926)
 * __Nix__: Drop PHP's `imap` PECL (#934)
 * __Vagrant__: Drop all support (#937)

--- a/README.md
+++ b/README.md
@@ -35,5 +35,4 @@ For installation instructions and other documentation, see [CiviCRM Developer Gu
 * Testing
     * [`civicrm-upgrade-test`](https://github.com/civicrm/civicrm-upgrade-test) - Scripts and data files for testing upgrades.
     * [`karma`](https://karma-runner.github.io) (w/[jasmine](https://jasmine.github.io/)) - Unit testing for Javascript.
-    * [`paratest`](https://github.com/brianium/paratest) - Parallelized version of PHPUnit.
     * [`phpunit` and `phpunit4`](https://phpunit.de/) - Unit testing for PHP (with Selenium and DB add-ons).

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
   },
   "config": {
     "platform": {
-      "php": "7.2"
+      "php": "7.3"
     },
     "bin-dir": "bin",
     "allow-plugins": {
@@ -23,7 +23,7 @@
     }
   },
   "require": {
-    "php": ">=7.2",
+    "php": ">=7.3",
     "totten/php-symbol-diff": "dev-master#54f869ca68a3cd75f3386f8490870369733d2c23",
     "civicrm/upgrade-test": "0.9",
     "drupal/coder": "dev-8.x-2.x-civi#e615288017c667e091b2f7d22507ad3a09227ce7",

--- a/composer.json
+++ b/composer.json
@@ -35,10 +35,6 @@
     {
       "type": "git",
       "url": "https://github.com/civicrm/coder.git"
-    },
-    {
-      "type": "git",
-      "url": "https://github.com/totten/paratest.git"
     }
   ],
   "extra": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "124a8eb518914876d50d8972ec6e93a3",
+    "content-hash": "fad1e0aef1287fea580bb120a703d690",
     "packages": [
         {
             "name": "civicrm/composer-compile-plugin",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fe428c9f540ef3a4e41af790b831e979",
+    "content-hash": "124a8eb518914876d50d8972ec6e93a3",
     "packages": [
         {
             "name": "civicrm/composer-compile-plugin",
@@ -245,12 +245,12 @@
             "version": "3.7.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
                 "reference": "1359e176e9307e906dc3d890bcc9603ff6d90619"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/1359e176e9307e906dc3d890bcc9603ff6d90619",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/1359e176e9307e906dc3d890bcc9603ff6d90619",
                 "reference": "1359e176e9307e906dc3d890bcc9603ff6d90619",
                 "shasum": ""
             },
@@ -575,11 +575,11 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.2"
+        "php": ">=7.3"
     },
     "platform-dev": {},
     "platform-overrides": {
-        "php": "7.2"
+        "php": "7.3"
     },
     "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
1. Recently dropped support for php72 from buildkit-nix. No point targetting php72 base.
2. Drop paratest. We haven't been using it. (There's a longer rationale on the individual commit.)