### PR TITLE
dont set builddir after 2019Q4

### DIFF
--- a/.loco/config/buildkit/civibuild.conf
+++ b/.loco/config/buildkit/civibuild.conf
@@ -5,10 +5,6 @@ if [ -z "$LOCO_PRJ" ]; then
    exit 1
 fi
 
-## FIXME: Setting BLDDIR will be redundant b/c loco sets CIVIBUILD_HOME;
-## we'll keep for transitional moment. Remove circa 2019Q4.
-BLDDIR="$HTTPD_VDROOT"
-
 if [ -n "$CIVIBUILD_URL_TEMPLATE" ]; then
   URL_TEMPLATE="$CIVIBUILD_URL_TEMPLATE"
 else


### PR DESCRIPTION
Is the transitional moment over?