### PR TITLE
civibuild - Change default URL formula for autobuilds and some local-dev

### DIFF
--- a/.loco/loco.yml
+++ b/.loco/loco.yml
@@ -16,7 +16,8 @@ default_environment:
  # - HOSTS_TYPE=file
 
  ## HTTPD_*: Determine how a local folder (eg "./build/dmaster") relates to a local HTTP service (eg "http://dmaster.bknix:8001").
- - HTTPD_DOMAIN=${LOCALHOST}.nip.io
+ # HTTPD_DOMAIN=${LOCALHOST}.nip.io
+ - HTTPD_DOMAIN=$(civi-domain "$LOCALHOST")
  - HTTPD_PORT=8001
  - HTTPD_VDROOT=$LOCO_PRJ/build
  - HTTPD_VISIBILITY=local

--- a/.loco/plugin/civi-domain.php
+++ b/.loco/plugin/civi-domain.php
@@ -1,0 +1,17 @@
+<?php
+namespace Loco;
+
+Loco::dispatcher()->addListener('loco.expr.functions', function (LocoEvent $e) {
+
+  $e['functions']['civi-domain'] = function ($ip) {
+    $ip = trim($ip);
+    if (empty($ip) || $ip === '127.0.0.1') {
+      return 'local.civi.bid';
+    }
+    else {
+      $ip = str_replace('.', '-', $ip);
+      return $ip . '.ip.civi.bid';
+    }
+  };
+
+});

--- a/.loco/plugin/civi-domain.php
+++ b/.loco/plugin/civi-domain.php
@@ -5,6 +5,19 @@ Loco::dispatcher()->addListener('loco.expr.functions', function (LocoEvent $e) {
 
   $e['functions']['civi-domain'] = function ($ip) {
     $ip = trim($ip);
+
+    // There are two options here.
+    //
+    // `*.local.civi.bid`: For most deployments with `127.0.0.1`, we use a
+    // simpler and prettier wildcard.  It can be easily supported by common
+    // DNS infra.
+    //
+    // `*.ip.civi.bid`: The IP-based wildcard is a more general and elegant
+    // solution, but it needs some specialized DNS ops (e.g.  pdns-pipe) and
+    // relies on gratis/unsupported hosting.  It's prone to random
+    // de-commissioning every 4 years.  (It can be re-built, but there will
+    // be lag.)
+
     if (empty($ip) || $ip === '127.0.0.1') {
       return 'local.civi.bid';
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Breaking changes:
 * `bin/securify`: Drop old script. (Deprecated circa 2019.)
 * __Nix__: Drop ancient packages `php71`, `php72`, `mysql56`, `mariadb105` (#926)
 * __Nix__: Drop PHP's `imap` PECL (#934)
-* __Nix__: Change default domain-suffix from `X.X.X.X.nip.io` to `local.civi.bid` (or `X-X-X-X.ip.civi.bid`)
+* __Nix__: Change default domain-suffix in civibuild (`*.nip.io` => `*.civi.bid`) (#954)
 * __Vagrant__: Drop all support (#937)
 
 Additionally, several scripts have moved to their own folders. This should

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Breaking changes:
 * `bin/securify`: Drop old script. (Deprecated circa 2019.)
 * __Nix__: Drop ancient packages `php71`, `php72`, `mysql56`, `mariadb105` (#926)
 * __Nix__: Drop PHP's `imap` PECL (#934)
+* __Nix__: Change default domain-suffix from `X.X.X.X.nip.io` to `local.civi.bid` (or `X-X-X-X.ip.civi.bid`)
 * __Vagrant__: Drop all support (#937)
 
 Additionally, several scripts have moved to their own folders. This should

--- a/nix/examples/gcloud/install_all_jenkins.sh
+++ b/nix/examples/gcloud/install_all_jenkins.sh
@@ -8,7 +8,7 @@
 
 ## This ramdisk is smaller than usual because we use pre-emptible instances that don't retain data as long.
 RAMDISKSIZE=4G
-HTTPD_DOMAIN=$(curl 'http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip' -H "Metadata-Flavor: Google").nip.io
+HTTPD_DOMAIN=$(curl 'http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip' -H "Metadata-Flavor: Google" | sed 's;\.;-;g').ip.civi.bid
 PROFILES="dfl min max edge"
 
 ## There is a startup script (via https://cloud.google.com/compute/docs/instances/startup-scripts/) which calls

--- a/nix/examples/gcloud/install_all_publisher.sh
+++ b/nix/examples/gcloud/install_all_publisher.sh
@@ -6,7 +6,7 @@
 ## It defines very high-level options for installing profiles for user "publisher".
 
 RAMDISKSIZE=250M
-HTTPD_DOMAIN=$(curl 'http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip' -H "Metadata-Flavor: Google").nip.io
+HTTPD_DOMAIN=$(curl 'http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip' -H "Metadata-Flavor: Google" | sed 's;\.;-;g').ip.civi.bid
 PROFILES="min"
 
 ## There is a startup script (via https://cloud.google.com/compute/docs/instances/startup-scripts/) which calls

--- a/nix/examples/gcloud/loco-overrides.yaml
+++ b/nix/examples/gcloud/loco-overrides.yaml
@@ -1,3 +1,3 @@
 environment:
   - GCLOUD_IP=(placeholder; computed via lazy-vars.php)
-  - HTTPD_DOMAIN=${GCLOUD_IP}.nip.io
+  - HTTPD_DOMAIN=$(civi-domain "$GCLOUD_IP")

--- a/nix/examples/localonly/loco-overrides.yaml
+++ b/nix/examples/localonly/loco-overrides.yaml
@@ -2,4 +2,4 @@
 environment:
   ## Local-only deployments cannot be accessed on public Internet.
   ## But we still want a wildcard DNS for '{buildname}.{hostname}`.
-  - HTTPD_DOMAIN=${LOCALHOST}.nip.io
+  - HTTPD_DOMAIN=$(civi-domain "$LOCALHOST")

--- a/nix/examples/nip/loco-overrides.yaml
+++ b/nix/examples/nip/loco-overrides.yaml
@@ -1,4 +1,4 @@
 ## The "nip" examples are used on "A.B.C.D.nip.io" hosts
 environment:
   - EXTERNAL_IP=(placeholder; computed via lazy-vars.php)
-  - HTTPD_DOMAIN=${EXTERNAL_IP}.nip.io
+  - HTTPD_DOMAIN=$(civi-domain "$EXTERNAL_IP")

--- a/nix/examples/runner/loco-overrides.yaml
+++ b/nix/examples/runner/loco-overrides.yaml
@@ -1,5 +1,5 @@
-## The "nip" examples are used on "A.B.C.D.nip.io" hosts
+## The "nip" examples are used on "A.B.C.D.ip.civi.bid" hosts
 environment:
   ## Local-only deployments cannot be accessed on public Internet.
   ## But we still want a wildcard DNS for '{buildname}.{hostname}`.
-  - HTTPD_DOMAIN=${LOCALHOST}.nip.io
+  - HTTPD_DOMAIN=$(civi-domain "$LOCALHOST")

--- a/nix/share/desktop-xfce4/site-list.desktop
+++ b/nix/share/desktop-xfce4/site-list.desktop
@@ -4,4 +4,4 @@ Type=Link
 Name=Site List
 Comment=
 Icon=user-bookmarks
-URL=http://site-list.127.0.0.1.nip.io:8001/
+URL=http://site-list.local.civi.bid:8001/


### PR DESCRIPTION
Overview
-------------

(*This PR only affects `buildkit-nix`.*)

The `HTTPD_DOMAIN` variable determines the DNS suffix on generated sites. The formula has used a third-party service (`nip.io`) which allows us to instantly construct a valid domain without manipulating `/etc/hosts` or running a DNS server.

Unfortunately, `nip.io` has gone through major changes which break the formula. So, we need a new formula.

Before
--------

In most `buildkit-nix` deployments, `HTTPD_DOMAIN` defaults to `X.X.X.X.nip.io`.

After
------

In most `buildkit-nix` deployments, `HTTPD_DOMAIN` defaults to `local.civi.bid` or `X-X-X-X.ip.civi.bid`.

This is a cheap $5/yr domain, so I prepaid a bunch of years. It's got a little wordplay ("civibuild" <=> "civi.bid"). It's using a mix of Cloudflare and `sslip.io`.

In Depth: Transition
--------------------------

* The new default will affect new builds. The URLs will look like:
    *  `http://<NAME>.local.civi.bid:<PORT>`, or
    *  `http://<NAME>.<IP>.ip.civi.bid:<PORT>` 
* Existing builds will remain attached to existing URLs (`http://<NAME>.<IP>.nip.io:<PORT>`), even if you do `civibuild reinstall`.
* Existing URLs should work -- unless the `<NAME>` includes hyphens/numbers.
* You may wish to use the new URL formula (for compatibility or aesthetics). Here are a few ways to do that:
    1. Just open the new URL by hand. (Ignore the output of `civibuild show` and `cv url`.) Or...
    2. Edit `build/NAME.sh` and change the `CMS_URL`. Then run `civibuild reinstall NAME`. Or...
    3. Fully destroy the existing build (`civibuild destroy NAME`) and then recreate it (`civibuild create NAME`).

In Depth: The Problem
------------------------------

The primary problem was in sending HTTP requests to `<NAME>.<IP>.nip.io`.  If the `<NAME>` includes any dashes/numbers, then the request goes to the wrong `<IP>` ([nip.io#54](https://github.com/exentriquesolutions/nip.io/issues/54)). For end-to-end tests, this triggers a cascade of problems.

(The recipient `<IP>` gets annoyed by this misdirected harassment, and it decides to poison all HTTP requests. The PHP-HTTP client humbly acquiesces to the censure -- its `timeout`s are quite long. After an interminable delay, the concurrent PHP-MySQL connection gets lonesome. Unfortunately, the forsaken MySQL shares the folly of Shakespeare's Romeo - he sees the idled PHP and assumes she is dead. But PHP is like Juliet -- only sleeping! And when she awakens, she finds a true tragedy and exclaims: "_MySQL server hath gone away!_"  And this lament is the only one loud enough to echo throughout the logs of the test-console.)

But I digress.

We get the wrong `<IP>`. Why? The root issue is that `nip.io` has been replaced by another project, `sslip.io`. These two projects are similar in purpose, but the implementations/scopes/designs are different:

* `nip.io` (OG) focused on IPv4, and it consistently supported a formula like `<NAME>.<IP>.nip.io`.
* `sslip.io` adds features relating to IPv6, SSL, white-label domains, and... some kind of internal/external multi-IP thing... and probably more. (The white-label idea is pretty clever.) However, this is more complex. (*Wildcards to left of them; wildcards to the right; wildcards in the middle; the regex authors endured the longest night.*) So... the maintainers are averse about any kind of edits.

Net result: regressions affecting `nip.io` are WONTFIX, so (*for purposes of `civibuild`*), the `nip.io` formulas are broken, and we need to migrate.

