### PR TITLE
nixpkgs - Change default from v22.05 to v25.05

### DIFF
--- a/nix/pins/default.nix
+++ b/nix/pins/default.nix
@@ -14,5 +14,5 @@ rec {
   # v2405 = import ((builtins.getEnv "HOME") + "/src/nixpkgs/default.nix") {};
 
   bkit = import ../pkgs;
-  default = v2205;
+  default = v2505;
 }

--- a/nix/pkgs/default.nix
+++ b/nix/pkgs/default.nix
@@ -33,7 +33,7 @@ let
 
 in pharDirectives // rec {
 
-   mysql57 = dists.default.mysql57;
+   mysql57 = dists.v2205.mysql57;
    mysql80 = dists.default.mysql80;
    mysql84 = dists.v2505.mysql84;
    mysql90 = dists.v2405.mysql90; ## Deprecated

--- a/nix/pkgs/default.nix
+++ b/nix/pkgs/default.nix
@@ -41,6 +41,9 @@ in pharDirectives // rec {
    mariadb106 = dists.v2205.mariadb;
    mariadb1011 = dists.v2505.mariadb;
 
+   nodejs_14 = dists.v2205.nodejs-14_x;
+   nodejs_22 = dists.v2505.nodejs;
+
    php73 = ifSupported "php73" (!isAppleM1) (import ./php73/default.nix);
    bknixPhpstormAdvisor = import ./bknixPhpstormAdvisor/default.nix;
    bknixProfile = import ./bknixProfile/default.nix;

--- a/nix/pkgs/transifexClient/default.nix
+++ b/nix/pkgs/transifexClient/default.nix
@@ -11,7 +11,7 @@ buildGoModule rec {
     sha256 = "76mGMf70MD3aLgMCNqVyjrx8Rx5aIT+vYQGsPYjEM28=";
   };
 
-  vendorSha256 = "rcimaHr3fFeHSjZXw1w23cKISCT+9t8SgtPnY/uYGAU=";
+  vendorHash = "sha256-rcimaHr3fFeHSjZXw1w23cKISCT+9t8SgtPnY/uYGAU=";
   postBuild = ''
     mv $GOPATH/bin/cli $GOPATH/bin/tx
   '';

--- a/nix/profiles/phpXXmXX/default.nix
+++ b/nix/profiles/phpXXmXX/default.nix
@@ -17,7 +17,8 @@ in if (isValidPackage php) && (isValidPackage dbms)
   then (import ../base/default.nix) ++ (import ../mgmt/default.nix) ++ [
 
     php
-    dists.default.nodejs-14_x
+    dists.bkit.nodejs_14
+    # dists.bkit.nodejs_22
     dists.default.apacheHttpd
     dists.default.mailhog
     dists.default.memcached

--- a/nix/profiles/phpXXmXX/default.nix
+++ b/nix/profiles/phpXXmXX/default.nix
@@ -17,8 +17,8 @@ in if (isValidPackage php) && (isValidPackage dbms)
   then (import ../base/default.nix) ++ (import ../mgmt/default.nix) ++ [
 
     php
-    dists.bkit.nodejs_14
-    # dists.bkit.nodejs_22
+    # dists.bkit.nodejs_14
+    dists.bkit.nodejs_22
     dists.default.apacheHttpd
     dists.default.mailhog
     dists.default.memcached


### PR DESCRIPTION
This looks big because it builds on #960 (which is pending). Whereas #960 is a formulaic update to PHP+MySQL, this is a general update for... everything else. So it affects:

* Other daemons like Mailhog, Redis, Memcache
* NodeJS
* CLI tools like `git`, `gettext`, `unzip`

This should be rebased and tested after #960 is resolved.