### PR TITLE
(infra/ops#1050) CI - Autorelease inactive homerdo mount-points

### DIFF
--- a/bin/homerdo
+++ b/bin/homerdo
@@ -169,6 +169,7 @@
     echo "  $prog [OPTIONS] enter [--] [CMD]"
     echo "  $prog [OPTIONS] status"
     echo "  $prog [OPTIONS] kill"
+    echo "  $prog [OPTIONS] auto-release"
     echo
     echo "Sysadmin actions:"
     echo "  $prog install"
@@ -558,6 +559,35 @@
   }
 
   ###########################################################################
+  ## If there is no original/parent/master process, then release all resources.
+
+  function task_auto_release() {
+    assert_valid_shares; realize_shares
+    assert_valid_img; realize_img
+
+    if [ $EUID -ne 0 ]; then
+      as_root auto-release
+      exit $?
+    fi
+
+    print_h2 "Auto-release ($homer_lock)"
+    assert_root_user
+    assert_ownership
+
+    ## Is the original requester/parent process still active?
+    if [[ -e "$homer_lock" ]]; then
+      local pid=$(cat "$homer_lock")
+      if [[ -n "$pid" && -e "/proc/$pid/cmdline" ]]; then
+        print_h2 "Skip. Found active process ($pid)."
+        exit 0
+      fi
+    fi
+
+    ## Same thing as "kill" - stop the "unshare" process and/or remove mount-points
+    task_kill
+  }
+
+  ###########################################################################
   ## Internal utility: Run a command as current user. Records its PID in a file.
   ##
   ## Example: homerdo pid-file --out-pid-file /tmp/my.pid -- do_some_work
@@ -865,7 +895,7 @@
       --timeout)    timeout="$2"      ; shift 2 ; assert_valid_timeout ; ;;
       -h|--help|help) action="usage"  ; shift 1 ; ;;
       --out-pid-file) out_pid_file="$2" ; shift 2 ; ;;
-      install|uninstall|run|enter|status|kill|create|mount|unmount|exec|enter-exec|pid-file) action="$1" ; shift ; ;;
+      install|uninstall|run|enter|status|kill|create|mount|unmount|exec|enter-exec|pid-file|auto-release) action="$1" ; shift ; ;;
       -*)           fatal "Unrecognized option $1" ; ;;
       *)            parsing=          ; ;;
     esac
@@ -887,6 +917,7 @@
   case "$action" in
     enter-exec) f=task_enter_exec ; ;;
     pid-file) f=task_pid_file ; ;;
+    auto-release) f=task_auto_release ; ;;
     *) f="task_${action}" ; ;;
   esac
   $f

--- a/bin/homerdo
+++ b/bin/homerdo
@@ -548,9 +548,11 @@
     assert_root_user
     assert_ownership
 
-    local pid=$(cat "$homer_ns/unshare.pid")
-    if [ -n "$pid" ]; then
-      kill "$pid"
+    if [[ -e "$homer_ns/unshare.pid" ]]; then
+      local pid=$(cat "$homer_ns/unshare.pid")
+      if [[ -n "$pid" && -e "/proc/$pid/cmdline" ]]; then
+        kill "$pid"
+      fi
     fi
     _task_unmount
   }

--- a/src/jobs/homerdo-runjob.sh
+++ b/src/jobs/homerdo-runjob.sh
@@ -122,6 +122,12 @@ function do_request() {
 ## NOTE: For concurrent invocations, run this with `flock`.
 
 function do_pick_image() {
+  ## (infra/ops#1050) If any jobs have been killed, then there maybe leftover mount-points which interfere with new jobs.
+  echo >&2 "[$USER] Auto-release any home-images"
+  for img_file in bknix-*.img ; do
+    homerdo -i "$img_file" auto-release
+  done
+
   echo >&2 "[$USER] Finding home-image in $PWD..."
   local OWNER_PID="$1"
 


### PR DESCRIPTION
Full details: https://lab.civicrm.org/infra/ops/-/issues/1050

Tldr: If you start a job in Jenkins-CI, and if you kill the job before it finishes, then some resources are not properly released. In particular, _processes_ (PIDs) will be killed, but _mount-points_ (e.g. the `tmpfs` where the job does work) are more complicated. They cleanup sometimes - but not always.

This adds a more proactive cleanup procedure. Whenever a server starts a new job, it will first check the statuses for its image files and auto-release any which appear to be unused.