### PR TITLE
nix - Update PHP versions to split between new/old ICU versions

### DIFF
--- a/nix/pins/25.05.nix
+++ b/nix/pins/25.05.nix
@@ -2,9 +2,14 @@
  * v25.05
  */
 fetchTarball {
+
+  ## Unofficial backports circa June 25, 2025; totten/pkgs2505-addenda; update icuXX
+  url = "https://github.com/nixos/nixpkgs/archive/7444fba07bd1988c5203bf198c3241afcf1a16e1.tar.gz";
+  sha256 = "19ypdda8vlc230lqjr9q7gs633mdry8i58mi864zdiqi66v3nwhh";
+
   ## Unofficial backports circa June 24, 2025; totten/pkgs2505-addenda; mysql93
-  url = "https://github.com/nixos/nixpkgs/archive/dad9999266b41da929ca8b9837e856d6db669298.tar.gz";
-  sha256 = "05m4psf3ls7v71nadwzizp12fn2zd7j8svmnibqk3miz7q3i6z07";
+  # url = "https://github.com/nixos/nixpkgs/archive/dad9999266b41da929ca8b9837e856d6db669298.tar.gz";
+  # sha256 = "05m4psf3ls7v71nadwzizp12fn2zd7j8svmnibqk3miz7q3i6z07";
 
   ## Original release
   # url = "https://github.com/nixos/nixpkgs/archive/11cb3517b3af6af300dd6c055aeda73c9bf52c48.tar.gz";


### PR DESCRIPTION
This is a follow-up to #960. As discussed in subsequent comments, the update to nixpkgs 25.05 has led to test-failures in some localization tests. This PR adds [a fix onto nixpkgs](https://github.com/totten/nixpkgs/commit/7444fba07bd1988c5203bf198c3241afcf1a16e1).

I bisected `nixpkgs` and found that the failures on `Civi\Core\FormatTest.testMoneyAndNumbers` started with  an upgrade of `unicode.org`'s [`icu`](https://github.com/unicode-org/icu) package from [v64 => v73 (`33a1b6e587ff`)](https://github.com/NixOS/nixpkgs/commit/33a1b6e587ff1f9eadcbd2d5739cc7f986c836c1).

This PR can be seen as walking-back `33a1b6e587ff` so that we can incrementally adjust to newer `icu` package:

* For PHP 8.1, 8.2, and 8.3, we'll stick with the earlier `icu64` (so that we can run tests on existing branches).
* For PHP 8.4+, we'll switch to the newer `icu73` (so that we still see the failure - and we can figure out a real/forward fix).

(For the record, I also checked the range `icu64`..`icu73`,  and it specifically started failing in `icu70`.)