### PR TITLE
civibuild - Allow --civi-ver using symbolic aliases

### DIFF
--- a/src/civibuild.compute-defaults.sh
+++ b/src/civibuild.compute-defaults.sh
@@ -80,6 +80,13 @@ elif [ -n "$CIVIBUILD_HOME" ]; then
 
 fi
 
+
+###############################################################################
+## The --civi-ver option may use aliases. We can resolve aliases now that (eg) CACHE_DIR is available.
+if [[ -n "$CIVI_VERSION" ]]; then
+  CIVI_VERSION=$(civicrm_resolve_ver "$CIVI_VERSION")
+fi
+
 ###############################################################################
 ## Wrap-up - common defaults which are derived from some other default
 

--- a/src/civibuild.defaults.sh
+++ b/src/civibuild.defaults.sh
@@ -32,6 +32,12 @@
 # CIVIBUILD_PATH=
 
 ###############################################################################
+## Constants
+
+## Feed URL with a list of current version-aliases
+CIVI_VERSION_ALIASES='https://lab.civicrm.org/infra/duderino/-/raw/master/config/aliases.yaml?ref_type=heads'
+
+###############################################################################
 ## Common variables
 
 ## Should we print lots of debug info?

--- a/src/civibuild.defaults.sh
+++ b/src/civibuild.defaults.sh
@@ -35,7 +35,7 @@
 ## Constants
 
 ## Feed URL with a list of current version-aliases
-CIVI_VERSION_ALIASES='https://lab.civicrm.org/infra/duderino/-/raw/master/config/aliases.yaml?ref_type=heads'
+CIVI_VERSION_ALIASES='https://test.civicrm.org/duderino/feed/aliases.txt'
 
 ###############################################################################
 ## Common variables

--- a/src/civibuild.lib.sh
+++ b/src/civibuild.lib.sh
@@ -303,7 +303,7 @@ function http_download() {
   fi
 }
 
-## usage: http_cache_setup <url> <local-file> [<ttl-minutes>]
+## usage: http_cache_setup <url> <local-file> [<ttl-seconds>]
 function http_cache_setup() {
   local url="$1"
   local cachefile="$2"

--- a/src/civibuild.lib.sh
+++ b/src/civibuild.lib.sh
@@ -26,7 +26,7 @@ function cvutil_assertvars() {
     var="$1"
     eval "val=\$$var"
     if [ -z "$val" ]; then
-      echo "missing variable: $var [in $context]"
+      echo >&2 "missing variable: $var [in $context]"
       exit 98
     fi
     shift

--- a/src/civibuild.lib.sh
+++ b/src/civibuild.lib.sh
@@ -1087,11 +1087,11 @@ function civicrm_resolve_ver() {
       ;;
     ## OK, we'll do a lookup
     *)
-      http_cache_setup "$CIVI_VERSION_ALIASES" "${CACHE_DIR}/duderino/aliases.yaml" "600" >&2
+      http_cache_setup "$CIVI_VERSION_ALIASES" "${CACHE_DIR}/duderino/aliases.txt" "600" >&2
       local result=$(
-        cat "${CACHE_DIR}/duderino/aliases.yaml" \
-        | grep -i '^\s*'"$target:" \
-        | head -n1 | cut -d: -f2 | tr -d \ \"\'
+        cat "${CACHE_DIR}/duderino/aliases.txt" \
+        | grep -i ^"$target"= \
+        | head -n1 | cut -d= -f2
       )
       if [[ -n "$result" ]]; then
         echo >&2 "Resolved CiviCRM version ($target => $result)"


### PR DESCRIPTION
This makes it easier to resolve versions using aliases from:

https://lab.civicrm.org/infra/duderino/-/raw/master/config/aliases.yaml?ref_type=heads

For example:

```bash
## Current stable branch
civibuild download tmp --type standalone-clean --civi-ver stable

## Current release-candidate branch
civibuild download tmp --type standalone-clean --civi-ver rc

## Current ESR
civibuild download tmp --type standalone-clean --civi-ver esr
```

(cc @ufundo)