### PR TITLE
civibuild.aliases.sh - Add aliases for standalone with STABLE/RC/ESR

### DIFF
--- a/src/civibuild.aliases.sh
+++ b/src/civibuild.aliases.sh
@@ -80,6 +80,10 @@ function civibuild_alias_resolve() {
     smaster)     SITE_TYPE=standalone-clean ; CIVI_VERSION=master    ; CMS_TITLE="CiviCRM Standalone Sandbox"        ;;
     sdmaster)    SITE_TYPE=standalone-dev   ; CIVI_VERSION=master    ; CMS_TITLE="CiviCRM Standalone Sandbox"        ;;
 
+    stable)     SITE_TYPE=standalone-clean  ; CIVI_VERSION=stable    ; CMS_TITLE="CiviCRM Standalone Sandbox (Stable)" ;;
+    rc)         SITE_TYPE=standalone-clean  ; CIVI_VERSION=rc        ; CMS_TITLE="CiviCRM Standalone Sandbox (RC)" ;;
+    esr)        SITE_TYPE=standalone-clean  ; CIVI_VERSION=esr       ; CMS_TITLE="CiviCRM Standalone Sandbox (ESR)" ;;
+
     civihr)      SITE_TYPE=civihr           ; CIVI_VERSION=5.3.1     ; CMS_TITLE="CiviHR Sandbox"                    ; NO_SAMPLE_DATA=1       ;;
 
     bempty)      SITE_TYPE=backdrop-empty   ; CIVI_VERSION=none      ; CMS_TITLE="Backdrop Sandbox"                  ;;

--- a/src/civibuild.aliases.sh
+++ b/src/civibuild.aliases.sh
@@ -78,7 +78,9 @@ function civibuild_alias_resolve() {
     b-master)    SITE_TYPE=backdrop-demo    ; CIVI_VERSION=master    ; CMS_TITLE="CiviCRM Sandbox on Backdrop"       ;;
 
     smaster)     SITE_TYPE=standalone-clean ; CIVI_VERSION=master    ; CMS_TITLE="CiviCRM Standalone Sandbox"        ;;
-    sdmaster)    SITE_TYPE=standalone-dev   ; CIVI_VERSION=master    ; CMS_TITLE="CiviCRM Standalone Sandbox"        ;;
+    # sdmaster)    SITE_TYPE=standalone-dev ; CIVI_VERSION=master    ; CMS_TITLE="CiviCRM Standalone Sandbox"      ;;
+    scmaster)    SITE_TYPE=standalone-composer ; CIVI_VERSION=master ; CMS_TITLE="CiviCRM Standalone Sandbox (Composer)"        ;;
+    master)      SITE_TYPE=standalone-clean  ; CIVI_VERSION=master   ; CMS_TITLE="CiviCRM Standalone Sandbox"        ;;
 
     stable)     SITE_TYPE=standalone-clean  ; CIVI_VERSION=stable    ; CMS_TITLE="CiviCRM Standalone Sandbox (Stable)" ;;
     rc)         SITE_TYPE=standalone-clean  ; CIVI_VERSION=rc        ; CMS_TITLE="CiviCRM Standalone Sandbox (RC)" ;;


### PR DESCRIPTION
Based on suggestions from https://chat.civicrm.org/civicrm/pl/zprzowtdg3fpzehr1h9qbucmcc

I'm not certain if we'll do STABLE/RC/ESR sites for the various CMS's. (It is more sites...) If we do, then we probably want aliases like...

* `d10-stable`
* `d10-rc`
* `wp-stable`
* `wp-rc`

But for the moment, I think we're mostly interested in standalone... and if that's it, then we can have simpler names:

* `stable`
* `rc`
* `esr`

As in:

```bash
civibuild create stable
civibuild create rc
civibuild create esr
```
