### PR TITLE
give demo user staff role not admin on standalone-* builds

### DIFF
--- a/app/config/standalone-clean/demo-user.php
+++ b/app/config/standalone-clean/demo-user.php
@@ -35,6 +35,6 @@ CRM_Core_Transaction::create()->run(function () {
     ->addValue('username' , $demoUser)
     ->addValue('password' , $demoPass)
     ->addValue('contact_id' , $contactID)
-    ->addValue('roles:name', ['admin'])
+    ->addValue('roles:name', ['staff'])
     ->execute();
 });

--- a/app/config/standalone-composer/demo-user.php
+++ b/app/config/standalone-composer/demo-user.php
@@ -35,6 +35,6 @@ CRM_Core_Transaction::create()->run(function () {
     ->addValue('username' , $demoUser)
     ->addValue('password' , $demoPass)
     ->addValue('contact_id' , $contactID)
-    ->addValue('roles:name', ['admin'])
+    ->addValue('roles:name', ['staff'])
     ->execute();
 });


### PR DESCRIPTION
@eileenmcnaughton was keen to have a less permissioned user for testing, e.g. on `smaster`

However - I'm not sure what the password for `admin` user is on `smaster` if you need to do admin things? With this change demo user can't e.g. enable extensions