### PR TITLE
civibuild - Drop aliases for 4.x 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Breaking changes:
 
 * `civi-download-tools`: Drop support for `hub` ([#941](https://github.com/civicrm/civicrm-buildkit/pull/941)) and `joomlatools-console` ([#940](https://github.com/civicrm/civicrm-buildkit/pull/940))
 * `civi-download-tools`: Drop support for the `--full` option ([#936](https://github.com/civicrm/civicrm-buildkit/pull/936))
+* `civibuild`: Drop ancient aliases pegged to CiviCRM 4.x (e.g `d43` and `wp46`)
 * `composer.json`: Drop support for PHP 7.2. Drop unused `paratest`. ([#944](https://github.com/civicrm/civicrm-buildkit/pull/944))
 * `bin/securify`: Drop old script. (Deprecated circa 2019.)
 * __Nix__: Drop ancient packages `php71`, `php72`, `mysql56`, `mariadb105` ([#926](https://github.com/civicrm/civicrm-buildkit/pull/926))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,12 @@ are generally "drop-in" updates that don't require any special action.
 However, if a change requires special action, it should be documented in
 this changelog.
 
-### v25.04.0 => v25.06.0
+### v25.04.0 => v25.07.0
 
-Breaking changes:
+Between mid-May and early July 2025, changes were more aggressive than usual.
+This included several breaking changes (generally relating to older tools and
+flags).  They shouldn't affect most current users, but we present them for
+completeness.
 
 * `civi-download-tools`: Drop support for `hub` ([#941](https://github.com/civicrm/civicrm-buildkit/pull/941)) and `joomlatools-console` ([#940](https://github.com/civicrm/civicrm-buildkit/pull/940))
 * `civi-download-tools`: Drop support for the `--full` option ([#936](https://github.com/civicrm/civicrm-buildkit/pull/936))

--- a/src/civibuild.aliases.sh
+++ b/src/civibuild.aliases.sh
@@ -23,57 +23,20 @@
 function civibuild_alias_resolve() {
   IS_ALIAS=1
   case "$1" in
-    d43)         SITE_TYPE=drupal-demo      ; CIVI_VERSION=4.3       ; CMS_TITLE="CiviCRM 4.3 Demo on Drupal"        ; DISC_VERSION=4.4         ;;
-    d44)         SITE_TYPE=drupal-demo      ; CIVI_VERSION=4.4       ; CMS_TITLE="CiviCRM 4.4 Demo on Drupal"        ; VOL_VERSION=4.4-1.x      ; DISC_VERSION=4.4      ;;
-    d45)         SITE_TYPE=drupal-demo      ; CIVI_VERSION=4.5       ; CMS_TITLE="CiviCRM 4.5 Demo on Drupal"        ; VOL_VERSION=v4.5-1.4.0   ; DISC_VERSION=4.4      ;;
-    d46)         SITE_TYPE=drupal-demo      ; CIVI_VERSION=4.6       ; CMS_TITLE="CiviCRM 4.6 Demo on Drupal"        ; VOL_VERSION=v4.5-1.4.0   ; DISC_VERSION=master   ; RULES_VERSION=master   ;;
-    d47)         SITE_TYPE=drupal-demo      ; CIVI_VERSION=master    ; CMS_TITLE="CiviCRM 4.7 Demo on Drupal"        ; VOL_VERSION=master       ; DISC_VERSION=master   ;;
     dmaster)     SITE_TYPE=drupal-demo      ; CIVI_VERSION=master    ; CMS_TITLE="CiviCRM Sandbox on Drupal"         ; VOL_VERSION=master       ; DISC_VERSION=master   ;;
-
-    d7-43)       SITE_TYPE=drupal-clean     ; CIVI_VERSION=4.3       ; CMS_TITLE="CiviCRM 4.3 Demo on Drupal 7"      ;;
-    d7-44)       SITE_TYPE=drupal-clean     ; CIVI_VERSION=4.4       ; CMS_TITLE="CiviCRM 4.4 Demo on Drupal 7"      ;;
-    d7-45)       SITE_TYPE=drupal-clean     ; CIVI_VERSION=4.5       ; CMS_TITLE="CiviCRM 4.5 Demo on Drupal 7"      ;;
-    d7-46)       SITE_TYPE=drupal-clean     ; CIVI_VERSION=4.6       ; CMS_TITLE="CiviCRM 4.6 Demo on Drupal 7"      ;;
-    d7-47)       SITE_TYPE=drupal-clean     ; CIVI_VERSION=master    ; CMS_TITLE="CiviCRM 4.7 Demo on Drupal 7"      ;;
     d7-master)   SITE_TYPE=drupal-clean     ; CIVI_VERSION=master    ; CMS_TITLE="CiviCRM Sandbox on Drupal 7"       ;;
 
-#   d6-46)       SITE_TYPE=drupal6-demo     ; CIVI_VERSION=4.6       ; CMS_TITLE="CiviCRM 4.6 Demo on Drupal 6"      ; VOL_VERSION=v4.5-1.4.0   ; DISC_VERSION=master   ; RULES_VERSION=master   ;;
-#   d6-47)       SITE_TYPE=drupal6-demo     ; CIVI_VERSION=master    ; CMS_TITLE="CiviCRM 4.7 Demo on Drupal 6"      ; VOL_VERSION=master       ; DISC_VERSION=master   ;;
-#   d6-master)   SITE_TYPE=drupal6-demo     ; CIVI_VERSION=master    ; CMS_TITLE="CiviCRM Sandbox on Drupal 6"       ; VOL_VERSION=master       ; DISC_VERSION=master   ;;
-#   d8-47)       SITE_TYPE=drupal8-demo     ; CIVI_VERSION=master    ; CMS_TITLE="CiviCRM 4.7 Demo on Drupal 8"      ; VOL_VERSION=master       ; DISC_VERSION=master   ;;
     d8-master)   SITE_TYPE=drupal8-demo    ; CIVI_VERSION=master    ; CMS_TITLE="CiviCRM Sandbox on Drupal 8"       ;;
-
     d9-master)   SITE_TYPE=drupal9-demo    ; CIVI_VERSION=master    ; CMS_TITLE="CiviCRM Sandbox on Drupal 9"       ;;
     d10-master)  SITE_TYPE=drupal10-demo   ; CIVI_VERSION=master    ; CMS_TITLE="CiviCRM Sandbox on Drupal 10"      ;;
-
-    dc43)        SITE_TYPE=drupal-clean     ; CIVI_VERSION=4.3       ; CMS_TITLE="CiviCRM 4.3 Clean on Drupal"       ;;
-    dc44)        SITE_TYPE=drupal-clean     ; CIVI_VERSION=4.4       ; CMS_TITLE="CiviCRM 4.4 Clean on Drupal"       ;;
-    dc45)        SITE_TYPE=drupal-clean     ; CIVI_VERSION=4.5       ; CMS_TITLE="CiviCRM 4.5 Clean on Drupal"       ;;
-    dc46)        SITE_TYPE=drupal-clean     ; CIVI_VERSION=4.6       ; CMS_TITLE="CiviCRM 4.6 Clean on Drupal"       ;;
-    dc47)        SITE_TYPE=drupal-clean     ; CIVI_VERSION=master    ; CMS_TITLE="CiviCRM 4.7 Clean on Drupal"       ;;
     dcmaster)    SITE_TYPE=drupal-clean     ; CIVI_VERSION=master    ; CMS_TITLE="CiviCRM Clean Sandbox on Drupal"   ;;
-
     dcase)       SITE_TYPE=drupal-case      ; CIVI_VERSION=master    ; CMS_TITLE="CiviCase Sandbox on Drupal"        ;;
+
     wpcase)      SITE_TYPE=wp-case          ; CIVI_VERSION=master    ; CMS_TITLE="CiviCase Sandbox on WordPress"     ;;
-
-    wp43)        SITE_TYPE=wp-demo          ; CIVI_VERSION=4.3       ; CMS_TITLE="CiviCRM 4.3 Demo on WordPress"     ;;
-    wp44)        SITE_TYPE=wp-demo          ; CIVI_VERSION=4.4       ; CMS_TITLE="CiviCRM 4.4 Demo on WordPress"     ; VOL_VERSION=4.4-1.x    ;;
-    wp45)        SITE_TYPE=wp-demo          ; CIVI_VERSION=4.5       ; CMS_TITLE="CiviCRM 4.5 Demo on WordPress"     ; VOL_VERSION=v4.5-1.4.0 ;;
-    wp46)        SITE_TYPE=wp-demo          ; CIVI_VERSION=4.6       ; CMS_TITLE="CiviCRM 4.6 Demo on WordPress"     ; VOL_VERSION=v4.5-1.4.0 ;;
-    wp47)        SITE_TYPE=wp-demo          ; CIVI_VERSION=master    ; CMS_TITLE="CiviCRM 4.7 Demo on WordPress"     ; VOL_VERSION=master     ;;
     wpmaster)    SITE_TYPE=wp-demo          ; CIVI_VERSION=master    ; CMS_TITLE="CiviCRM Sandbox on WordPress"      ; VOL_VERSION=master     ;;
-
-    wp-43)       SITE_TYPE=wp-demo          ; CIVI_VERSION=4.3       ; CMS_TITLE="CiviCRM 4.3 Demo on WordPress"     ;;
-    wp-44)       SITE_TYPE=wp-demo          ; CIVI_VERSION=4.4       ; CMS_TITLE="CiviCRM 4.4 Demo on WordPress"     ; VOL_VERSION=4.4-1.x    ;;
-    wp-45)       SITE_TYPE=wp-demo          ; CIVI_VERSION=4.5       ; CMS_TITLE="CiviCRM 4.5 Demo on WordPress"     ; VOL_VERSION=v4.5-1.4.0 ;;
-    wp-46)       SITE_TYPE=wp-demo          ; CIVI_VERSION=4.6       ; CMS_TITLE="CiviCRM 4.6 Demo on WordPress"     ; VOL_VERSION=v4.5-1.4.0 ;;
-    wp-47)       SITE_TYPE=wp-demo          ; CIVI_VERSION=master    ; CMS_TITLE="CiviCRM 4.7 Demo on WordPress"     ; VOL_VERSION=master     ;;
     wp-master)   SITE_TYPE=wp-demo          ; CIVI_VERSION=master    ; CMS_TITLE="CiviCRM Sandbox on WordPress"      ; VOL_VERSION=master     ;;
 
-    bc47)        SITE_TYPE=backdrop-clean   ; CIVI_VERSION=master    ; CMS_TITLE="CiviCRM 4.7 Clean on Backdrop"     ;;
     bcmaster)    SITE_TYPE=backdrop-clean   ; CIVI_VERSION=master    ; CMS_TITLE="CiviCRM Clean Sandbox on Backdrop" ;;
-
-    b47)         SITE_TYPE=backdrop-demo    ; CIVI_VERSION=master    ; CMS_TITLE="CiviCRM 4.7 on Backdrop"           ;;
     bmaster)     SITE_TYPE=backdrop-demo    ; CIVI_VERSION=master    ; CMS_TITLE="CiviCRM Sandbox on Backdrop"       ;;
     b-master)    SITE_TYPE=backdrop-demo    ; CIVI_VERSION=master    ; CMS_TITLE="CiviCRM Sandbox on Backdrop"       ;;
 


### PR DESCRIPTION
These aliases were a convenience to quickly instantiate CiviCRM 4.x builds (eg `civibuild create d45`, `civibuild create wp46`).

We don't need convenient aliases for 10 year old versions... (And, in case, the current version of `civicrm-buildkit` doesn't support php5...)