### PR TITLE
Set CMS_VERSION in install.sh in case download.sh didn't set it

### DIFF
--- a/app/config/drupal10-demo/install.sh
+++ b/app/config/drupal10-demo/install.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+[ -z "$CMS_VERSION" ] && CMS_VERSION='^10'
+
 ## install.sh -- Create config files and databases; fill the databases
 [ -d "$WEB_ROOT/web" ] && CMS_ROOT="$WEB_ROOT/web"
 


### PR DESCRIPTION
CMS_VERSION is needed by the function civicrm_enable_riverlea_theme. If Drupal has already been downloaded, the variable may not be set.