### PR TITLE
civibuild create - Save at midpoint. Facilitate reinstall.

### DIFF
--- a/src/command/create.run.sh
+++ b/src/command/create.run.sh
@@ -1,4 +1,9 @@
 civibuild_app_download
+civibuild_app_save
+## Save `build/SITE_NAME.sh` at mid-point. If installer hits a problem, you can do targetted reinstall (without needing to redownload).
+
 civibuild_app_install
 civibuild_app_save
+## Save `build/SITE_NAME.sh` with final data.
+
 civibuild_app_show


### PR DESCRIPTION
Background
--------------------

Recall that `civibuild` has two distinct phases - `download` and `install`. These are often executed as a single command (`create`).

| Command | Description | Which helper scripts are used?<br/> (`app/config/TYPE/*`) |
| -- | -- | -- |
| `civibuild download NAME [ARGS]` | Get code | `download.sh` |
| `civibuild install NAME [ARGS]` | Setup config files and DB | `install.sh` |
| `civibuild create NAME [ARGS]` | Get code _and_ setup config/DB. | `download.sh` _and_ `install.sh` |


Overview
-------------

In #972, the question: what happens if there's an error in these steps? Can you re-run the `install` steps?

This PR improves prospects for re-installing -- in a specific case. The case looks like this (pseudo-run):

```bash
## Try to create in one go...
civibuild create NAME [ARGS]
# Downloading...
# Download Completed.
# Installing...
# ERROR!

## Manually fix problem. Try to install again...
civibuild install NAME [ARGS]
# Installing...
```

In this case, the `download` has completed -- so we know that all the key prerequisites are available. This means that it's OK to try the narrower `install` a second time. (In fact, it should be safe to re-run the `install` many times, with incremental adjustments to `install.sh` and/or the underlying codebase.)

This patch contributes to #972. It is complementary with #973 (but they don't strictly depend on each other).

Before
-----------------------

When `civibuild create` crashes, it neglects to store any metadata in `build/NAME.sh`. (Ex: `CMS_VERSION` is lost.) Without that metadata, `civibuild install` will have trouble.

After
---------------------

As `civibuild create` runs, it stores `build/NAME.sh` at a few key check-points.

When `civibuild create` crashes, we retain enough metadata... such that the next call to `civibuild install` can find it.

Comment
------------------

This does NOT provide _general_ resume support for all possible errors in `civibuild create`. In particular:

* It DOES help with errors that occur during `install.sh`. (The main pre-condition of `install.sh` is that `download.sh` has completed. As long as that pre-condition is met, you should be able to re-install many times.)
* It DOES NOT help with errors that occur during `download.sh`. (If you have a crash there, then the codebase itself is corrupt. In many build-types, fixing that can require many steps.)
