### PR TITLE
remove transitional civicrm_enable_riverlea_theme

### DIFF
--- a/app/config/backdrop-demo/install.sh
+++ b/app/config/backdrop-demo/install.sh
@@ -58,8 +58,6 @@ pushd "$CMS_ROOT" >> /dev/null
   cv api StatusPreference.create ignore_severity=critical name=checkOutboundMail
   cv api StatusPreference.create ignore_severity=critical name=checkLastCron
 
-  civicrm_enable_riverlea_theme
-
   ## Setup CiviCRM dashboards
   INSTALL_DASHBOARD_USERS="$ADMIN_USER;$DEMO_USER" cv scr "$SITE_CONFIG_DIR/install-dashboard.php"
 

--- a/app/config/drupal-demo/install.sh
+++ b/app/config/drupal-demo/install.sh
@@ -139,7 +139,6 @@ EOPERM
   ## Demo sites always disable email and often disable cron
   drush cvapi StatusPreference.create ignore_severity=critical name=checkOutboundMail
   drush cvapi StatusPreference.create ignore_severity=critical name=checkLastCron
-  civicrm_enable_riverlea_theme
   ## Setup CiviCRM dashboards
   INSTALL_DASHBOARD_USERS="$ADMIN_USER;$DEMO_USER" drush scr "$SITE_CONFIG_DIR/install-dashboard.php"
 

--- a/app/config/drupal10-demo/install.sh
+++ b/app/config/drupal10-demo/install.sh
@@ -75,7 +75,6 @@ pushd "${CMS_ROOT}/sites/${DRUPAL_SITE_DIR}" >> /dev/null
   cv api StatusPreference.create ignore_severity=critical name=checkOutboundMail
   cv api StatusPreference.create ignore_severity=critical name=checkLastCron
 
-  civicrm_enable_riverlea_theme
   export SITE_CONFIG_DIR
   ## Install theem and blocks
   drush8 scr "$SITE_CONFIG_DIR/install-theme.php"

--- a/app/config/standalone-clean/install.sh
+++ b/app/config/standalone-clean/install.sh
@@ -37,7 +37,6 @@ civicrm_install_cv
 # Settings appropriate to a dev environment
 cv setting:set environment=Development
 cv setting:set debug_enabled=1
-civicrm_enable_riverlea_theme
 
 env DEMO_USER="$DEMO_USER" DEMO_PASS="$DEMO_PASS" DEMO_EMAIL="$DEMO_EMAIL" \
   cv scr "$SITE_CONFIG_DIR/demo-user.php"

--- a/app/config/standalone-composer/install.sh
+++ b/app/config/standalone-composer/install.sh
@@ -23,7 +23,6 @@ civicrm_install_cv
 
 pushd "$CMS_ROOT"
   composer civicrm:publish
-  civicrm_enable_riverlea_theme
 popd
 
 ###############################################################################

--- a/app/config/wmf/install.sh
+++ b/app/config/wmf/install.sh
@@ -66,7 +66,6 @@ EOSQL
 # Settings appropriate to a dev environment
 cv setting:set environment=Development
 cv setting:set debug_enabled=1
-civicrm_enable_riverlea_theme
 
 echo "enabling wmf-civicrm"
 cv en --ignore-missing rpow wmf-civicrm

--- a/app/config/wp-demo/install.sh
+++ b/app/config/wp-demo/install.sh
@@ -163,8 +163,6 @@ wp eval '$c=[civi_wp()->basepage->create_wp_basepage()];if (is_callable($c)) $c(
 wp civicrm api StatusPreference.create ignore_severity=critical name=checkOutboundMail
 wp civicrm api StatusPreference.create ignore_severity=critical name=checkLastCron
 
-civicrm_enable_riverlea_theme
-
 # Disable WP fatal error handler as it gets in the way of debugging.
 wp config set WP_DISABLE_FATAL_ERROR_HANDLER true --raw
 

--- a/src/civibuild.lib.sh
+++ b/src/civibuild.lib.sh
@@ -636,19 +636,6 @@ function civicrm_download_composer_d8() {
 }
 
 ###############################################################################
-## Enable RiverLea (and one of its sub-themes) -- if available
-##
-## usage: civicrm_enable_riverlea_theme
-## todo: Add support for indicating preferred subtheme(s)
-function civicrm_enable_riverlea_theme() {
-  cvutil_assertvars civicrm_enable_riverlea_theme CIVI_VERSION CMS_VERSION
-  if civicrm_check_ver '>' 5.80.alpha1 ; then
-    cv en --ignore-missing riverlea
-    cv vset theme_backend=minetta
-  fi
-}
-
-###############################################################################
 ## Setup CiviCRM l10n data folder
 ##
 ## usage: civicrm_l10n_setup [<TARGET_DIR>]


### PR DESCRIPTION
This served to enable Riverlea in buildkit builds / on test sites etc.

But it's enabled by default on all new installs since 6.0, so this is redundant.

(It will mean if you make buildkit builds of 5.80/81/82 you wont get Riverlea by default, but I think we can live with that.)