### PR TITLE
homerdo - Isolate and autoclean /tmp

### DIFF
--- a/bin/homerdo
+++ b/bin/homerdo
@@ -103,7 +103,6 @@
 ##
 ## - Allow running without any persistent images (`homerdo --temp` starts with empty tmpfs)
 ## - Allow layering multiple images (`homerdo -i base.img -i extra.img --temp`)
-## - Replace /tmp and /var/tmp. (Issue: Sharing tar fifo)
 ## - Consider adding a network namespace. Maybe make it optional (`homerdo -n`).
 ## - Use qcow2 instead of raw. (Issue: When learning/playing with qemu-nbd, it felt crashy.)
 ## - Have more flavors of "run/enter" (e.g. a start+stop flavor)

--- a/bin/homerdo
+++ b/bin/homerdo
@@ -103,7 +103,7 @@
 ##
 ## - Allow running without any persistent images (`homerdo --temp` starts with empty tmpfs)
 ## - Allow layering multiple images (`homerdo -i base.img -i extra.img --temp`)
-## - Replace /tmp and /var/tmp. (Issue: Sharing ssh socket and tar fifo)
+## - Replace /tmp and /var/tmp. (Issue: Sharing tar fifo)
 ## - Consider adding a network namespace. Maybe make it optional (`homerdo -n`).
 ## - Use qcow2 instead of raw. (Issue: When learning/playing with qemu-nbd, it felt crashy.)
 ## - Have more flavors of "run/enter" (e.g. a start+stop flavor)
@@ -115,6 +115,7 @@
   ## Environment
   SELF="$(realpath "$0")"
   HOMER_VAR=/var/local/homer
+  HOMER_SSH="${HOMER_VAR}-ssh"
   HOMER_USER=homer
   HOMER_GROUP=homer
   HOMER_SIZE=${HOMER_SIZE:-2048m}
@@ -217,6 +218,9 @@
       $GUARD adduser "$HOMER_USER" --gecos "Homer" --home "/home/homer" --ingroup "$HOMER_GROUP" --disabled-password
     fi
 
+    mkdir -p "$HOMER_SSH"
+    chmod 1777 "$HOMER_SSH"
+
     #print_h2 "Grant all users access to homerdo (/etc/sudoers.d/homerdo)"
     #echo -n > /etc/sudoers.d/homerdo
     #echo "ALL ALL = (root) NOPASSWD: NOSETENV: /usr/local/bin/homerdo" >> /etc/sudoers.d/homerdo
@@ -269,7 +273,7 @@
 
     local prefix_cmd=()
     if [ -n "$ssh_agent" ]; then
-      local socket="/tmp/ssh.$RANDOM$RANDOM/agent.$RANDOM$RANDOM"
+      local socket="$HOMER_SSH/ssh.$RANDOM$RANDOM/agent.$RANDOM$RANDOM"
       forward_ssh "$socket"
       if [ -e "$socket" ]; then
         prefix_cmd+=(env "SSH_AUTH_SOCK=$socket")
@@ -298,7 +302,7 @@
 
     local prefix_cmd=()
     if [ -n "$ssh_agent" ]; then
-      local socket="/tmp/ssh.$RANDOM$RANDOM/agent.$RANDOM$RANDOM"
+      local socket="$HOMER_SSH/ssh.$RANDOM$RANDOM/agent.$RANDOM$RANDOM"
       forward_ssh "$socket"
       if [ -e "$socket" ]; then
         prefix_cmd+=(env "SSH_AUTH_SOCK=$socket")

--- a/bin/homerdo
+++ b/bin/homerdo
@@ -467,12 +467,14 @@
 
   function _task_exec_script() {
     printf "#!/usr/bin/env bash\n"
+    printf "{ # https://stackoverflow.com/a/21100710\n"
     printf "function cleanup() {\n"
 
     for share in "${shares[@]}" ; do
       local rhs=$(echo "$share" | cut -f2 -d:)
       printf "  umount %q/%q\n" ~homer "$rhs"
     done
+    printf "  umount %q\n" /tmp
     printf "  umount %q\n" ~homer
 
     printf "}\n"
@@ -486,6 +488,9 @@
       printf "mount --bind %q ~homer/%q\n" "$lhs" "$rhs"
     done
 
+    printf "mkdir -p %q\n" ~homer/.tmp
+    printf "chmod 1777 %q\n" ~homer/.tmp
+    printf "mount --bind %q %q\n" ~homer/.tmp /tmp
     echo 'mount -t proc proc /proc'
 
     if [ -n "$timeout" ]; then
@@ -493,6 +498,7 @@
       echo -n "timeout $timeout " ## continue to next...
     fi
     echo "sudo -iu \"$HOMER_USER\" ${cmd[@]}"
+    printf "}\n"
   }
 
   ###########################################################################

--- a/nix/bin/install-runner.sh
+++ b/nix/bin/install-runner.sh
@@ -85,4 +85,7 @@ install_dispatcher
 warmup_binaries
 warmup_dispatcher_images
 
+mkdir -p /var/local/runjob
+chmod 1777 /var/local/runjob
+
 touch /var/local/bknix-ready


### PR DESCRIPTION
This updates the file-sharing rules when running test jobs:

* __Before__: Test jobs use the host's `/tmp` folder. Consequently, it survives across multiple test-runs and can accumulate data.
* __After__: Test jobs use their own `/tmp` (alias for `$HOME/.tmp`). Since each job has its own `$HOME`, this means it also has its own `$HOME/.tmp` (aka `/tmp`).

To make this work, we have to hunt-down any dataflows which rely on (1) sharing data between the inside+outside of container and (2) use `/tmp` for the sharing.

NOTE: In some initial/rough test, this seemed OK. Marking draft because it needs more systemic testing.