### PR TITLE
nix - Fix for installing profile snapshots (re:use-bknix) on new hosts

### DIFF
--- a/nix/lib/common.sh
+++ b/nix/lib/common.sh
@@ -616,7 +616,9 @@ function get_nix_profile_path() {
   elif [ -e "/nix/var/nix/profiles/per-user/$USER" ]; then
     echo "/nix/var/nix/profiles/per-user/$USER/$1"
   else
-    echo >&2 "get_nix_profile_base(): Failed to determine base"
-    exit 2
+    ## The change was a while ago. If there's no evidence of existing profile,
+    ## then we're probably on a newer version...
+    mkdir -p "$HOME/.local/state/nix/profiles"
+    echo "$HOME/.local/state/nix/profiles/$1"
   fi
 }


### PR DESCRIPTION
This bit of code was written to bridge a breaking-change in a past version of nix. Basically, they moved one of the folders that's important for `use-bknix` -- and so you have to detect what the proper path is.

The detection works by checking your existing folders -- and that's fine if you already have some profiles (either from past bknix or from something else). However, on a recent system-build (Ubuntu 24.04 w/nix 2.31.0), there were no folders -- and so it failed to pick the right base.

With this update, `install-developer.sh` should work for:

* Existing installations (with old layout)
* Existing installations (with new layout)
* New installations (with new layout; fixed-here)