### PR TITLE
releaser - Update credential loading

### DIFF
--- a/tools/releaser/composer.json
+++ b/tools/releaser/composer.json
@@ -7,6 +7,7 @@
     },
     "require": {
         "php": ">=7.4",
-        "clippy/std": "~0.5.1"
+        "clippy/std": "~0.5.1",
+        "pear/crypt_gpg": "~1.6.4"
     }
 }

--- a/tools/releaser/composer.lock
+++ b/tools/releaser/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7c17e79de9ea332d2d9e4bac20303b60",
+    "content-hash": "4aec06c66076bb5a6161ffe6b3fb5310",
     "packages": [
         {
             "name": "clippy/container",
@@ -519,6 +519,196 @@
                 }
             ],
             "time": "2024-10-30T10:26:44+00:00"
+        },
+        {
+            "name": "pear/console_commandline",
+            "version": "v1.2.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pear/Console_CommandLine.git",
+                "reference": "611c5bff2e47ec5a184748cb5fedc2869098ff28"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pear/Console_CommandLine/zipball/611c5bff2e47ec5a184748cb5fedc2869098ff28",
+                "reference": "611c5bff2e47ec5a184748cb5fedc2869098ff28",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-xml": "*",
+                "pear/pear_exception": "^1.0.0",
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "*"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Console": "./"
+                },
+                "exclude-from-classmap": [
+                    "tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "include-path": [
+                ""
+            ],
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Richard Quadling",
+                    "email": "rquadling@gmail.com"
+                },
+                {
+                    "name": "David Jean Louis",
+                    "email": "izimobil@gmail.com"
+                }
+            ],
+            "description": "A full featured command line options and arguments parser.",
+            "homepage": "https://github.com/pear/Console_CommandLine",
+            "keywords": [
+                "console"
+            ],
+            "support": {
+                "issues": "http://pear.php.net/bugs/search.php?cmd=display&package_name[]=Console_CommandLine",
+                "source": "https://github.com/pear/Console_CommandLine"
+            },
+            "time": "2023-04-02T18:49:53+00:00"
+        },
+        {
+            "name": "pear/crypt_gpg",
+            "version": "v1.6.11",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pear/Crypt_GPG.git",
+                "reference": "6d307aae8b38ee35d0a2297510bd2356d1452c2b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pear/Crypt_GPG/zipball/6d307aae8b38ee35d0a2297510bd2356d1452c2b",
+                "reference": "6d307aae8b38ee35d0a2297510bd2356d1452c2b",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "pear/console_commandline": "*",
+                "pear/pear_exception": "*",
+                "php": ">=5.4.8"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.2",
+                "phpunit/phpunit": "^9"
+            },
+            "suggest": {
+                "ext-posix": "May require the posix PHP extension"
+            },
+            "bin": [
+                "scripts/crypt-gpg-pinentry"
+            ],
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "Crypt/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "include-path": [
+                "./"
+            ],
+            "license": [
+                "LGPL-2.1"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Gauthier",
+                    "email": "mike@silverorange.com"
+                },
+                {
+                    "name": "Nathan Fredrickson",
+                    "email": "nathan@silverorange.com"
+                },
+                {
+                    "name": "Aleksander Machniak",
+                    "email": "alec@alec.pl"
+                }
+            ],
+            "description": "Provides an object oriented interface to the GNU Privacy Guard (GnuPG). It requires the GnuPG executable to be on the system.",
+            "homepage": "https://github.com/pear/Crypt_GPG",
+            "keywords": [
+                "PGP",
+                "encryption",
+                "gnupg",
+                "gpg"
+            ],
+            "support": {
+                "issues": "https://pear.php.net/bugs/search.php?cmd=display&package_name[]=Crypt_GPG",
+                "source": "https://github.com/pear/Crypt_GPG"
+            },
+            "time": "2025-05-22T11:41:53+00:00"
+        },
+        {
+            "name": "pear/pear_exception",
+            "version": "v1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pear/PEAR_Exception.git",
+                "reference": "b14fbe2ddb0b9f94f5b24cf08783d599f776fff0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pear/PEAR_Exception/zipball/b14fbe2ddb0b9f94f5b24cf08783d599f776fff0",
+                "reference": "b14fbe2ddb0b9f94f5b24cf08783d599f776fff0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.2.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "<9"
+            },
+            "type": "class",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "PEAR/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "include-path": [
+                "."
+            ],
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Helgi Thormar",
+                    "email": "dufuz@php.net"
+                },
+                {
+                    "name": "Greg Beaver",
+                    "email": "cellog@php.net"
+                }
+            ],
+            "description": "The PEAR Exception base class.",
+            "homepage": "https://github.com/pear/PEAR_Exception",
+            "keywords": [
+                "exception"
+            ],
+            "support": {
+                "issues": "http://pear.php.net/bugs/search.php?cmd=display&package_name[]=PEAR_Exception",
+                "source": "https://github.com/pear/PEAR_Exception"
+            },
+            "time": "2021-03-21T15:43:46+00:00"
         },
         {
             "name": "php-di/invoker",

--- a/tools/releaser/script.php
+++ b/tools/releaser/script.php
@@ -15,6 +15,15 @@ $c = clippy()->register(plugins());
 ###############################################################################
 ## Services / computed data
 
+$c['gpg'] = function(Credentials $cred): \Crypt_GPG {
+  // It's easier to sign multiple files if we use Crypt_GPG wrapper API.
+  #!require pear/crypt_gpg: ~1.6.4
+  $gpg = new \Crypt_GPG(['binary' => trim(`which gpg`)]);
+  $gpg->addSignKey($cred->get('GPG_KEY'), $cred->get('GPG_PASSPHRASE'));
+  return $gpg;
+};
+
+
 $c['versionSpec'] = function (InputInterface $input) {
   $stagingBaseDir = getenv('RELEASE_TMPDIR');
   assertThat($stagingBaseDir && file_exists($stagingBaseDir), 'Environment variable RELEASE_TMPDIR should reference a local data dir');
@@ -313,13 +322,8 @@ $c['task_get()'] = function (array $versionSpec, $input, $io, $gsutil) {
  * @param \Symfony\Component\Console\Input\InputInterface $input
  * @param \Symfony\Component\Console\Style\SymfonyStyle $io
  */
-$c['task_sign()'] = function (array $versionSpec, $input, $io, $runner) {
+$c['task_sign()'] = function (array $versionSpec, $input, $io, $runner, \Crypt_GPG $gpg) {
   $io->section('Generate checksum and GPG signature');
-  $gpgKey = $input->getOption('gpg-key');
-
-  //  $passphrase = getenv('RELEASE_PASS');
-  //  if (empty($passphrase)) {throw new \Exception("Cannot generate signatures. Please set RELEASE_PASS.");}
-  //  $command = sprintf("echo %s | gpg -b --armor --batch --passphrase-fd 0 -u %s --sign %s");
 
   $md5File = 'civicrm-' . $versionSpec['version'] . '.MD5SUMS';
   $sha256File = 'civicrm-' . $versionSpec['version'] . '.SHA256SUMS';
@@ -329,12 +333,13 @@ $c['task_sign()'] = function (array $versionSpec, $input, $io, $runner) {
   $runner->exec($versionSpec['stagingDir'],
     sprintf("sha256sum *.tar.gz *.zip *.json > %s", escapeshellarg($sha256File)));
 
-  $runner->exec($versionSpec['stagingDir'],
-    sprintf("gpg -b --armor --pinentry-mode=loopback -u %s --sign %s",
-      escapeshellarg($gpgKey), escapeshellarg($md5File)));
-  $runner->exec($versionSpec['stagingDir'],
-    sprintf("gpg -b --armor --pinentry-mode=loopback -u %s --sign %s",
-      escapeshellarg($gpgKey), escapeshellarg($sha256File)));
+  if (!$input->getOption('dry-run')) {
+    $base = $versionSpec['stagingDir'];
+    foreach (["$base/$md5File", "$base/$sha256File"] as $file) {
+      $gpg->signFile("$file", "$file.asc", \Crypt_GPG::SIGN_MODE_DETACHED);
+      assertThat(!empty($gpg->verifyFile($file, file_get_contents("$file.asc"))), "$file should have valid signature");
+    }
+  }
 };
 
 /**
@@ -496,8 +501,8 @@ $c['task_debug()'] = function(array $versionSpec, $io) use ($c) {
 ## Main
 // FIXME: Help should show an example, echo "example: releaser gs://civicrm-build/4.7.19-rc/civicrm-4.7.19-201705020430.json --get --sign\n";
 // FIXME: Help should show a task list
-$c['app']->main('[-f|--force] [-N|--dry-run] [--git-remote=] [--gpg-key=] json-url tasks*', function($tasks, InputInterface $input) use ($c) {
-  $defaults = ['git-remote' => 'origin', 'gpg-key' => '7A1E75CB'];
+$c['app']->main('[-f|--force] [-N|--dry-run] [--git-remote=] json-url tasks*', function($tasks, InputInterface $input, SymfonyStyle $io) use ($c) {
+  $defaults = ['git-remote' => 'origin'];
   foreach ($defaults as $option => $value) {
     if (!$input->getOption($option)) {
       $input->setOption($option, $value);

--- a/tools/releaser/script.php
+++ b/tools/releaser/script.php
@@ -517,6 +517,17 @@ $c['app']->main('[-f|--force] [-N|--dry-run] [--git-remote=] json-url tasks*', f
     assertThat($c->has('task_' . $task), "Unrecognized task: $task");
   }
 
+  if (!empty($tasks)) {
+    if ($vars = $io->askHidden('(Optional) Paste a batch list of secrets (KEY1=VALUE1 KEY2=VALUE2...)')) {
+      assertThat(!preg_match(';[\'\\"];', $vars), "Sorry, not clever enough to handle meta-characters.");
+      foreach (explode(' ', $vars) as $keyValue) {
+        [$key, $value] = explode('=', $keyValue, 2);
+        putenv($keyValue);
+        $_ENV[$key] = $_SERVER[$key] = $value;
+      }
+    }
+  }
+
   foreach ($tasks as $task) {
     $c['task_' . $task]();
   }

--- a/tools/releaser/script.php
+++ b/tools/releaser/script.php
@@ -191,7 +191,7 @@ $c['gitlabClient()'] = function($url, Credentials $cred, HandlerStack $guzzleHan
   list ($scheme, , $host, $owner, $repo) = explode('/', $url);
 
   static $credCache = [];
-  $credCache[$host] = $credCache[$host] ?? $cred->get('PRIVATE_TOKEN', $host);
+  $credCache[$host] = $credCache[$host] ?? $cred->get('LAB_TOKEN', $host);
 
   $client = new \GuzzleHttp\Client([
     'base_uri' => "{$scheme}//{$host}/api/v4/projects/{$owner}%2F{$repo}/",
@@ -382,14 +382,12 @@ $c['task_esr_tag()'] = function (array $versionSpec, $input, $io, $gitTag) {
  * @param \Symfony\Component\Console\Input\InputInterface $input
  * @param \Symfony\Component\Console\Style\SymfonyStyle $io
  */
-$c['task_publish()'] = function (array $versionSpec, $input, $io, $runner) {
+$c['task_publish()'] = function (array $versionSpec, $input, $io, $runner, Credentials $cred) {
   $io->section('Publish tarballs to primary download service');
 
   // Get missing info before doing anything
   $io->writeln('This will be uploaded to sf.net. To mark it as the default download on sf.net, one needs an api_key. (To skip, leave blank.)');
-  $sfApiKey = $io->askHidden('Enter sf.net api_key: ', function($pass) {
-    return $pass;
-  });
+  $sfApiKey = $cred->get('FORGE_TOKEN');
   if (empty($sfApiKey)) {
     $io->warning('No api_key specified. Will not update default download on sourceforge.net.');
   }


### PR DESCRIPTION
The net effect of this is to make it is easier to run the `releaser` - instead of answering a handful of prompts for different keys/tokens (*which may vary based on task*), you can paste in a batch of keys/tokens. (Alternatively, you can inherit the values in the environment.)

The style of this brings it into more alignment with the releaser script used for the PHAR/CLI apps (like `cv` and `civix`).