### PR TITLE
add typesense-server service

### DIFF
--- a/.loco/loco.yml
+++ b/.loco/loco.yml
@@ -63,6 +63,10 @@ default_environment:
  - CHROME_HOST=${LOCALHOST}
  - CHROME_PORT=9222
 
+ # TYPESENSE
+ - TYPESENSE_API_KEY=xyz
+ - TYPESENSE_PORT=8108
+
 #### Mandatory environment settings
 environment:
  # CLI applications should use our stuff
@@ -159,3 +163,10 @@ services:
     run: 'loco-pid-file "$LOCO_SVC_VAR/chrome-headless.pid" -- "$CHROME_BIN" --disable-gpu --headless --remote-debugging-address="$CHROME_HOST" --remote-debugging-port="$CHROME_PORT"'
     pid_file : '$LOCO_SVC_VAR/chrome-headless.pid'
     message: 'Chrome (headless) is running on "<comment>http://$CHROME_HOST:$CHROME_PORT</comment>" to support automated testing.'
+
+  # FIXME: process fails if we dont create the data dir manually
+  typesense:
+    enabled: false
+    run: 'loco-pid-file "$LOCO_SVC_VAR/typesense.pid" -- typesense-server --data-dir="$LOCO_SVC_VAR/data" --api-address="$LOCALHOST" --api-port="$TYPESENSE_PORT" --api-key="$TYPESENSE_API_KEY"' #--enable-cors'
+    pid_file : '$LOCO_SVC_VAR/typesense.pid'
+    message: 'Typesense Server is running on "<comment>http://$LOCALHOST:$TYPESENSE_PORT</comment>".'

--- a/nix/profiles/phpXXmXX/default.nix
+++ b/nix/profiles/phpXXmXX/default.nix
@@ -25,6 +25,7 @@ in if (isValidPackage php) && (isValidPackage dbms)
     dbms
     dists.default.redis
     dists.bkit.transifexClient
+    dists.default.typesense
 
   ] ++ (if isApple then [] else [dists.default.chromium])
 


### PR DESCRIPTION
Enables adding Typesense server service for use with https://lab.civicrm.org/extensions/typesense/

I wasn't sure if there is a good way to do this in an "optional" way? E.g. add a new separate profile that extends the existing profile? Or add a variable flag somehow?

Likewise wasn't sure how best to handle TYPESENSE_API_KEY variable. I suppose a dummy value is no less secure than the default mysql root password, so maybe it is fine as is?