### PR TITLE
Update civistrings 2026-01-28-08687561

### DIFF
--- a/phars.json
+++ b/phars.json
@@ -12,8 +12,8 @@
    },
 
    "civistrings":  {
-     "url": "https://download.civicrm.org/civistrings/civistrings.phar-2022-08-30-c035da67",
-     "sha256": "657068d8302cdbd60387e634a6bfc6052d3e38005f9f4ed7c064c8e7f8b9a15e",
+     "url": "https://download.civicrm.org/civistrings/civistrings.phar-2026-01-28-08687561",
+     "sha256": "08687561799aab42079ca4c373fa60ab33c6eeb9",
      "buildkit-path": "bin/civistrings"
    },
 


### PR DESCRIPTION
@seamuslee001 Would this be sufficient to update bknix profiles, so that we can fix the .mo missing charset header build problem?

(apparently I also did this in #828)

note for me: I found the filename in the Jenkins civistrings build job (console output), and the sha256 hash is the hash of the PHAR file published by jenkins (Seamus updated it after this PR).