### PR TITLE
loco - Consistently opt-out of binary logging for default mysqld

### DIFF
--- a/.loco/config/mysql-1/conf/my.cnf.loco.tpl
+++ b/.loco/config/mysql-1/conf/my.cnf.loco.tpl
@@ -17,6 +17,8 @@ tmpdir          = {{LOCO_SVC_VAR}}/tmp
 log-bin		= {{LOCO_SVC_VAR}}/log/mysql-bin
 
 expire_logs_days = 10
+binlog_format	= row
+sync_binlog	= 1
 
 # Uncomment the following if you are using InnoDB tables
 #innodb_data_home_dir = /var/lib/mysql

--- a/.loco/config/mysql-2/conf/my.cnf.loco.tpl
+++ b/.loco/config/mysql-2/conf/my.cnf.loco.tpl
@@ -16,6 +16,9 @@ pid_file        = {{LOCO_SVC_VAR}}/run/mysql.pid
 tmpdir          = {{LOCO_SVC_VAR}}/tmp
 log-bin		= {{LOCO_SVC_VAR}}/log/mysql-bin
 
+binlog_format	= row
+sync_binlog	= 1
+
 read_only       = 1
 
 # Replication Slave (comment out master section to use this)

--- a/.loco/config/mysql-common/my.cnf
+++ b/.loco/config/mysql-common/my.cnf
@@ -12,9 +12,6 @@ query_cache_size= 16M
 # Try number of CPU's*2 for thread_concurrency
 #MariaDB?# thread_concurrency = 8
 
-binlog_format	= row
-sync_binlog	= 1
-
 innodb_file_per_table = 1
 # You can set .._buffer_pool_size up to 50 - 80 %
 # of RAM but beware of setting memory usage too high

--- a/.loco/config/mysql/conf/my.cnf.loco.tpl
+++ b/.loco/config/mysql/conf/my.cnf.loco.tpl
@@ -15,6 +15,9 @@ socket		= {{LOCO_SVC_VAR}}/run/mysql.sock
 pid_file        = {{LOCO_SVC_VAR}}/run/mysql.pid
 tmpdir          = {{LOCO_SVC_VAR}}/tmp
 
+## On MySQL 8/9, you must explicitly opt-out of binary logging.
+disable-log-bin
+
 # Uncomment the following if you are using InnoDB tables
 #innodb_data_home_dir = /var/lib/mysql
 #innodb_data_file_path = ibdata1:10M:autoextend


### PR DESCRIPTION
## Overview

In MySQL 5.7 and MariaDB, binary-logging is disabled by default (*the flag was opt-in*). For newer MySQL (8/9), it becomes enabled by default (*the flag is opt-out*). This created inconsistent test results.

## Details

In test jobs, MySQL binlogs can take a lot of space. Every system-flush adds another 1-2M to the binlog; but one test-suite can involve hundreds (if not thousands) of system-flushes -- so the binlog eats a bunch of disk-space. (*For mysql+ramdisk, that can hit hard limits and kill the job; or for mysql+ssd, it would aggravate TBW limits.*) 

To `r-run` this update, I made a sample DB snapshot (`civibuild reinstall dev` on mysql57) and then went through several environments (`php83m57`, `php83m84`, `php83m90`, `php83r106`, `php83r1011`). On each environment, run steps like this:

```bash
cd buildkit

## Spin up DB with snapshot
loco clean mysql ; loco start mysql ; sleep 1; civibuild restore dev
## the sleep is probably unnecessary; but easier to do this than to do debugging in the off-chance it matters

## Examine files and usage
ls -lh .loco/var/mysql/data/ ; du -sh .loco/var/mysql/data/

## Flush caches
(cd build/dev && cv flush)

## Examine files and usage
ls -lh .loco/var/mysql/data/ ; du -sh .loco/var/mysql/data/
```

In each tested environment, I found that the `mysqld` started, and that disk-usage was stable.

(*Note: The loco configuration technically includes three variants of the MySQL config files. I focused on the default  variant which is used by test-runners.*)