### PR TITLE
Upgrade upgrade-test to v26.07.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
   "require": {
     "php": ">=7.4",
     "totten/php-symbol-diff": "dev-master#54f869ca68a3cd75f3386f8490870369733d2c23",
-    "civicrm/upgrade-test": "~26.03.0",
+    "civicrm/upgrade-test": "~26.07.0",
     "drupal/coder": "dev-8.x-2.x-civi#aa31dd918e302f6c01f6d28a495256e171abf581",
     "civicrm/composer-downloads-plugin": "^4.0",
     "civicrm/composer-compile-plugin": "~0.20",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bad6c4377cb1ee24e0bb54366e4e4a84",
+    "content-hash": "8e065fadeb182f82705da9f38dc75a71",
     "packages": [
         {
             "name": "civicrm/composer-compile-plugin",
@@ -151,16 +151,16 @@
         },
         {
             "name": "civicrm/upgrade-test",
-            "version": "v26.03.0",
+            "version": "v26.07.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/civicrm/civicrm-upgrade-test.git",
-                "reference": "e89db15767b1c54c9e1282a64fd4089afa618a9e"
+                "reference": "663d85273db80d084f923347b9c7b2aea12611bb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/civicrm/civicrm-upgrade-test/zipball/e89db15767b1c54c9e1282a64fd4089afa618a9e",
-                "reference": "e89db15767b1c54c9e1282a64fd4089afa618a9e",
+                "url": "https://api.github.com/repos/civicrm/civicrm-upgrade-test/zipball/663d85273db80d084f923347b9c7b2aea12611bb",
+                "reference": "663d85273db80d084f923347b9c7b2aea12611bb",
                 "shasum": ""
             },
             "bin": [
@@ -186,9 +186,9 @@
             "description": "Collection of scripts and data-files for testing CiviCRM upgrades",
             "homepage": "https://github.com/civicrm/civicrm-upgrade-test",
             "support": {
-                "source": "https://github.com/civicrm/civicrm-upgrade-test/tree/v26.03.0"
+                "source": "https://github.com/civicrm/civicrm-upgrade-test/tree/v26.07.0"
             },
-            "time": "2026-03-16T23:39:07+00:00"
+            "time": "2026-07-06T20:32:55+00:00"
         },
         {
             "name": "drupal/coder",


### PR DESCRIPTION
Upgrades to https://github.com/civicrm/civicrm-upgrade-test/releases/tag/v26.07.0